### PR TITLE
Encrypt pin account secret updates

### DIFF
--- a/app/modules/pin/index.ts
+++ b/app/modules/pin/index.ts
@@ -22,10 +22,13 @@ export function getModule(app: IGeesomeApp, models) {
 
 		async updateAccount(userId: number, id: number, updateData: IPinAccount): Promise<IPinAccount> {
 			const account = await models.PinAccount.findOne({where: {id}});
+			if (!account) {
+				throw new Error("pin_account_not_found");
+			}
 			if (account.userId !== userId && !(await app.ms.group.canEditGroup(userId, account.groupId))) {
 				throw new Error("not_permitted");
 			}
-			return models.PinAccount.update(updateData, {where: {id}})
+			return models.PinAccount.update(await this.encryptPinAccountIfNecessary(updateData), {where: {id}})
 				.then(() => models.PinAccount.findOne({where: {id}}))
 				.then(acc => this.decryptPinAccountIfNecessary(acc));
 		}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -136,7 +136,7 @@ Verification:
 
 ### 4. Pinata And Pinning MVP
 
-Status: in progress. [#854](https://github.com/galtproject/geesome-node/issues/854) hardens direct pin negative paths with explicit missing-account, unknown-service, and missing-content errors before remote pinning is attempted.
+Status: in progress. [#854](https://github.com/galtproject/geesome-node/issues/854) hardens direct pin negative paths with explicit missing-account, unknown-service, and missing-content errors before remote pinning is attempted. [#856](https://github.com/galtproject/geesome-node/issues/856) keeps pin account secret updates encrypted and returns an explicit missing-account error for update calls.
 
 Goal: turn "Pin to services like pinata from UI" into a shippable backend/API slice first.
 

--- a/test/pinUnit.test.ts
+++ b/test/pinUnit.test.ts
@@ -4,6 +4,8 @@ import {IGeesomeApp} from "../app/interface.js";
 
 function createPinModule(accounts: any[] = [], contentByStorageId: Record<string, any> = {}) {
 	return getPinModule({
+		encryptTextWithAppPass: async (text) => `encrypted:${text}`,
+		decryptTextWithAppPass: async (text) => text.replace(/^encrypted:/, ""),
 		ms: {
 			content: {
 				getContentByStorageAndUserId: async (storageId, userId) => {
@@ -22,7 +24,16 @@ function createPinModule(accounts: any[] = [], contentByStorageId: Record<string
 		PinAccount: {
 			findOne: async ({where}) => accounts.find((account) => {
 				return Object.keys(where).every((key) => account[key] === where[key]);
-			}) || null
+			}) || null,
+			update: async (updateData, {where}) => {
+				const account = accounts.find((item) => {
+					return Object.keys(where).every((key) => item[key] === where[key]);
+				});
+				if (account) {
+					Object.assign(account, updateData);
+				}
+				return [account ? 1 : 0];
+			}
 		}
 	});
 }
@@ -53,5 +64,39 @@ describe("pin negative paths", function () {
 			() => pins.pinByUserAccount(1, "pinata", "missing-storage"),
 			(error: Error) => error.message === "content_not_found"
 		);
+	});
+
+	it("fails explicitly when updating a missing pin account", async () => {
+		const pins = createPinModule();
+
+		await assert.rejects(
+			() => pins.updateAccount(1, 404, {apiKey: "updated"}),
+			(error: Error) => error.message === "pin_account_not_found"
+		);
+	});
+
+	it("encrypts secret keys on pin account updates", async () => {
+		const account = {
+			id: 1,
+			userId: 1,
+			name: "pinata",
+			service: "pinata",
+			apiKey: "old-key",
+			secretApiKey: "",
+			secretApiKeyEncrypted: "encrypted:old-secret",
+			isEncrypted: true
+		};
+		const pins = createPinModule([account]);
+
+		const updated = await pins.updateAccount(1, 1, {
+			apiKey: "new-key",
+			secretApiKey: "new-secret",
+			isEncrypted: true
+		});
+
+		assert.equal(account.apiKey, "new-key");
+		assert.equal(account.secretApiKey, "new-secret");
+		assert.equal(account.secretApiKeyEncrypted, "encrypted:new-secret");
+		assert.equal(updated.secretApiKey, "new-secret");
 	});
 });


### PR DESCRIPTION
Summary
- closes #856
- returns pin_account_not_found when updating a missing pin account
- applies the existing pin secret encryption path to updateAccount
- extends lightweight pin unit tests for missing update targets and encrypted secret updates
- updates docs/todo.md pinning status

Verification
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/pinUnit.test.ts --exit -t 10000
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/pin/index.ts'); await import('./app/modules/pin/api.ts'); console.log('pin imports ok')"
- git diff --check