### PR TITLE
Route gateway HEAD requests to content headers

### DIFF
--- a/app/modules/gateway/api.ts
+++ b/app/modules/gateway/api.ts
@@ -5,13 +5,23 @@ const {trim} = _;
 
 export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 
-	module.onGetRequest(async (req, res) => {
+	async function getGatewayContentPath(req) {
 		const dnsLinkPath = trim(await module.getDnsLinkPathFromRequest(req), '/');
 		const type = dnsLinkPath.split('/')[0];
 		let cid = dnsLinkPath.split('/')[1];
 		if(type === 'ipns') {
 			cid = await app.ms.staticId.resolveStaticId(cid);
 		}
-		app.ms.content.getFileStreamForApiRequest(req, res, cid + req.route).catch((e) => {console.error(e); res.send(400)});
+		return cid + req.route;
+	}
+
+	module.onGetRequest(async (req, res) => {
+		const contentPath = await getGatewayContentPath(req);
+		app.ms.content.getFileStreamForApiRequest(req, res, contentPath).catch((e) => {console.error(e); res.send(400)});
+	});
+
+	module.onHeadRequest(async (req, res) => {
+		const contentPath = await getGatewayContentPath(req);
+		app.ms.content.getContentHead(req, res, contentPath).catch((e) => {console.error(e); res.send(400)});
 	});
 }

--- a/app/modules/gateway/index.ts
+++ b/app/modules/gateway/index.ts
@@ -6,10 +6,12 @@ import IGeesomeGatewayModule from "./interface.js";
 import {IGeesomeApp} from "../../interface.js";
 import helpers from "./helpers.js";
 
-export default async (app: IGeesomeApp) => {
+export default async (app: IGeesomeApp, options: {registerApi?: boolean, port?: number | string} = {}) => {
 	app.checkModules(['api']);
-	const module = await getModule(app, process.env.GATEWAY_PORT || 2082);
-	(await import('./api.js')).default(app, module);
+	const module = await getModule(app, options.port || process.env.GATEWAY_PORT || 2082);
+	if (options.registerApi !== false) {
+		(await import('./api.js')).default(app, module);
+	}
 	return module;
 }
 
@@ -40,7 +42,7 @@ async function getModule(app: IGeesomeApp, port) {
 	});
 	service.head("/*", function (req, res, next) {
 		setHeaders(res);
-		res.send(200);
+		next();
 	});
 
 	const server = await service.listen(port);
@@ -64,6 +66,12 @@ async function getModule(app: IGeesomeApp, port) {
 		}
 		onGetRequest(callback) {
 			service.get("/*", (req, res) => {
+				setHeaders(res);
+				callback(app.ms.api.reqToModuleInput(req), app.ms.api.resToModuleOutput(res));
+			});
+		}
+		onHeadRequest(callback) {
+			service.head("/*", (req, res) => {
 				setHeaders(res);
 				callback(app.ms.api.reqToModuleInput(req), app.ms.api.resToModuleOutput(res));
 			});

--- a/app/modules/gateway/interface.ts
+++ b/app/modules/gateway/interface.ts
@@ -4,4 +4,6 @@ export default interface IGeesomeGatewayModule {
 	getDnsLinkPathFromRequest(req): Promise<string>;
 
 	onGetRequest(callback);
+
+	onHeadRequest(callback);
 }

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -108,7 +108,7 @@ Verification:
 
 ### 3. Content Serving Stabilization
 
-Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback.
+Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback. [#846](https://github.com/galtproject/geesome-node/issues/846) extends the same header behavior to gateway HEAD requests so published folder/IPFS-style paths can return storage headers.
 
 Goal: fix the highest user-visible backend bugs before feature work.
 

--- a/test/gatewayHeaders.test.ts
+++ b/test/gatewayHeaders.test.ts
@@ -1,0 +1,59 @@
+import assert from "assert";
+import http from "node:http";
+import gatewayModule from "../app/modules/gateway/index.js";
+import {IGeesomeApp} from "../app/interface.js";
+
+function requestHead(port: number, path: string): Promise<http.IncomingMessage> {
+	return new Promise((resolve, reject) => {
+		const req = http.request({host: "127.0.0.1", port, path, method: "HEAD"}, resolve);
+		req.on("error", reject);
+		req.end();
+	});
+}
+
+describe("gateway headers", function () {
+	this.timeout(10000);
+
+	it("lets gateway HEAD handlers set storage response headers", async () => {
+		const port = 7789;
+		const gateway = await gatewayModule({
+			checkModules: () => null,
+			ms: {
+				api: {
+					reqToModuleInput: (req) => ({
+						headers: req.headers,
+						route: req.url,
+						fullRoute: req.originalUrl,
+						stream: req
+					}),
+					resToModuleOutput: (res) => ({
+						send: res.send.bind(res),
+						setHeader: res.setHeader.bind(res),
+						writeHead: res.writeHead.bind(res),
+						stream: res
+					})
+				}
+			}
+		} as unknown as IGeesomeApp, {registerApi: false, port});
+
+		try {
+			gateway.onHeadRequest(async (req, res) => {
+				res.writeHead(200, {
+					"Content-Length": "7",
+					"Content-Type": "text/html",
+					"x-test-head-handler": "gateway"
+				});
+				res.stream.end();
+			});
+
+			const res = await requestHead(port, "/published/index.html");
+
+			assert.equal(res.statusCode, 200);
+			assert.equal(res.headers["content-length"], "7");
+			assert.equal(res.headers["content-type"], "text/html");
+			assert.equal(res.headers["x-test-head-handler"], "gateway");
+		} finally {
+			gateway.stop();
+		}
+	});
+});


### PR DESCRIPTION
Summary
- closes #846
- lets gateway HEAD requests fall through to registered handlers instead of the generic fallback ending the response
- adds gateway onHeadRequest routing and maps DNSLink/IPFS gateway HEAD requests to content.getContentHead
- adds a focused gateway header regression test and updates docs/todo.md

Verification
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/gatewayHeaders.test.ts test/apiHeaders.test.ts test/contentHeaders.test.ts --exit -t 10000
- npm run generate-docs
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/gateway/index.ts'); await import('./app/modules/gateway/api.ts'); console.log('gateway imports ok')"
- git diff --check