### PR TITLE
Harden pin negative paths

### DIFF
--- a/app/modules/pin/index.ts
+++ b/app/modules/pin/index.ts
@@ -11,7 +11,7 @@ export default async (app: IGeesomeApp) => {
 	return module;
 }
 
-function getModule(app: IGeesomeApp, models) {
+export function getModule(app: IGeesomeApp, models) {
 	class PinModule implements IGeesomePinModule {
 		async createAccount(userId: number, account: IPinAccount): Promise<IPinAccount> {
 			return models.PinAccount.create({
@@ -54,15 +54,24 @@ function getModule(app: IGeesomeApp, models) {
 
 		async pinByUserAccount(userId: number, name: string, storageId: string, options = {}): Promise<any> {
 			const account = await this.getUserAccount(userId, name);
+			if (!account) {
+				throw new Error("pin_account_not_found");
+			}
 			return this.pinByAnyService(storageId, account)
 		}
 
 		async pinByGroupAccount(userId: number, groupId: number, name: string, storageId: string, options = {}): Promise<any> {
 			const account = await this.getGroupAccount(userId, groupId, name);
+			if (!account) {
+				throw new Error("pin_account_not_found");
+			}
 			return this.pinByAnyService(storageId, account)
 		}
 
 		async pinByAnyService(storageId: string, account: IPinAccount, options?) {
+			if (!account) {
+				throw new Error("pin_account_not_found");
+			}
 			if (account.service === 'pinata') {
 				return this.pinByPinata(storageId, account, options);
 			} else {
@@ -72,6 +81,9 @@ function getModule(app: IGeesomeApp, models) {
 
 		async pinByPinata(storageId: string, account: IPinAccount, options?) {
 			const content = await app.ms.content.getContentByStorageAndUserId(storageId, account.userId);
+			if (!content) {
+				throw new Error("content_not_found");
+			}
 			const hostNodes = await app.ms.storage.remoteNodeAddressList(['tcp']);
 			console.log('hostNodes', hostNodes);
 			return axios

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -136,6 +136,8 @@ Verification:
 
 ### 4. Pinata And Pinning MVP
 
+Status: in progress. [#854](https://github.com/galtproject/geesome-node/issues/854) hardens direct pin negative paths with explicit missing-account, unknown-service, and missing-content errors before remote pinning is attempted.
+
 Goal: turn "Pin to services like pinata from UI" into a shippable backend/API slice first.
 
 Scope:

--- a/test/pinUnit.test.ts
+++ b/test/pinUnit.test.ts
@@ -1,0 +1,57 @@
+import assert from "assert";
+import {getModule as getPinModule} from "../app/modules/pin/index.js";
+import {IGeesomeApp} from "../app/interface.js";
+
+function createPinModule(accounts: any[] = [], contentByStorageId: Record<string, any> = {}) {
+	return getPinModule({
+		ms: {
+			content: {
+				getContentByStorageAndUserId: async (storageId, userId) => {
+					const content = contentByStorageId[storageId];
+					return content && content.userId === userId ? content : null;
+				}
+			},
+			storage: {
+				remoteNodeAddressList: async () => ["node-address"]
+			},
+			group: {
+				canEditGroup: async () => true
+			}
+		}
+	} as unknown as IGeesomeApp, {
+		PinAccount: {
+			findOne: async ({where}) => accounts.find((account) => {
+				return Object.keys(where).every((key) => account[key] === where[key]);
+			}) || null
+		}
+	});
+}
+
+describe("pin negative paths", function () {
+	it("fails explicitly when a user pin account is missing", async () => {
+		const pins = createPinModule();
+
+		await assert.rejects(
+			() => pins.pinByUserAccount(1, "missing", "storage-id"),
+			(error: Error) => error.message === "pin_account_not_found"
+		);
+	});
+
+	it("fails explicitly for unknown pin services", async () => {
+		const pins = createPinModule([{userId: 1, name: "custom", service: "custom"}]);
+
+		await assert.rejects(
+			() => pins.pinByUserAccount(1, "custom", "storage-id"),
+			(error: Error) => error.message === "unknown_service"
+		);
+	});
+
+	it("fails before remote pinning when content is not owned by the account user", async () => {
+		const pins = createPinModule([{userId: 1, name: "pinata", service: "pinata"}]);
+
+		await assert.rejects(
+			() => pins.pinByUserAccount(1, "pinata", "missing-storage"),
+			(error: Error) => error.message === "content_not_found"
+		);
+	});
+});


### PR DESCRIPTION
Summary
- closes #854
- returns explicit pin_account_not_found errors before service dispatch
- keeps unknown_service explicit for unsupported pin providers
- returns content_not_found before attempting remote Pinata pinning for missing/non-owned content
- adds lightweight pin negative-path unit tests and updates docs/todo.md

Verification
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/pinUnit.test.ts --exit -t 10000
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/pin/index.ts'); await import('./app/modules/pin/api.ts'); console.log('pin imports ok')"
- npm run generate-docs
- git diff --check