### PR TITLE
Improve pin API docs and examples

### DIFF
--- a/app/interface.ts
+++ b/app/interface.ts
@@ -315,13 +315,17 @@ export interface IContentStatResponse {
 }
 
 export interface IPinOptionsInput {
-  name?: string;
-  path?: string;
-  metadata?: any;
+  [key: string]: string | number | boolean | null;
 }
 
 export interface IPinAccountListResponse {
   list: any[];
+}
+
+export interface IPinServiceResponse {
+  data?: any;
+  status?: number;
+  statusText?: string;
 }
 
 export interface IForeignAccountLookupInput {

--- a/app/modules/pin/api.ts
+++ b/app/modules/pin/api.ts
@@ -3,13 +3,33 @@ import IGeesomePinModule from "./interface.js";
 
 export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
     /**
+     * @apiDefine PinErrors
+     *
+     * @apiError (400) PinAccountNotFound The requested user or group pin account does not exist.
+     * @apiError (400) UnknownService The pin account service is not supported.
+     * @apiError (404) ContentNotFound The storage id does not belong to visible local content.
+     * @apiError (403) NotPermitted Current user or API key cannot manage the requested group pin account.
+     * @apiError (502) PinataPinFailed The remote Pinata pin request failed.
+     * @apiErrorExample {json} Pin account missing
+     *   {
+     *     "error": "pin_account_not_found"
+     *   }
+     * @apiErrorExample {json} Remote Pinata failure
+     *   {
+     *     "error": "pinata_pin_failed"
+     *   }
+     */
+
+    /**
      * @api {post} /v1/user/pin/create-account Create pin account
      * @apiName UserPinCreateAccount
      * @apiGroup UserPin
+     * @apiDescription Creates a user-owned or group-owned account for an external pinning service. For Pinata, set `service` to `pinata`; `secretApiKey` can be encrypted at rest by setting `isEncrypted` to `true`.
      *
      * @apiUse ApiKey
      * @apiUse AuthErrors
      * @apiUse ValidationErrors
+     * @apiUse PinErrors
      *
      * @apiInterface (./interface.ts) {IPinAccount} apiBody
      * @apiInterface (./interface.ts) {IPinAccount} apiSuccess
@@ -19,6 +39,12 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      *     -H "Authorization: Bearer geesome-api-key" \
      *     -H "Content-Type: application/json" \
      *     -d '{"name":"pinata","service":"pinata","apiKey":"pinata-key","secretApiKey":"pinata-secret"}'
+     *
+     * @apiExample {curl} Create a group Pinata account with encrypted secret
+     *   curl -X POST http://localhost:2052/v1/user/pin/create-account \
+     *     -H "Authorization: Bearer geesome-api-key" \
+     *     -H "Content-Type: application/json" \
+     *     -d '{"name":"group-pinata","service":"pinata","groupId":42,"apiKey":"pinata-key","secretApiKey":"pinata-secret","isEncrypted":true}'
      */
     app.ms.api.onAuthorizedPost('user/pin/create-account', async (req, res) => {
         res.send(await pinModule.createAccount(req.user.id, req.body));
@@ -28,14 +54,22 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      * @api {post} /v1/user/pin/update-account/:id Update pin account
      * @apiName UserPinUpdateAccount
      * @apiGroup UserPin
+     * @apiDescription Updates a user-owned pin account or a group-owned pin account editable by the current user. Secret updates follow the same `isEncrypted` handling as account creation.
      *
      * @apiUse ApiKey
      * @apiUse AuthErrors
      * @apiUse ValidationErrors
+     * @apiUse PinErrors
      *
      * @apiParam {Number} id Pin account id.
      * @apiInterface (./interface.ts) {IPinAccount} apiBody
      * @apiInterface (./interface.ts) {IPinAccount} apiSuccess
+     *
+     * @apiExample {curl} Rotate a Pinata secret
+     *   curl -X POST http://localhost:2052/v1/user/pin/update-account/15 \
+     *     -H "Authorization: Bearer geesome-api-key" \
+     *     -H "Content-Type: application/json" \
+     *     -d '{"secretApiKey":"new-pinata-secret","isEncrypted":true}'
      */
     app.ms.api.onAuthorizedPost('user/pin/update-account/:id', async (req, res) => {
         res.send(await pinModule.updateAccount(req.user.id, req.params.id, req.body));
@@ -45,11 +79,16 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      * @api {get} /v1/user/pin/user-accounts List user pin accounts
      * @apiName UserPinAccounts
      * @apiGroup UserPin
+     * @apiDescription Lists pin accounts owned directly by the current user.
      *
      * @apiUse ApiKey
      * @apiUse AuthErrors
      *
      * @apiInterface (../../interface.ts) {IPinAccountListResponse} apiSuccess
+     *
+     * @apiExample {curl} List current user's pin accounts
+     *   curl -X GET http://localhost:2052/v1/user/pin/user-accounts \
+     *     -H "Authorization: Bearer geesome-api-key"
      */
     app.ms.api.onAuthorizedGet('user/pin/user-accounts', async (req, res) => {
         res.send({
@@ -61,12 +100,18 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      * @api {get} /v1/user/pin/group-accounts/:groupId List group pin accounts
      * @apiName UserPinGroupAccounts
      * @apiGroup UserPin
+     * @apiDescription Lists pin accounts attached to a group the current user can edit.
      *
      * @apiUse ApiKey
      * @apiUse AuthErrors
+     * @apiUse PinErrors
      *
      * @apiParam {String} groupId Group id.
      * @apiInterface (../../interface.ts) {IPinAccountListResponse} apiSuccess
+     *
+     * @apiExample {curl} List group pin accounts
+     *   curl -X GET http://localhost:2052/v1/user/pin/group-accounts/42 \
+     *     -H "Authorization: Bearer geesome-api-key"
      */
     app.ms.api.onAuthorizedGet('user/pin/group-accounts/:groupId', async (req, res) => {
         res.send({
@@ -78,14 +123,24 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      * @api {post} /v1/user/pin/account/:accountName/pin-content/:storageId/by-user Pin content by user account
      * @apiName UserPinContentByUser
      * @apiGroup UserPin
+     * @apiDescription Pins existing local content through a user-owned pin account. The JSON body is forwarded to Pinata as `pinataMetadata.keyvalues`, so use flat metadata fields that Pinata should store with the pin.
      *
      * @apiUse ApiKey
      * @apiUse AuthErrors
      * @apiUse StorageErrors
+     * @apiUse PinErrors
      *
      * @apiParam {String} accountName Pin account name.
      * @apiParam {String} storageId Content storage id.
+     * @apiBody {String|Number|Boolean} [metadataKey] Any flat metadata key forwarded to Pinata as `pinataMetadata.keyvalues`.
      * @apiInterface (../../interface.ts) {IPinOptionsInput} apiBody
+     * @apiInterface (../../interface.ts) {IPinServiceResponse} apiSuccess
+     *
+     * @apiExample {curl} Pin content by user account
+     *   curl -X POST http://localhost:2052/v1/user/pin/account/pinata/pin-content/bafy.../by-user \
+     *     -H "Authorization: Bearer geesome-api-key" \
+     *     -H "Content-Type: application/json" \
+     *     -d '{"source":"manual","channel":"telegram-backup"}'
      */
     app.ms.api.onAuthorizedPost('user/pin/account/:accountName/pin-content/:storageId/by-user', async (req, res) => {
         res.send(await pinModule.pinByUserAccount(req.user.id, req.params.accountName, req.params.storageId, req.body));
@@ -95,15 +150,25 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      * @api {post} /v1/user/pin/account/:accountName/pin-content/:storageId/by-group/:groupId Pin content by group account
      * @apiName UserPinContentByGroup
      * @apiGroup UserPin
+     * @apiDescription Pins existing local content through a group-owned pin account. The current user must be able to edit the group. The JSON body is forwarded to Pinata as `pinataMetadata.keyvalues`.
      *
      * @apiUse ApiKey
      * @apiUse AuthErrors
      * @apiUse StorageErrors
+     * @apiUse PinErrors
      *
      * @apiParam {String} accountName Pin account name.
      * @apiParam {String} storageId Content storage id.
      * @apiParam {String} groupId Group id.
+     * @apiBody {String|Number|Boolean} [metadataKey] Any flat metadata key forwarded to Pinata as `pinataMetadata.keyvalues`.
      * @apiInterface (../../interface.ts) {IPinOptionsInput} apiBody
+     * @apiInterface (../../interface.ts) {IPinServiceResponse} apiSuccess
+     *
+     * @apiExample {curl} Pin content by group account
+     *   curl -X POST http://localhost:2052/v1/user/pin/account/group-pinata/pin-content/bafy.../by-group/42 \
+     *     -H "Authorization: Bearer geesome-api-key" \
+     *     -H "Content-Type: application/json" \
+     *     -d '{"source":"auto-action","group":"docs"}'
      */
     app.ms.api.onAuthorizedPost('user/pin/account/:accountName/pin-content/:storageId/by-group/:groupId', async (req, res) => {
         res.send(await pinModule.pinByGroupAccount(req.user.id, req.params.groupId, req.params.accountName, req.params.storageId, req.body));

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -142,7 +142,7 @@ Verification:
 
 ### 4. Pinata And Pinning MVP
 
-Status: in progress. [#854](https://github.com/galtproject/geesome-node/issues/854) hardens direct pin negative paths with explicit missing-account, unknown-service, and missing-content errors before remote pinning is attempted. [#856](https://github.com/galtproject/geesome-node/issues/856) keeps pin account secret updates encrypted and returns an explicit missing-account error for update calls. [#858](https://github.com/galtproject/geesome-node/issues/858) forwards caller pin options into Pinata metadata and normalizes remote Pinata failures to `pinata_pin_failed`.
+Status: in progress. [#854](https://github.com/galtproject/geesome-node/issues/854) hardens direct pin negative paths with explicit missing-account, unknown-service, and missing-content errors before remote pinning is attempted. [#856](https://github.com/galtproject/geesome-node/issues/856) keeps pin account secret updates encrypted and returns an explicit missing-account error for update calls. [#858](https://github.com/galtproject/geesome-node/issues/858) forwards caller pin options into Pinata metadata and normalizes remote Pinata failures to `pinata_pin_failed`. [#868](https://github.com/galtproject/geesome-node/issues/868) documents the account and direct pin API flows, examples, forwarded Pinata keyvalues, and common pin errors.
 
 Goal: turn "Pin to services like pinata from UI" into a shippable backend/API slice first.
 


### PR DESCRIPTION
Closes #868

## Source of truth
Continue the Pinata and pinning MVP from `docs/todo.md`. Backend hardening is merged, and this slice makes the generated API docs clear enough for client/UI work.

## Summary
- Adds shared pin error documentation for missing accounts, unknown services, missing content, permission denial, and Pinata failures.
- Adds examples for creating user/group Pinata accounts, rotating encrypted secrets, listing accounts, and pinning by user or group account.
- Aligns `IPinOptionsInput` with the current implementation: the request body is forwarded to Pinata as flat `pinataMetadata.keyvalues`.
- Updates `docs/todo.md` pinning status for this API-doc slice.

## Verification
- `npm run generate-docs`
- Generated docs check for `metadataKey`, `telegram-backup`, `PinataPinFailed`, and `group-pinata` in `docs/assets/main.bundle.js`.
- `git diff --check`
- `npm --prefix /Users/microwavedev/workspace/microwave-hub run github:body:check -- --repo galtproject/geesome-node --issue 868`