### PR TITLE
Generate local Docker test fixtures

### DIFF
--- a/bash/prepare-test-resources.sh
+++ b/bash/prepare-test-resources.sh
@@ -4,10 +4,24 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RESOURCES_DIR="$ROOT_DIR/test/resources"
 
+command -v ffmpeg >/dev/null 2>&1 || {
+	echo "ffmpeg is required to generate deterministic test media fixtures." >&2
+	exit 127
+}
+
+command -v zip >/dev/null 2>&1 || {
+	echo "zip is required to generate deterministic test archive fixtures." >&2
+	exit 127
+}
+
 mkdir -p "$RESOURCES_DIR"
 
 if [[ ! -s "$RESOURCES_DIR/input-image.jpg" ]]; then
 	ffmpeg -y -f lavfi -i "testsrc=size=640x360:rate=1" -frames:v 1 -q:v 2 "$RESOURCES_DIR/input-image.jpg" >/dev/null 2>&1
+fi
+
+if [[ ! -s "$RESOURCES_DIR/input-image.png" ]]; then
+	ffmpeg -y -f lavfi -i "testsrc=size=640x360:rate=1" -frames:v 1 "$RESOURCES_DIR/input-image.png" >/dev/null 2>&1
 fi
 
 if [[ ! -s "$RESOURCES_DIR/not-streamable-input-video.mp4" ]]; then
@@ -31,6 +45,24 @@ if [[ ! -s "$RESOURCES_DIR/streamable-input-video.mp4" ]]; then
 		-c:a aac \
 		-movflags +faststart \
 		"$RESOURCES_DIR/streamable-input-video.mp4" >/dev/null 2>&1
+fi
+
+if [[ ! -s "$RESOURCES_DIR/input-video.mov" ]]; then
+	ffmpeg -y \
+		-f lavfi -i "testsrc=size=320x240:rate=24" \
+		-f lavfi -i "sine=frequency=600:sample_rate=44100" \
+		-t 2 \
+		-pix_fmt yuv420p \
+		-c:v libx264 \
+		-c:a aac \
+		"$RESOURCES_DIR/input-video.mov" >/dev/null 2>&1
+fi
+
+if [[ ! -s "$RESOURCES_DIR/test-gif.gif" ]]; then
+	ffmpeg -y \
+		-f lavfi -i "testsrc=size=160x120:rate=8" \
+		-t 1 \
+		"$RESOURCES_DIR/test-gif.gif" >/dev/null 2>&1
 fi
 
 if [[ ! -s "$RESOURCES_DIR/test-archive.zip" ]]; then

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -44,6 +44,7 @@ Runtime maintenance:
 - Migrate the supported runtime from Node `>=18` to Node 22. Node 18 and Node 20 are EOL or effectively out of support for new GeeSome work. Use Node 22 as the immediate baseline, then validate Node 24 separately.
 - [#859](https://github.com/galtproject/geesome-node/issues/859) adds a Docker-backed full test flow for environments where host PostgreSQL credentials or `ffmpeg` are missing.
 - [#861](https://github.com/galtproject/geesome-node/issues/861) makes Docker the preferred full-suite test path and optimizes it for warm reruns after source-only implementation changes.
+- [#862](https://github.com/galtproject/geesome-node/issues/862) removes the remaining `gateway.ipfs.io` fallback from test media/archive fixtures by generating every named resource locally before the Docker suite runs.
 
 Issue clusters still represented by the old README TODO:
 

--- a/test/helpers/resources.ts
+++ b/test/helpers/resources.ts
@@ -1,8 +1,18 @@
 
 import fs from "fs";
-import axios from "axios";
+import {execFileSync} from "child_process";
 import helpers from "../../app/helpers.js";
 import appHelpers from "../../app/helpers.js";
+
+const resourceNames = [
+    'input-image.png',
+    'input-image.jpg',
+    'test-archive.zip',
+    'input-video.mov',
+    'not-streamable-input-video.mp4',
+    'streamable-input-video.mp4',
+    'test-gif.gif'
+];
 
 export default {
     getOutputDir() {
@@ -20,28 +30,18 @@ export default {
         if (fs.existsSync(dir + name)) {
             return dir + name;
         }
-        const hashes = {
-            'input-image.png': 'QmSnpR15Bdm3jVQWpmiGqRyqFGqararwGrvi1WdEmZzJRC',
-            'input-image.jpg': 'QmSRYP2MaJxT3uHWLDkanQF2Uhi1K2zTf3Ppr5fPdEqsYt',
-            'test-archive.zip': 'QmabvdMeL3wb1P71FP2AAnyzbvD9u2sucphtFoQH8vJStN',
-            'input-video.mov': 'QmYNiAJyK9ZzQ3DVwRJ7vB3jNuKqumrAZmjyWzaTRMTzxm',
-            'not-streamable-input-video.mp4': 'QmYP1UGu9gTQZ5hjG7h7Em2ejQAEpmLWA3cfFg5UkjLYCQ',
-            'streamable-input-video.mp4': 'QmWasM9o4RGMvVs1MPxcabw8QAtxanHpmDKv4bMVVfiXSF',
-            'test-gif.gif': 'QmNTJLLe4eCYsGybL4NDzGhkWF81QmGLZrRSZscsxm3dtR'
-        };
-        const writer = fs.createWriteStream(dir + name)
+        if (!resourceNames.includes(name)) {
+            throw new Error(`Unknown test resource: ${name}`);
+        }
 
-        const response = await axios({
-            url: 'https://gateway.ipfs.io/ipfs/' + hashes[name] + '?download=true',
-            method: 'GET',
-            responseType: 'stream'
-        })
-
-        response.data.pipe(writer)
-
-        return new Promise((resolve, reject) => {
-            writer.on('finish', () => resolve(dir + name))
-            writer.on('error', reject)
+        execFileSync('bash', [helpers.getCurDir() + '/../bash/prepare-test-resources.sh'], {
+            stdio: 'inherit'
         });
+
+        if (!fs.existsSync(dir + name)) {
+            throw new Error(`Test resource was not generated: ${name}`);
+        }
+
+        return dir + name;
     }
 }


### PR DESCRIPTION
## Summary

Closes #862

- generates all named media/archive test fixtures locally with ffmpeg/zip, including PNG, MOV, GIF, MP4, JPG, and ZIP resources
- removes the gateway.ipfs.io download fallback from the test resource helper and reports unknown/missing fixtures explicitly
- updates docs/todo.md with the Docker fixture status

## Verification

- docker compose -f ./test/docker-compose.yml build test
- docker compose -f ./test/docker-compose.yml run --rm --no-deps test sh -lc 'rm -rf test/resources/* && npm run test:prepare-resources && ls -lh test/resources && node --import tsx --experimental-global-customevent -e "const r=(await import(\"./test/helpers/resources.ts\")).default; for (const name of [\"input-image.png\",\"input-image.jpg\",\"test-archive.zip\",\"input-video.mov\",\"not-streamable-input-video.mp4\",\"streamable-input-video.mp4\",\"test-gif.gif\"]) { const p = await r.prepare(name); console.log(name, p); }"'
- docker compose -f ./test/docker-compose.yml run --rm test node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/app.test.ts --exit -t 10000 (10 passing, 1 known geesome-libs IPFS address failure remains)
- npm run test:docker (57 passing, 11 pending, 8 known failures remain; fixture download failures are gone)
- git diff --check
