### PR TITLE
Use group avatar for static site favicon

### DIFF
--- a/app/modules/staticSiteGenerator/index.ts
+++ b/app/modules/staticSiteGenerator/index.ts
@@ -304,6 +304,8 @@ async function getModule(app: IGeesomeApp, models) {
                     fs.writeFileSync(routePath + '/index.html', htmlContent);
                 }
              */
+            await this.copySiteAssets(siteStorageDir, renderData.options.site.avatarStorageId);
+
             await this.renderAndSave(renderPage, options, siteStorageDir, ``, 'main');
             for (let i = 1; i <= renderData.pagesCount - 1; i++) {
                 // VueSSR: render other pages by url
@@ -354,6 +356,13 @@ async function getModule(app: IGeesomeApp, models) {
             }
         }
 
+        async copySiteAssets(siteStorageDir: string, faviconSourceStorageId?: string) {
+            await this.saveSiteAssets();
+            await app.ms.storage.copyFileFromId(publicDirStorageId, `${siteStorageDir}/public`);
+            await app.ms.storage.copyFileFromId(vendorAssetsStorageId, `${siteStorageDir}/vendor`);
+            await app.ms.storage.copyFileFromId(faviconSourceStorageId || faviconStorageId, `${siteStorageDir}/favicon.ico`);
+        }
+
         async generateContentListSite(userId, renderArgs: IStaticSiteRenderArgs, options: any = {}): Promise<{storageId, staticSiteId}> {
             const {entityType, entityIds} = renderArgs;
             const {
@@ -366,10 +375,7 @@ async function getModule(app: IGeesomeApp, models) {
             const {id: cssStorageId} = await app.ms.storage.saveFileByData(css + (options.stylesCss || ''));
             await app.ms.storage.copyFileFromId(cssStorageId, `${siteStorageDir}/style.css`);
 
-            await this.saveSiteAssets();
-            await app.ms.storage.copyFileFromId(publicDirStorageId, `${siteStorageDir}/public`);
-            await app.ms.storage.copyFileFromId(vendorAssetsStorageId, `${siteStorageDir}/vendor`);
-            await app.ms.storage.copyFileFromId(faviconStorageId, `${siteStorageDir}/favicon.ico`);
+            await this.copySiteAssets(siteStorageDir);
 
             renderData.defaultRoute = 'content-list';
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -192,11 +192,13 @@ Verification:
 
 ### 6. Static Site Generator Polish
 
+Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is the active slice for generated group-site favicons.
+
 Goal: deliver visible improvements without redesigning the protocol.
 
 Scope:
 
-- Finish [#564](https://github.com/galtproject/geesome-node/issues/564) by preferring group avatar for generated favicon when available, falling back to UI favicon.
+- Finish [#564](https://github.com/galtproject/geesome-node/issues/564) by preferring group avatar for generated favicon when available, falling back to UI favicon. Implementation should copy the prepared group avatar storage object into `favicon.ico` during group static-site generation and keep content-list static sites on the bundled UI favicon.
 - Triage [#494](https://github.com/galtproject/geesome-node/issues/494) into concrete options with defaults, validation, and stored option compatibility.
 - Treat [#573](https://github.com/galtproject/geesome-node/issues/573) as a separate deployment/distribution task after generated sites are stable.
 

--- a/test/staticSiteGenerator.test.ts
+++ b/test/staticSiteGenerator.test.ts
@@ -146,6 +146,39 @@ describe("staticSiteGenerator", function () {
 		assert.equal(await app.callHookCheckAllowed('content', 'isStorageIdAllowed', [directoryStorageId]), true);
 	});
 
+	it('should use group avatar as generated site favicon', async () => {
+		const pngImagePath = await resourcesHelper.prepare('input-image.png');
+		const avatarContent = await app.ms.content.saveData(testUser.id, fs.createReadStream(pngImagePath), 'input-image.png', {
+			groupId: testGroup.id,
+			waitForPin: true
+		});
+		await app.ms.group.updateGroup(testUser.id, testGroup.id, {avatarImageId: avatarContent.id});
+
+		const directoryStorageId = await staticSiteGenerator.generateGroupSite(testUser.id, {entityType: 'group', entityId: testGroup.id}, {
+			lang: 'en',
+			dateFormat: 'DD.MM.YYYY hh:mm:ss',
+			baseStorageUri: 'http://localhost:2052/ipfs/',
+			post: {
+				titleLength: 0,
+				descriptionLength: 400,
+			},
+			postList: {
+				postsPerPage: 5,
+			},
+			site: {
+				title: 'MySite',
+				name: 'my_site',
+				description: 'My About',
+				username: 'myusername',
+				base: '/'
+			}
+		});
+
+		const faviconContent = await app.ms.storage.getFileData(`${directoryStorageId}/favicon.ico`);
+		const avatarStorageContent = await app.ms.storage.getFileData(avatarContent.storageId);
+		assert.equal(faviconContent.toString('hex'), avatarStorageContent.toString('hex'));
+	});
+
 	it('should generate site correctly from content list', async () => {
 		const contentIds = [];
 		for (let i = 0; i < 30; i++) {


### PR DESCRIPTION
## Source of truth

Finish the static-site polish slice from #564: generated group sites should use the group avatar as `favicon.ico` when one exists, with the bundled UI favicon as fallback.

## Summary

- adds a shared static-site asset copy helper for public/vendor/favicon assets
- uses the prepared group avatar storage id as the generated group-site favicon source
- keeps content-list generated sites on the bundled UI favicon
- adds a regression test that compares the generated favicon bytes with the saved group avatar bytes
- updates `docs/todo.md` with the active static-site favicon slice status

## Verification

- `git diff --check`
- `npm run test:docker` (`66 passing`, `11 pending`)

Closes #564
