### PR TITLE
Harden content byte-range handling

### DIFF
--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -40,6 +40,43 @@ export default async (app: IGeesomeApp) => {
 function getModule(app: IGeesomeApp) {
 	app.checkModules(['database', 'drivers', 'storage']);
 
+	function parseByteRange(rangeHeader: string, dataSize: number, defaultChunkSize: number): {start: number, end: number} | null {
+		if (!rangeHeader || !rangeHeader.startsWith('bytes=') || rangeHeader.includes(',')) {
+			return null;
+		}
+
+		const rangeParts = rangeHeader.replace(/bytes=/, "").split("-");
+		if (rangeParts.length !== 2) {
+			return null;
+		}
+		const [rawStart, rawEnd] = rangeParts;
+		if ((rawStart === '' && rawEnd === '') || (rawStart && !/^\d+$/.test(rawStart)) || (rawEnd && !/^\d+$/.test(rawEnd))) {
+			return null;
+		}
+
+		let start: number;
+		let end: number;
+		if (rawStart === '') {
+			const suffixLength = parseInt(rawEnd, 10);
+			if (!suffixLength) {
+				return null;
+			}
+			start = Math.max(dataSize - suffixLength, 0);
+			end = dataSize - 1;
+		} else {
+			start = parseInt(rawStart, 10);
+			end = rawEnd ? parseInt(rawEnd, 10) : start + defaultChunkSize;
+		}
+
+		if (dataSize <= 0 || start >= dataSize || end < start) {
+			return null;
+		}
+		if (end > dataSize - 1) {
+			end = dataSize - 1;
+		}
+		return {start, end};
+	}
+
 	class ContentModule implements IGeesomeContentModule {
 
 		async getAllContentList(adminId, searchString?, listParams?: IListParams) {
@@ -866,14 +903,15 @@ function getModule(app: IGeesomeApp) {
 				chunkSize = Math.ceil(dataSize * 0.25);
 			}
 
-			range = range.replace(/bytes=/, "").split("-");
-
-			range[0] = range[0] ? parseInt(range[0], 10) : 0;
-			range[1] = range[1] ? parseInt(range[1], 10) : range[0] + chunkSize;
-			if(range[1] > dataSize - 1) {
-				range[1] = dataSize - 1;
+			range = parseByteRange(range, dataSize, chunkSize);
+			if (!range) {
+				res.writeHead(416, {
+					'Content-Range': `bytes */${dataSize}`,
+					'Accept-Ranges': 'bytes',
+					'Cross-Origin-Resource-Policy': 'cross-origin'
+				});
+				return res.stream.end();
 			}
-			range = {start: range[0], end: range[1]};
 
 			const contentLength = range.end - range.start + 1;
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -108,7 +108,7 @@ Verification:
 
 ### 3. Content Serving Stabilization
 
-Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback. [#846](https://github.com/galtproject/geesome-node/issues/846) extends the same header behavior to gateway HEAD requests so published folder/IPFS-style paths can return storage headers.
+Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback. [#846](https://github.com/galtproject/geesome-node/issues/846) extends the same header behavior to gateway HEAD requests so published folder/IPFS-style paths can return storage headers. [#848](https://github.com/galtproject/geesome-node/issues/848) hardens byte-range handling so malformed or unsatisfiable ranges return `416` before storage streams are opened.
 
 Goal: fix the highest user-visible backend bugs before feature work.
 

--- a/test/contentHeaders.test.ts
+++ b/test/contentHeaders.test.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import {Readable} from "node:stream";
 import contentModule from "../app/modules/content/index.js";
 import {ContentMimeType} from "../app/modules/database/interface.js";
 import {IGeesomeApp} from "../app/interface.js";
@@ -54,5 +55,167 @@ describe("content headers", function () {
 		assert.equal(headers["x-ipfs-datasize"], contentSize);
 		assert.equal(headers["Content-Type"], ContentMimeType.Text);
 		assert.equal(ended, true);
+	});
+
+	it("rejects unsatisfiable byte ranges before opening storage streams", async () => {
+		let streamRequested = false;
+		const writes: any = {};
+		const contentSize = 5;
+		const content = await contentModule({
+			checkModules: () => null,
+			ms: {
+				api: {
+					onGet: () => null,
+					onHead: () => null,
+					onUnversionGet: () => null,
+					onUnversionHead: () => null,
+					onAuthorizedGet: () => null,
+					onAuthorizedPost: () => null,
+					setStorageHeaders: () => null
+				},
+				database: {
+					getContentByStorageId: async () => ({
+						storageId: "file.txt",
+						mimeType: ContentMimeType.Text,
+						size: contentSize
+					})
+				},
+				storage: {
+					getFileStat: async () => ({size: contentSize}),
+					getFileStream: async () => {
+						streamRequested = true;
+						return Readable.from(["unexpected"]);
+					}
+				}
+			}
+		} as unknown as IGeesomeApp);
+
+		await content.getFileStreamForApiRequest({
+			headers: {range: "bytes=10-20"}
+		} as any, {
+			writeHead: (status, responseHeaders) => {
+				writes.status = status;
+				writes.headers = responseHeaders;
+			},
+			stream: {
+				end: () => {
+					writes.ended = true;
+				}
+			}
+		} as any, "file.txt");
+
+		assert.equal(writes.status, 416);
+		assert.equal(writes.headers["Content-Range"], "bytes */5");
+		assert.equal(writes.headers["Accept-Ranges"], "bytes");
+		assert.equal(writes.ended, true);
+		assert.equal(streamRequested, false);
+	});
+
+	it("rejects malformed byte ranges before opening storage streams", async () => {
+		let streamRequested = false;
+		const writes: any = {};
+		const contentSize = 5;
+		const content = await contentModule({
+			checkModules: () => null,
+			ms: {
+				api: {
+					onGet: () => null,
+					onHead: () => null,
+					onUnversionGet: () => null,
+					onUnversionHead: () => null,
+					onAuthorizedGet: () => null,
+					onAuthorizedPost: () => null,
+					setStorageHeaders: () => null
+				},
+				database: {
+					getContentByStorageId: async () => ({
+						storageId: "file.txt",
+						mimeType: ContentMimeType.Text,
+						size: contentSize
+					})
+				},
+				storage: {
+					getFileStat: async () => ({size: contentSize}),
+					getFileStream: async () => {
+						streamRequested = true;
+						return Readable.from(["unexpected"]);
+					}
+				}
+			}
+		} as unknown as IGeesomeApp);
+
+		await content.getFileStreamForApiRequest({
+			headers: {range: "bytes=1-2-3"}
+		} as any, {
+			writeHead: (status, responseHeaders) => {
+				writes.status = status;
+				writes.headers = responseHeaders;
+			},
+			stream: {
+				end: () => {
+					writes.ended = true;
+				}
+			}
+		} as any, "file.txt");
+
+		assert.equal(writes.status, 416);
+		assert.equal(writes.headers["Content-Range"], "bytes */5");
+		assert.equal(writes.ended, true);
+		assert.equal(streamRequested, false);
+	});
+
+	it("supports suffix byte ranges", async () => {
+		let streamOptions: any;
+		const writes: any = {};
+		const contentSize = 5;
+		const content = await contentModule({
+			checkModules: () => null,
+			ms: {
+				api: {
+					onGet: () => null,
+					onHead: () => null,
+					onUnversionGet: () => null,
+					onUnversionHead: () => null,
+					onAuthorizedGet: () => null,
+					onAuthorizedPost: () => null,
+					setStorageHeaders: () => null
+				},
+				database: {
+					getContentByStorageId: async () => ({
+						storageId: "file.txt",
+						mimeType: "video/mp4",
+						size: contentSize
+					})
+				},
+				storage: {
+					getFileStat: async () => ({size: contentSize}),
+					getFileStream: async (_path, options) => {
+						streamOptions = options;
+						return Readable.from(["de"]);
+					}
+				}
+			}
+		} as unknown as IGeesomeApp);
+
+		await content.getFileStreamForApiRequest({
+			headers: {range: "bytes=-2"}
+		} as any, {
+			writeHead: (status, responseHeaders) => {
+				writes.status = status;
+				writes.headers = responseHeaders;
+			},
+			stream: {
+				write: () => null,
+				on: () => null,
+				once: () => null,
+				emit: () => null,
+				end: () => null
+			}
+		} as any, "file.txt");
+
+		assert.equal(writes.status, 206);
+		assert.equal(writes.headers["Content-Range"], "bytes 3-4/5");
+		assert.equal(writes.headers["Content-Length"], 2);
+		assert.deepEqual(streamOptions, {offset: 3, length: 2});
 	});
 });


### PR DESCRIPTION
Summary
- closes #848
- parses content byte ranges explicitly and rejects malformed, multi-range, or unsatisfiable ranges with 416
- supports suffix ranges like bytes=-N
- avoids opening storage streams when the requested range cannot be served
- updates docs/todo.md content-serving status

Verification
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/contentHeaders.test.ts test/apiHeaders.test.ts test/gatewayHeaders.test.ts --exit -t 10000
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/content/index.ts'); console.log('content import ok')"
- git diff --check