### PR TITLE
Finalize API docs git dependencies

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -15,7 +15,7 @@ Corrections and added requirements:
 - Plans saved to Markdown should keep this `Source Of Truth` section current when the user corrects architecture or adds requirements. Status: this plan has been adjusted under that rule.
 - Add Node.js 22 migration to the TODO. Node 22 should become the supported baseline now, with Node 24 tested separately as the next LTS target. Status: implemented in [#779](https://github.com/galtproject/geesome-node/issues/779), with the Helia wrapper dependency update tracked by `geesome-libs` [#119](https://github.com/galtproject/geesome-libs/issues/119); Node 24 remains follow-up validation.
 - Add security review of API and encryption flows to the TODO. Status: tracked in [#782](https://github.com/galtproject/geesome-node/issues/782) and added as a fast-delivery security gate.
-- API documentation tooling should be handled through microwave-hub submodules for [`apidoc-template`](https://github.com/MicrowaveDev/apidoc-template) and [`apidoc-plugin-ts`](https://github.com/MicrowaveDev/apidoc-plugin-ts). Status: hub submodule tracking is in [Microwave Hub #2](https://github.com/MicrowaveDev/microwave-hub/issues/2), planning was tracked in [#787](https://github.com/galtproject/geesome-node/issues/787), vulnerable `apidoc-core` removal was tracked in [#802](https://github.com/galtproject/geesome-node/issues/802), and final git-URL wiring is tracked in [#804](https://github.com/galtproject/geesome-node/issues/804).
+- API documentation tooling should be handled through microwave-hub submodules for [`apidoc-template`](https://github.com/MicrowaveDev/apidoc-template) and [`apidoc-plugin-ts`](https://github.com/MicrowaveDev/apidoc-plugin-ts). Status: hub submodule tracking is in [Microwave Hub #2](https://github.com/MicrowaveDev/microwave-hub/issues/2), planning was tracked in [#787](https://github.com/galtproject/geesome-node/issues/787), vulnerable `apidoc-core` removal was tracked in [#802](https://github.com/galtproject/geesome-node/issues/802), final git-URL wiring was tracked in [#804](https://github.com/galtproject/geesome-node/issues/804), and the final plugin-master repoint is tracked in [#806](https://github.com/galtproject/geesome-node/issues/806).
 
 Last issue snapshot: 2026-05-03 from `galtproject/geesome-node` open GitHub issues and PRs.
 
@@ -206,7 +206,7 @@ Verification:
 
 ### 7. API Documentation Toolchain Cleanup
 
-Status: nearly complete. [#802](https://github.com/galtproject/geesome-node/issues/802) upgraded `geesome-node` to `apidoc@1.x` and removed the vulnerable `apidoc-core` package graph. [#804](https://github.com/galtproject/geesome-node/issues/804) wires `geesome-node` to the modern template and TypeScript plugin through git URLs. The repos are tracked by microwave-hub as submodules:
+Status: complete. [#802](https://github.com/galtproject/geesome-node/issues/802) upgraded `geesome-node` to `apidoc@1.x` and removed the vulnerable `apidoc-core` package graph. [#804](https://github.com/galtproject/geesome-node/issues/804) wired `geesome-node` to the modern template and TypeScript plugin through git URLs. [#806](https://github.com/galtproject/geesome-node/issues/806) repoints the plugin dependency to the merged plugin master instead of the temporary PR commit. The repos are tracked by microwave-hub as submodules:
 
 - `apidoc-template` for generated documentation UI/template work.
 - `apidoc-plugin-ts` for TypeScript parsing and apiDoc annotation support.
@@ -223,8 +223,8 @@ Repo split:
 First deliverable:
 
 - Audit current `geesome-node` API doc generation command and package usage. Status: complete in [#802](https://github.com/galtproject/geesome-node/issues/802) and [#804](https://github.com/galtproject/geesome-node/issues/804).
-- Consume `apidoc-plugin-ts` and `geesome-apidoc-template` by git URL. Status: in progress in [#804](https://github.com/galtproject/geesome-node/issues/804); the plugin git install fix is in [`apidoc-plugin-ts` PR #2](https://github.com/MicrowaveDev/apidoc-plugin-ts/pull/2).
-- Generate docs with the modern custom template. Status: local smoke passes with `app/modules/api`.
+- Consume `apidoc-plugin-ts` and `geesome-apidoc-template` by git URL. Status: complete in [#804](https://github.com/galtproject/geesome-node/issues/804) and [#806](https://github.com/galtproject/geesome-node/issues/806).
+- Generate docs with the modern custom template. Status: complete; local smoke passes with `app/modules/api`.
 - Future polish only: richer endpoint examples, rendered browser/mobile review, and API annotation cleanup for warnings where request-body fields are currently documented as `@apiParam`.
 
 Verification:

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.9",
     "apidoc": "^1.2.0",
-    "apidoc-plugin-ts": "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#d1c84f6",
+    "apidoc-plugin-ts": "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git",
     "chai": "^4.2.0",
     "chai-http": "^4.2.1",
     "geesome-apidoc-template": "git+ssh://git@github.com/MicrowaveDev/apidoc-template.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,9 +3386,9 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-"apidoc-plugin-ts@git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#d1c84f6":
+"apidoc-plugin-ts@git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git":
   version "1.1.0"
-  resolved "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#d1c84f6d6e026a4d66c852089bdba72398c1de9e"
+  resolved "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#5ead337dd86cb97de37f9846e9331932cc3a3e1e"
   dependencies:
     ts-morph "3.1.0"
     typescript "3.5.2"


### PR DESCRIPTION
## Summary
- repoint `apidoc-plugin-ts` from the temporary PR commit hash to the plain MicrowaveDev git URL now that the git-install build fix is merged
- refresh the lockfile to the merged plugin master commit
- mark the apidoc tooling TODO slice complete, with future polish separated from implementation work

Closes #806

## Verification
- `yarn add --dev apidoc-plugin-ts@git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git geesome-apidoc-template@git+ssh://git@github.com/MicrowaveDev/apidoc-template.git`
- `./node_modules/.bin/apidoc -i app/modules/api -o /tmp/geesome-node-apidoc-complete -t node_modules/geesome-apidoc-template/template`
- `test -s /tmp/geesome-node-apidoc-complete/index.html`
- `test -s /tmp/geesome-node-apidoc-complete/assets/main.bundle.js`
- `yarn why apidoc-core --depth=0` confirms no match
- `yarn why apidoc-plugin-ts --depth=0`
- `yarn why geesome-apidoc-template --depth=0`
- `git diff --check`

## Notes
The remaining warnings are apiDoc annotation polish: request body fields are represented as `@apiParam`, so apiDoc warns that they are not URL params. The generator, plugin, template, and git URL dependency wiring are complete.