### PR TITLE
Polish API docs body annotations

### DIFF
--- a/app/modules/api/api.ts
+++ b/app/modules/api/api.ts
@@ -37,7 +37,7 @@ export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 	 * @apiName RunSetup
 	 * @apiGroup Setup
 	 *
-	 * @apiInterface (../../interface.ts) {IUserInput} apiParam
+	 * @apiInterface (../../interface.ts) {IUserInput} apiBody
 	 * @apiInterface (../database/interface.ts) {IUser} apiSuccess
 	 */
 	module.onPost('setup', async (req, res) => {
@@ -49,8 +49,8 @@ export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 	 * @apiName LoginPassword
 	 * @apiGroup Login
 	 *
-	 * @apiParam {String} login
-	 * @apiParam {String} password
+	 * @apiBody {String} login
+	 * @apiBody {String} password
 	 *
 	 * @apiInterface (../../interface.ts) {IUserAuthResponse} apiSuccess
 	 */

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -225,7 +225,7 @@ First deliverable:
 - Audit current `geesome-node` API doc generation command and package usage. Status: complete in [#802](https://github.com/galtproject/geesome-node/issues/802) and [#804](https://github.com/galtproject/geesome-node/issues/804).
 - Consume `apidoc-plugin-ts` and `geesome-apidoc-template` by git URL. Status: complete in [#804](https://github.com/galtproject/geesome-node/issues/804) and [#806](https://github.com/galtproject/geesome-node/issues/806).
 - Generate docs with the modern custom template. Status: complete; local smoke passes with `app/modules/api`.
-- Future polish only: richer endpoint examples, rendered browser/mobile review, and API annotation cleanup for warnings where request-body fields are currently documented as `@apiParam`.
+- Future polish only: richer endpoint examples and rendered browser/mobile review. API annotation cleanup for request-body fields is tracked in [#808](https://github.com/galtproject/geesome-node/issues/808).
 
 Verification:
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.9",
     "apidoc": "^1.2.0",
-    "apidoc-plugin-ts": "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git",
+    "apidoc-plugin-ts": "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#afc63f1",
     "chai": "^4.2.0",
     "chai-http": "^4.2.1",
     "geesome-apidoc-template": "git+ssh://git@github.com/MicrowaveDev/apidoc-template.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,9 +3386,9 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-"apidoc-plugin-ts@git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git":
+"apidoc-plugin-ts@git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#afc63f1":
   version "1.1.0"
-  resolved "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#5ead337dd86cb97de37f9846e9331932cc3a3e1e"
+  resolved "git+ssh://git@github.com/MicrowaveDev/apidoc-plugin-ts.git#afc63f1950902c81f428f1b663326e0ba66bacbe"
   dependencies:
     ts-morph "3.1.0"
     typescript "3.5.2"


### PR DESCRIPTION
## Summary
- move setup and password-login request body docs from `@apiParam` to `@apiBody`
- use the `apidoc-plugin-ts` apiBody support from MicrowaveDev/apidoc-plugin-ts#3 for interface-generated body fields
- update the TODO plan so request-body warning cleanup is tracked under #808

Closes #808

## Verification
- `./node_modules/.bin/apidoc -i app/modules/api -o /tmp/geesome-node-apidoc-polished -t node_modules/geesome-apidoc-template/template`
- confirmed no `warn:` lines in `/tmp/geesome-node-apidoc-polished.log`
- confirmed generated data for `RunSetup` and `LoginPassword` has request fields under `body`
- `test -s /tmp/geesome-node-apidoc-polished/index.html`
- `test -s /tmp/geesome-node-apidoc-polished/assets/main.bundle.js`
- `git diff --check`

## Notes
This temporarily pins `apidoc-plugin-ts` to commit `afc63f1` from MicrowaveDev/apidoc-plugin-ts#3 because `apiBody` interface output is needed before geesome-node can remove the warnings. After that PR is merged, the node dependency can be repointed back to the plain plugin git URL.