### PR TITLE
Isolate API header test port

### DIFF
--- a/test/apiHeaders.test.ts
+++ b/test/apiHeaders.test.ts
@@ -16,16 +16,20 @@ describe("api headers", function () {
 
 	it("lets module HEAD handlers set storage response headers", async () => {
 		const port = 7788;
-		const api = await apiModule({
-			config: {port},
-			ms: {
-				database: {getUsersCount: async () => 0},
-				storage: {remoteNodeAddressList: async () => []},
-				communicator: {nodeAddressList: async () => []}
-			}
-		} as unknown as IGeesomeApp);
+		const previousPort = process.env.PORT;
+		let api;
+		delete process.env.PORT;
 
 		try {
+			api = await apiModule({
+				config: {port},
+				ms: {
+					database: {getUsersCount: async () => 0},
+					storage: {remoteNodeAddressList: async () => []},
+					communicator: {nodeAddressList: async () => []}
+				}
+			} as unknown as IGeesomeApp);
+
 			api.onHead("content-data/*", async (req, res) => {
 				res.writeHead(200, {
 					"Content-Length": "5",
@@ -42,7 +46,12 @@ describe("api headers", function () {
 			assert.equal(res.headers["content-type"], "text/plain");
 			assert.equal(res.headers["x-test-head-handler"], "content-data");
 		} finally {
-			api.stop();
+			if (previousPort === undefined) {
+				delete process.env.PORT;
+			} else {
+				process.env.PORT = previousPort;
+			}
+			api?.stop();
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- Closes #863 by isolating `apiHeaders.test.ts` from the ambient `PORT` value used by the Docker full-suite environment.
- Preserves the HEAD regression that module handlers can set storage response headers such as `Content-Length`, `Content-Type`, and custom headers.

## Verification

- `PORT=7772 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/apiHeaders.test.ts --exit -t 10000`
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/pinUnit.test.ts`
- `docker compose -f ./test/docker-compose.yml build test`
- `docker compose -f ./test/docker-compose.yml run --rm --no-deps test node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/apiHeaders.test.ts --exit -t 10000`
- `git diff --check`
