### PR TITLE
Return 404 for missing content storage

### DIFF
--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -874,9 +874,10 @@ function getModule(app: IGeesomeApp) {
 				}
 				const fileStat = await app.ms.storage.getFileStat(dataPath);
 				console.log('getFileStat', fileStat);
-				if (fileStat) {
-					content = await app.ms.database.getContentByStorageId(ipfsHelper.cidToIpfsHash(fileStat.cid), true);
+				if (!fileStat) {
+					return res.send(404);
 				}
+				content = await app.ms.database.getContentByStorageId(ipfsHelper.cidToIpfsHash(fileStat.cid), true);
 				const headers = await this.getIpfsHashHeadersObj(content, dataPath, fileStat.size, false);
 				console.log('headers', headers);
 				res.writeHead(200, headers);

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -108,7 +108,7 @@ Verification:
 
 ### 3. Content Serving Stabilization
 
-Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback. [#846](https://github.com/galtproject/geesome-node/issues/846) extends the same header behavior to gateway HEAD requests so published folder/IPFS-style paths can return storage headers. [#848](https://github.com/galtproject/geesome-node/issues/848) hardens byte-range handling so malformed or unsatisfiable ranges return `416` before storage streams are opened.
+Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback. [#846](https://github.com/galtproject/geesome-node/issues/846) extends the same header behavior to gateway HEAD requests so published folder/IPFS-style paths can return storage headers. [#848](https://github.com/galtproject/geesome-node/issues/848) hardens byte-range handling so malformed or unsatisfiable ranges return `416` before storage streams are opened. [#850](https://github.com/galtproject/geesome-node/issues/850) returns `404` when an allowed content path is missing from storage instead of dereferencing a missing stat.
 
 Goal: fix the highest user-visible backend bugs before feature work.
 

--- a/test/contentHeaders.test.ts
+++ b/test/contentHeaders.test.ts
@@ -111,6 +111,46 @@ describe("content headers", function () {
 		assert.equal(streamRequested, false);
 	});
 
+	it("returns 404 for allowed storage paths missing from storage", async () => {
+		let streamRequested = false;
+		const sends: any[] = [];
+		const content = await contentModule({
+			checkModules: () => null,
+			callHookCheckAllowed: async () => true,
+			ms: {
+				api: {
+					onGet: () => null,
+					onHead: () => null,
+					onUnversionGet: () => null,
+					onUnversionHead: () => null,
+					onAuthorizedGet: () => null,
+					onAuthorizedPost: () => null,
+					setStorageHeaders: () => null
+				},
+				database: {
+					getContentByStorageId: async () => null
+				},
+				storage: {
+					getFileStat: async () => null,
+					getFileStream: async () => {
+						streamRequested = true;
+						return Readable.from(["unexpected"]);
+					}
+				}
+			}
+		} as unknown as IGeesomeApp);
+
+		await content.getFileStreamForApiRequest({
+			headers: {}
+		} as any, {
+			send: (...args) => sends.push(args),
+			setHeader: () => null
+		} as any, "missing.txt");
+
+		assert.deepEqual(sends, [[404]]);
+		assert.equal(streamRequested, false);
+	});
+
 	it("rejects malformed byte ranges before opening storage streams", async () => {
 		let streamRequested = false;
 		const writes: any = {};


### PR DESCRIPTION
Summary
- closes #850
- returns 404 when an allowed non-range content path is missing from storage
- avoids dereferencing a missing file stat and avoids opening a storage stream for missing files
- updates docs/todo.md content-serving status

Verification
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/contentHeaders.test.ts test/apiHeaders.test.ts test/gatewayHeaders.test.ts --exit -t 10000
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/content/index.ts'); console.log('content import ok')"
- git diff --check