### PR TITLE
Normalize static site generator settings

### DIFF
--- a/app/modules/staticSiteGenerator/index.ts
+++ b/app/modules/staticSiteGenerator/index.ts
@@ -9,11 +9,61 @@ import helpers from '../../helpers.js';
 import ssgHelpers from './helpers.js';
 import site from './site/index.js';
 import vendorAssets from './site/vendorAssets.js';
-const {clone, uniq, merge, set, get, pick, last} = _;
+const {clone, uniq, merge, pick, last} = _;
 const {getPostTitleAndDescription, getOgHeaders} = ssgHelpers;
 const {prepareRender} = site;
 const base = '/';
 let publicDirStorageId, faviconStorageId, vendorAssetsStorageId;
+const customStylesCssMaxLength = 128 * 1024;
+
+function parsePositiveInteger(value, fallback, min = 0, max = Number.MAX_SAFE_INTEGER) {
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+        return fallback;
+    }
+    return Math.min(Math.max(parsed, min), max);
+}
+
+function validateStaticSiteName(name) {
+    if (name && !helpers.validateUsername(name)) {
+        throw new Error("incorrect_name");
+    }
+}
+
+function normalizeStaticSiteOptions(options: any = {}) {
+    const normalized = clone(options) || {};
+    normalized.post = normalized.post || {};
+    normalized.postList = normalized.postList || {};
+    normalized.site = normalized.site || {};
+
+    validateStaticSiteName(normalized.name);
+    validateStaticSiteName(normalized.site.name);
+
+    normalized.post.titleLength = parsePositiveInteger(normalized.post.titleLength, 0, 0, 500);
+    normalized.post.descriptionLength = parsePositiveInteger(normalized.post.descriptionLength, 400, 0, 5000);
+    normalized.postList.postsPerPage = parsePositiveInteger(normalized.postList.postsPerPage, 10, 1, 100);
+
+    if (normalized.stylesCss !== undefined) {
+        if (typeof normalized.stylesCss !== 'string') {
+            throw new Error("incorrect_styles_css");
+        }
+        if (normalized.stylesCss.length > customStylesCssMaxLength) {
+            throw new Error("styles_css_too_large");
+        }
+    }
+
+    return normalized;
+}
+
+function prepareStaticSiteUpdateData(updateData) {
+    const prepared = clone(updateData) || {};
+    validateStaticSiteName(prepared.name);
+    if (prepared.options !== undefined) {
+        const parsedOptions = typeof prepared.options === 'string' ? JSON.parse(prepared.options) : prepared.options;
+        prepared.options = JSON.stringify(normalizeStaticSiteOptions(parsedOptions));
+    }
+    return prepared;
+}
 
 export default async (app: IGeesomeApp) => {
     // VueSSR: import JS [type: module] (by workspaces in package.json)
@@ -45,9 +95,7 @@ async function getModule(app: IGeesomeApp, models) {
             } else {
                 throw Error('unknown_type');
             }
-            if (options['name'] && !helpers.validateUsername(options['name'])) {
-                throw new Error("incorrect_name");
-            }
+            options = normalizeStaticSiteOptions(options);
 
             const operationQueue = await app.ms.asyncOperation.addUserOperationQueue(userId, this.moduleName, userApiKeyId, {
                 renderArgs,
@@ -162,7 +210,7 @@ async function getModule(app: IGeesomeApp, models) {
             try {
                 staticSiteOptions = JSON.parse(staticSite.options)
             } catch (e) {}
-            return {
+            return normalizeStaticSiteOptions({
                 lang: 'en',
                 dateFormat: 'DD.MM.YYYY hh:mm:ss',
                 post: {
@@ -180,7 +228,7 @@ async function getModule(app: IGeesomeApp, models) {
                     base
                 },
                 ...staticSiteOptions
-            }
+            });
         }
 
         async getGroupResultOptions(group, options) {
@@ -193,13 +241,11 @@ async function getModule(app: IGeesomeApp, models) {
                     postsCount: group.publishedPostsCount,
                 }
             });
-            ['post.titleLength', 'post.descriptionLength', 'postList.postsPerPage'].forEach(name => {
-                set(merged, name, parseInt(get(merged, name)))
-            });
-            if (!merged.site.avatarUrl && merged.site.avatarStorageId) {
-                merged.site.avatarUrl = options.baseStorageUri + merged.site.avatarStorageId;
+            const normalized = normalizeStaticSiteOptions(merged);
+            if (!normalized.site.avatarUrl && normalized.site.avatarStorageId) {
+                normalized.site.avatarUrl = options.baseStorageUri + normalized.site.avatarStorageId;
             }
-            return merged;
+            return normalized;
         }
 
         async prepareContentListForRender(userId, entityType, entityIds, options: any = {}) {
@@ -228,8 +274,8 @@ async function getModule(app: IGeesomeApp, models) {
 
         async prepareGroupPostsForRender(userId, entityType, entityId, options: any = {}) {
             const group = await app.ms.group.getLocalGroup(userId, entityId);
-            let staticSite = await this.getOrCreateStaticSite(userId, entityType, entityId, options);
             options = await this.getGroupResultOptions(group, options);
+            let staticSite = await this.getOrCreateStaticSite(userId, entityType, entityId, options);
 
             const {list: groupPosts} = await app.ms.group.getGroupPosts(entityId, {}, {
                 sortBy: 'publishedAt',
@@ -273,6 +319,9 @@ async function getModule(app: IGeesomeApp, models) {
 
         async getOrCreateStaticSite(userId, entityType, entityId, options) {
             const {site} = options;
+            if (!site || !site.name || !site.title) {
+                throw new Error("incorrect_static_site_options");
+            }
             let staticSite = await models.StaticSite.findOne({where: {entityType, entityId: entityId.toString()}});
             if (!staticSite) {
                 staticSite = await this.createDbStaticSite({userId, entityType, entityId, title: site.title, name: site.name, options: JSON.stringify(options)});
@@ -291,10 +340,11 @@ async function getModule(app: IGeesomeApp, models) {
                 renderData,
                 manifestStorageId
             } = await this.prepareGroupPostsForRender(userId, entityType, entityId, options);
+            const renderOptions = renderData.options;
 
             // VueSSR: initialize app
             const {renderPage, css} = await prepareRender(renderData);
-            const {id: cssStorageId} = await app.ms.storage.saveFileByData(css + (options.stylesCss || ''));
+            const {id: cssStorageId} = await app.ms.storage.saveFileByData(css + (renderOptions.stylesCss || ''));
             await app.ms.storage.copyFileFromId(cssStorageId, `${siteStorageDir}/style.css`);
 
             // VueSSR: render main page
@@ -306,17 +356,17 @@ async function getModule(app: IGeesomeApp, models) {
              */
             await this.copySiteAssets(siteStorageDir, renderData.options.site.avatarStorageId);
 
-            await this.renderAndSave(renderPage, options, siteStorageDir, ``, 'main');
+            await this.renderAndSave(renderPage, renderOptions, siteStorageDir, ``, 'main');
             for (let i = 1; i <= renderData.pagesCount - 1; i++) {
                 // VueSSR: render other pages by url
-                await this.renderAndSave(renderPage, options, siteStorageDir, `/page/${i}`, 'page');
+                await this.renderAndSave(renderPage, renderOptions, siteStorageDir, `/page/${i}`, 'page');
             }
             await pIteration.forEachSeries(renderData.posts, (p) => {
-                return this.renderAndSave(renderPage, options, siteStorageDir, `/post/${p.id}`, 'post', p);
+                return this.renderAndSave(renderPage, renderOptions, siteStorageDir, `/post/${p.id}`, 'post', p);
             });
 
             const storageId = await app.ms.storage.getDirectoryId(siteStorageDir);
-            const baseData = {storageId, lastEntityManifestStorageId: manifestStorageId, options: JSON.stringify(options)};
+            const baseData = {storageId, lastEntityManifestStorageId: manifestStorageId, options: JSON.stringify(renderOptions)};
             await this.updateDbStaticSite(staticSite.id, baseData);
             return storageId;
         }
@@ -364,6 +414,7 @@ async function getModule(app: IGeesomeApp, models) {
         }
 
         async generateContentListSite(userId, renderArgs: IStaticSiteRenderArgs, options: any = {}): Promise<{storageId, staticSiteId}> {
+            options = normalizeStaticSiteOptions(options);
             const {entityType, entityIds} = renderArgs;
             const {
                 staticSite,
@@ -531,13 +582,11 @@ async function getModule(app: IGeesomeApp, models) {
 
         async updateStaticSiteInfo(userId, staticSiteId, updateData) {
             const staticSiteInfo = await models.StaticSite.findOne({ where: {id: staticSiteId}}) as IStaticSite;
-            const {entityType, entityId, name} = staticSiteInfo;
             if (!staticSiteInfo) {
                 throw new Error("static_site_not_found");
             }
-            if (updateData['name'] && !helpers.validateUsername(updateData['name'])) {
-                throw new Error("incorrect_name");
-            }
+            updateData = prepareStaticSiteUpdateData(updateData);
+            const {entityType, entityId, name} = staticSiteInfo;
             if (name && updateData['name'] && updateData['name'] !== name) {
                 if (entityType === 'group') {
                     await app.ms.staticId.renameGroupStaticAccountId(userId, entityId, name, updateData['name']);

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -192,14 +192,14 @@ Verification:
 
 ### 6. Static Site Generator Polish
 
-Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is the active slice for generated group-site favicons.
+Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is implemented for generated group-site favicons. [#494](https://github.com/galtproject/geesome-node/issues/494) is the active static-site settings slice.
 
 Goal: deliver visible improvements without redesigning the protocol.
 
 Scope:
 
 - Finish [#564](https://github.com/galtproject/geesome-node/issues/564) by preferring group avatar for generated favicon when available, falling back to UI favicon. Implementation should copy the prepared group avatar storage object into `favicon.ico` during group static-site generation and keep content-list static sites on the bundled UI favicon.
-- Triage [#494](https://github.com/galtproject/geesome-node/issues/494) into concrete options with defaults, validation, and stored option compatibility.
+- Triage [#494](https://github.com/galtproject/geesome-node/issues/494) into concrete options with defaults, validation, and stored option compatibility. First implementation should normalize numeric render settings, validate static site names in the nested `site` object, keep custom CSS bounded, and persist the normalized render options used for the generated site.
 - Treat [#573](https://github.com/galtproject/geesome-node/issues/573) as a separate deployment/distribution task after generated sites are stable.
 
 Likely modules:

--- a/test/staticSiteGenerator.test.ts
+++ b/test/staticSiteGenerator.test.ts
@@ -179,6 +179,60 @@ describe("staticSiteGenerator", function () {
 		assert.equal(faviconContent.toString('hex'), avatarStorageContent.toString('hex'));
 	});
 
+	it('should normalize static site settings before render', async () => {
+		const stylesCss = '\n.static-site-settings-marker { color: rgb(1, 2, 3); }\n';
+		const directoryStorageId = await staticSiteGenerator.generateGroupSite(testUser.id, {entityType: 'group', entityId: testGroup.id}, {
+			lang: 'en',
+			dateFormat: 'DD.MM.YYYY hh:mm:ss',
+			baseStorageUri: 'http://localhost:2052/ipfs/',
+			stylesCss,
+			post: {
+				titleLength: '5.8',
+				descriptionLength: 'bad-value',
+			},
+			postList: {
+				postsPerPage: '0',
+			},
+			site: {
+				title: 'MySite',
+				name: 'my_site',
+				description: 'My About',
+				username: 'myusername',
+				base: '/'
+			}
+		});
+
+		const staticSiteInfo = await staticSiteGenerator.getStaticSiteInfo(testUser.id, {entityType: 'group', entityId: testGroup.id});
+		const storedOptions = JSON.parse(staticSiteInfo.options);
+		assert.equal(storedOptions.post.titleLength, 5);
+		assert.equal(storedOptions.post.descriptionLength, 400);
+		assert.equal(storedOptions.postList.postsPerPage, 1);
+		assert.equal(storedOptions.stylesCss, stylesCss);
+
+		const styleCssContent = await app.ms.storage.getFileData(`${directoryStorageId}/style.css`).then(b => b.toString('utf8'));
+		assert.equal(styleCssContent.includes('.static-site-settings-marker'), true);
+	});
+
+	it('should reject invalid static site settings', async () => {
+		await assert.rejects(
+			() => staticSiteGenerator.generateGroupSite(testUser.id, {entityType: 'group', entityId: testGroup.id}, {
+				site: {
+					title: 'MySite',
+					name: 'bad site name',
+					description: 'My About',
+					username: 'myusername',
+					base: '/'
+				}
+			}),
+			/incorrect_name/
+		);
+
+		await assert.rejects(
+			() => staticSiteGenerator.updateStaticSiteInfo(testUser.id, 999999, {name: 'missing_site'}),
+			/static_site_not_found/
+		);
+	});
+
 	it('should generate site correctly from content list', async () => {
 		const contentIds = [];
 		for (let i = 0; i < 30; i++) {


### PR DESCRIPTION
## Source of truth

Closes #494. Static-site generator settings should be normalized, validated, and persisted as the exact options used for rendering.

## Summary

- Normalizes numeric render settings with bounded defaults before queueing or rendering static sites.
- Validates top-level and nested static-site names, bounds custom CSS, and returns a clear missing-site error on update.
- Persists the normalized render options and adds focused static-site generator regression coverage.
- Updates docs/todo.md with the implemented #494 settings slice.

## Verification

- git diff --check
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/staticSiteGenerator/index.ts'); console.log('static site generator import ok')"
- npm run test:docker (68 passing, 11 pending)

Closes #494