### PR TITLE
Enforce API key expiry and permission scope

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -243,6 +243,7 @@ geesomeClient.init().then(async () => {
 - Stabilize content serving, upload limits, and high-CPU paths reported in open operational issues.
 - Finish the existing Pinata/pinning path with manual and auto pin flows exposed cleanly in API/UI.
 - API key permissions and expiration are enforced; keep extending scoped service-token tests as new integrations land.
+- Run a focused security review of API authorization and encryption boundaries before expanding integrations and production E2EE.
 - Improve static-site generation options, favicon handling, and frontend build delivery by IPFS.
 - Design real frontend E2EE for chat groups using user-held private keys, recipient/device public keys, and group key rotation.
 - Integrate ActivityPub/Fediverse so GeeSome groups and posts can federate with compatible servers.

--- a/README.MD
+++ b/README.MD
@@ -242,7 +242,7 @@ geesomeClient.init().then(async () => {
 ## TODO:
 - Stabilize content serving, upload limits, and high-CPU paths reported in open operational issues.
 - Finish the existing Pinata/pinning path with manual and auto pin flows exposed cleanly in API/UI.
-- Tighten API key permissions and expiration behavior before expanding service integrations.
+- API key permissions and expiration are enforced; keep extending scoped service-token tests as new integrations land.
 - Improve static-site generation options, favicon handling, and frontend build delivery by IPFS.
 - Design real frontend E2EE for chat groups using user-held private keys, recipient/device public keys, and group key rotation.
 - Integrate ActivityPub/Fediverse so GeeSome groups and posts can federate with compatible servers.

--- a/app/index.ts
+++ b/app/index.ts
@@ -12,6 +12,7 @@ import _ from 'lodash';
 import debug from 'debug';
 import pIteration from 'p-iteration';
 import uuidAPIKey from "uuid-apikey";
+import {AsyncLocalStorage} from "node:async_hooks";
 import commonHelper from "geesome-libs/src/common.js";
 import ipfsHelper from "geesome-libs/src/ipfsHelper.js";
 import IGeesomeEntityJsonManifestModule from "./modules/entityJsonManifest/interface.js";
@@ -83,6 +84,8 @@ function getModule(config, appPass) {
     events: GeesomeEmitter;
 
     frontendStorageId;
+
+    apiKeyContext = new AsyncLocalStorage<any>();
 
     ms: {
       database: IGeesomeDatabaseModule,
@@ -313,11 +316,36 @@ function getModule(config, appPass) {
 
       if (!data.permissions) {
         data.permissions = JSON.stringify(await this.ms.database.getCorePermissions(userId).then(list => list.map(i => i.name)));
+      } else if (Array.isArray(data.permissions)) {
+        data.permissions = JSON.stringify(data.permissions);
       }
 
       await this.ms.database.addApiKey(data);
 
       return generated.apiKey;
+    }
+
+    getApiKeyPermissionList(apiKey) {
+      if (!apiKey || !apiKey.permissions) {
+        return [];
+      }
+      if (Array.isArray(apiKey.permissions)) {
+        return apiKey.permissions;
+      }
+      try {
+        const permissions = JSON.parse(apiKey.permissions);
+        return Array.isArray(permissions) ? permissions : [];
+      } catch (e) {
+        return [];
+      }
+    }
+
+    isApiKeyExpired(apiKey, now = new Date()) {
+      return !!apiKey?.expiredOn && new Date(apiKey.expiredOn).getTime() <= now.getTime();
+    }
+
+    isApiKeyActive(apiKey, now = new Date()) {
+      return !!apiKey && !apiKey.isDisabled && !this.isApiKeyExpired(apiKey, now);
     }
 
     async getUserByApiToken(token) {
@@ -326,7 +354,7 @@ function getModule(config, appPass) {
       }
       const valueHash = uuidAPIKey['toUUID'](token);
       const keyObj = await this.ms.database.getApiKeyByHash(valueHash);
-      if (!keyObj) {
+      if (!this.isApiKeyActive(keyObj)) {
         return {user: null, apiKey: null};
       }
       return {
@@ -505,7 +533,61 @@ function getModule(config, appPass) {
       return this.ms.database.getUserLimit(userId, limitName);
     }
 
-    async isUserCan(userId, permission) {
+    runWithApiKey(apiKey, callback) {
+      return this.apiKeyContext.run(apiKey, callback);
+    }
+
+    isApiKeyCan(apiKey, permission) {
+      if (!apiKey) {
+        return true;
+      }
+      if (!this.isApiKeyActive(apiKey)) {
+        return false;
+      }
+      const permissions = this.getApiKeyPermissionList(apiKey);
+      if (startsWith(permission, 'admin:')) {
+        return permissions.includes(CorePermissionName.AdminAll) || permissions.includes(permission);
+      }
+      return permissions.includes(CorePermissionName.UserAll) || permissions.includes(permission);
+    }
+
+    async isUserCan(userId, permission, apiKey = this.apiKeyContext.getStore()) {
+      const userCanAll = await this.ms.database.isHaveCorePermission(userId, CorePermissionName.UserAll);
+      const userCan = userCanAll || await this.ms.database.isHaveCorePermission(userId, permission);
+      if (!userCan) {
+        return false;
+      }
+      if (apiKey && apiKey.userId !== userId) {
+        return false;
+      }
+      return this.isApiKeyCan(apiKey, permission);
+    }
+
+    async isAdminCan(userId, permission, apiKey = this.apiKeyContext.getStore()) {
+      const adminCanAll = await this.ms.database.isHaveCorePermission(userId, CorePermissionName.AdminAll);
+      const adminCan = adminCanAll || await this.ms.database.isHaveCorePermission(userId, permission);
+      if (!adminCan) {
+        return false;
+      }
+      if (apiKey && apiKey.userId !== userId) {
+        return false;
+      }
+      return this.isApiKeyCan(apiKey, permission);
+    }
+
+    async checkUserCan(userId, permission, apiKey = this.apiKeyContext.getStore()) {
+      log('checkUserCan start', userId, permission);
+      if (startsWith(permission, 'admin:')) {
+        if (await this.isAdminCan(userId, permission, apiKey).then(can => !can)) {
+          throw new Error("not_permitted");
+        }
+      } else if (await this.isUserCan(userId, permission, apiKey).then(can => !can)) {
+        throw new Error("not_permitted");
+      }
+      log('checkUserCan finish', userId, permission);
+    }
+
+    async isUserCanByUserPermissionOnly(userId, permission) {
       const userCanAll = await this.ms.database.isHaveCorePermission(userId, CorePermissionName.UserAll);
       if (userCanAll) {
         return true;
@@ -513,24 +595,12 @@ function getModule(config, appPass) {
       return this.ms.database.isHaveCorePermission(userId, permission);
     }
 
-    async isAdminCan(userId, permission) {
+    async isAdminCanByUserPermissionOnly(userId, permission) {
       const adminCanAll = await this.ms.database.isHaveCorePermission(userId, CorePermissionName.AdminAll);
       if (adminCanAll) {
         return true;
       }
       return this.ms.database.isHaveCorePermission(userId, permission);
-    }
-
-    async checkUserCan(userId, permission) {
-      log('checkUserCan start', userId, permission);
-      if (startsWith(permission, 'admin:')) {
-        if (await this.isAdminCan(userId, permission).then(can => !can)) {
-          throw new Error("not_permitted");
-        }
-      } else if (await this.isUserCan(userId, permission).then(can => !can)) {
-        throw new Error("not_permitted");
-      }
-      log('checkUserCan finish', userId, permission);
     }
 
     async encryptTextWithAppPass(text) {

--- a/app/interface.ts
+++ b/app/interface.ts
@@ -72,15 +72,17 @@ export interface IGeesomeApp {
 
   getUserByApiToken(apiKey): Promise<{user: IUser | null, apiKey: IUserApiKey | null}>;
 
+  runWithApiKey(apiKey: IUserApiKey, callback): Promise<any>;
+
   getUserApiKeys(userId, isDisabled?, search?, listParams?: IListParams): Promise<IUserApiKeysListResponse>;
 
   setUserLimit(adminId, limitData: IUserLimit): Promise<IUserLimit>;
 
-  checkUserCan(userId, permission): Promise<void>;
+  checkUserCan(userId, permission, apiKey?: IUserApiKey): Promise<void>;
 
-  isUserCan(userId, permission): Promise<boolean>;
+  isUserCan(userId, permission, apiKey?: IUserApiKey): Promise<boolean>;
 
-  isAdminCan(userId, permission): Promise<boolean>;
+  isAdminCan(userId, permission, apiKey?: IUserApiKey): Promise<boolean>;
 
   getDataStructure(dataId, isResolve?);
 
@@ -192,4 +194,3 @@ export interface IContentListResponse {
   list: IContent[];
   total: number;
 }
-

--- a/app/modules/api/index.ts
+++ b/app/modules/api/index.ts
@@ -120,7 +120,7 @@ async function getModule(app: IGeesomeApp, version, port) {
 			if (!req.user || !req.user.id) {
 				return res.send({error: "Not authorized", errorCode: 2}, 401);
 			}
-			return this.handleCallback(req, res, callback);
+			return app.runWithApiKey(apiKey, () => this.handleCallback(req, res, callback));
 		}
 
 		onAuthorizedGet(routeName: string, callback: (req: IApiModuleGetInput, res: IApiModuleCommonOutput) => any) {

--- a/app/modules/database/interface.ts
+++ b/app/modules/database/interface.ts
@@ -137,6 +137,8 @@ export interface IUserApiKey {
   title?: string;
   userId: number;
   valueHash: string;
+  type?: string;
+  permissions?: string;
   expiredOn?: Date;
   isDisabled: boolean;
 }

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -146,13 +146,15 @@ Verification:
 
 ### 5. API Key Permissions And Expiration
 
+Status: implemented in [#190](https://github.com/galtproject/geesome-node/issues/190). Disabled and expired API keys no longer authenticate, and authorized API requests now apply the current key's stored permissions as a request-scoped limit on top of the user's core permissions.
+
 Goal: make API keys safer before broader service integrations.
 
 Scope:
 
-- Implement [#190](https://github.com/galtproject/geesome-node/issues/190) by rejecting disabled or expired keys in API authentication.
-- Clarify whether `permissions` on `userApiKey` should constrain core permissions at request time.
-- Add tests for disabled, expired, and permission-limited API keys.
+- Implemented [#190](https://github.com/galtproject/geesome-node/issues/190) by rejecting disabled or expired keys in API authentication.
+- `permissions` on `userApiKey` now constrain core permission checks at request time through an async request context. A user's own permissions remain the upper bound, and the API key must also allow the requested permission.
+- Added tests for disabled, expired, and permission-limited API keys.
 
 Likely modules:
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -14,6 +14,7 @@ Corrections and added requirements:
 - `geesome-node` is not inherently "the server side." It is a larger GeeSome app/node that can run locally, but is preferably run on an always-on server when content should be more available to other GeeSome network members. Status: this plan treats it as a node/app, not only a backend server.
 - Plans saved to Markdown should keep this `Source Of Truth` section current when the user corrects architecture or adds requirements. Status: this plan has been adjusted under that rule.
 - Add Node.js 22 migration to the TODO. Node 22 should become the supported baseline now, with Node 24 tested separately as the next LTS target. Status: added as the first fast-delivery slice.
+- Add security review of API and encryption flows to the TODO. Status: tracked in [#782](https://github.com/galtproject/geesome-node/issues/782) and added as a fast-delivery security gate.
 
 Last issue snapshot: 2026-05-03 from `galtproject/geesome-node` open GitHub issues and PRs.
 
@@ -52,6 +53,7 @@ Issue clusters still represented by the old README TODO:
 - Pinning and backups: [#495](https://github.com/galtproject/geesome-node/issues/495), [#493](https://github.com/galtproject/geesome-node/issues/493), [#518](https://github.com/galtproject/geesome-node/issues/518), [#604](https://github.com/galtproject/geesome-node/issues/604).
 - Static sites and frontend delivery: [#573](https://github.com/galtproject/geesome-node/issues/573), [#564](https://github.com/galtproject/geesome-node/issues/564), [#494](https://github.com/galtproject/geesome-node/issues/494).
 - Permissions and auth: [#522](https://github.com/galtproject/geesome-node/issues/522), [#515](https://github.com/galtproject/geesome-node/issues/515), [#542](https://github.com/galtproject/geesome-node/issues/542), [#190](https://github.com/galtproject/geesome-node/issues/190).
+- Security review: [#782](https://github.com/galtproject/geesome-node/issues/782) for API auth and encryption flows.
 - Media and content handling: [#423](https://github.com/galtproject/geesome-node/issues/423), [#196](https://github.com/galtproject/geesome-node/issues/196), [#136](https://github.com/galtproject/geesome-node/issues/136), [#609](https://github.com/galtproject/geesome-node/issues/609).
 - Group/feed/search evolution: [#646](https://github.com/galtproject/geesome-node/issues/646), [#563](https://github.com/galtproject/geesome-node/issues/563), [#517](https://github.com/galtproject/geesome-node/issues/517), [#33](https://github.com/galtproject/geesome-node/issues/33), [#2](https://github.com/galtproject/geesome-node/issues/2).
 - Secure chat E2EE: [#2](https://github.com/galtproject/geesome-node/issues/2), [#33](https://github.com/galtproject/geesome-node/issues/33), [#115](https://github.com/galtproject/geesome-node/issues/115). Use [Vas3k's E2EE explainer](https://vas3k.blog/blog/end_to_end_encryption/) as background for why backend-only encryption and a single long-lived group key are not enough.
@@ -190,7 +192,31 @@ Verification:
 - `test/render.test.ts`
 - `yarn test`
 
-### 7. Secure Chat E2EE Design
+### 7. API And Encryption Security Review
+
+Goal: run a focused security review before expanding service integrations, ActivityPub federation, and production chat E2EE.
+
+Scope:
+
+- Review API authentication and authorization boundaries, including API-key expiry, disabled keys, scoped key permissions, user/admin permission separation, and route coverage.
+- Build a route/permission matrix for protected API endpoints, especially content upload, file catalog, groups, pinning, social imports, ActivityPub inbox/outbox, and service integrations.
+- Review encryption boundaries: backend-side chat encryption PoC, frontend E2EE envelopes, key storage, public/private key separation, sender signatures, replay/dedupe metadata, and attachment encryption.
+- Review secret handling for node app passphrases, account storage, social-network credentials, Pinata keys, ActivityPub signing keys, and local client bindings.
+- Model abuse cases: stolen API key, expired/disabled token reuse, scoped-token privilege escalation, replayed encrypted chat envelope, malicious ActivityPub request, and oversized upload/content-serving DoS.
+
+Deliverables:
+
+- Threat model and findings document.
+- Route/permission matrix.
+- Test checklist for authorization and encryption boundaries.
+- Follow-up issues for concrete vulnerabilities or missing controls.
+
+Verification:
+
+- Docs review against [#782](https://github.com/galtproject/geesome-node/issues/782).
+- Targeted tests for any concrete auth/encryption fixes created from the review.
+
+### 8. Secure Chat E2EE Design
 
 Goal: replace the backend encryption PoC with an implementation plan that can become real end-to-end encrypted chat.
 
@@ -223,7 +249,7 @@ Verification:
 - Node tests for opaque envelope storage.
 - Frontend/browser tests once client crypto exists.
 
-### 8. ActivityPub/Fediverse Integration MVP
+### 9. ActivityPub/Fediverse Integration MVP
 
 Goal: make GeeSome groups/posts visible and interoperable through ActivityPub without losing the IPFS/IPNS-first storage model.
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -163,6 +163,58 @@ describe("app", function () {
 		assert.equal(permissions.filter(p => p.name === CorePermissionName.UserGroupManagement).length, 1);
 	});
 
+	it('should reject disabled and expired api keys', async () => {
+		const apiKeyTestUser = await app.registerUser({
+			email: 'api-key-expiration@user.com',
+			name: 'api-key-expiration',
+			permissions: [CorePermissionName.UserAll]
+		});
+
+		const activeToken = await app.generateUserApiKey(apiKeyTestUser.id, {type: 'active-test'});
+		const activeAuth = await app.getUserByApiToken(activeToken);
+		assert.equal(activeAuth.user.id, apiKeyTestUser.id);
+		assert.equal(activeAuth.apiKey.isDisabled, false);
+
+		await app.updateApiKey(apiKeyTestUser.id, activeAuth.apiKey.id, {isDisabled: true});
+		const disabledAuth = await app.getUserByApiToken(activeToken);
+		assert.equal(disabledAuth.user, null);
+		assert.equal(disabledAuth.apiKey, null);
+
+		const expiredToken = await app.generateUserApiKey(apiKeyTestUser.id, {
+			type: 'expired-test',
+			expiredOn: new Date(Date.now() - 1000)
+		});
+		const expiredAuth = await app.getUserByApiToken(expiredToken);
+		assert.equal(expiredAuth.user, null);
+		assert.equal(expiredAuth.apiKey, null);
+	});
+
+	it('should scope user permissions by current api key permissions', async () => {
+		const apiKeyPermissionUser = await app.registerUser({
+			email: 'api-key-permissions@user.com',
+			name: 'api-key-permissions',
+			permissions: [CorePermissionName.UserAll]
+		});
+
+		const saveOnlyToken = await app.generateUserApiKey(apiKeyPermissionUser.id, {
+			type: 'save-only-test',
+			permissions: [CorePermissionName.UserSaveData]
+		});
+		const {apiKey} = await app.getUserByApiToken(saveOnlyToken);
+
+		assert.equal(await app.isUserCan(apiKeyPermissionUser.id, CorePermissionName.UserGroupManagement), true);
+		await app.runWithApiKey(apiKey, async () => {
+			assert.equal(await app.isUserCan(apiKeyPermissionUser.id, CorePermissionName.UserSaveData), true);
+			assert.equal(await app.isUserCan(apiKeyPermissionUser.id, CorePermissionName.UserGroupManagement), false);
+			try {
+				await app.checkUserCan(apiKeyPermissionUser.id, CorePermissionName.UserGroupManagement);
+				assert.equal(true, false);
+			} catch (e) {
+				assert.equal(e.message, 'not_permitted');
+			}
+		});
+	});
+
 	it('should correctly save data with only save permission', async () => {
 		try {
 			await app.registerUser({


### PR DESCRIPTION
## Summary
- reject disabled and expired user API keys during token lookup
- normalize generated API-key permission arrays before storage
- apply the current API key as async request context so existing permission checks are scoped by token permissions
- update TODO/README notes for the delivered API-key safety slice
- add a dedicated API/encryption security-review TODO and tracker issue

Closes #190
Refs #782

## Verification
- git diff --check
- node --import tsx --experimental-global-customevent -e "await import('./app/index.ts'); await import('./app/modules/api/index.ts')"

## Blocked checks
- yarn test test/app.test.ts: install failed before Mocha on node-datachannel@0.11.0 prebuild under the current runtime
- direct app Mocha grep: app startup reached local PostgreSQL but failed password auth for user geesome; current master dependency tree also hit the known Helia/protons-runtime mismatch before app modules could initialize