### PR TITLE
Keep handled auto-action failures out of stderr

### DIFF
--- a/app/modules/autoActions/cronService.ts
+++ b/app/modules/autoActions/cronService.ts
@@ -1,8 +1,11 @@
 import _ from 'lodash';
+import debug from 'debug';
 import pIteration from 'p-iteration';
 import IGeesomeAutoActionsModule, {IAutoAction} from "./interface.js";
 import {IGeesomeApp} from "../../interface.js";
+import helpers from "../../helpers.js";
 const {some, uniqBy, isArray, isString} = _;
+const log = debug('geesome:app:autoActions:cron');
 
 export default class CronService {
 	queueByModules = {};
@@ -142,12 +145,12 @@ export default class CronService {
 	async executeAction(a: IAutoAction, rootActionId = null): Promise<{result?, success}> {
 		const module = this.app.ms[a.moduleName];
 		if (!module || !module.isAutoActionAllowed) {
-			console.error('executeAction', a.id, 'module_dont_support_auto_actions');
+			logAutoActionExecutionFailure(a, rootActionId, 'module_dont_support_auto_actions');
 			await this.autoActionsModule.deactivateAutoActionWithError(a.userId, a.id, new Error('module_dont_support_auto_actions'), rootActionId);
 			return {success: false};
 		}
 		if (!(await module.isAutoActionAllowed(a.userId, a.funcName, a.funcArgs))) {
-			console.error('executeAction', a.id, 'auto_action_not_allowed_in_module');
+			logAutoActionExecutionFailure(a, rootActionId, 'auto_action_not_allowed_in_module');
 			await this.autoActionsModule.deactivateAutoActionWithError(a.userId, a.id, new Error('auto_action_not_allowed_in_module'), rootActionId);
 			return {success: false};
 		}
@@ -158,7 +161,7 @@ export default class CronService {
 				throw new Error("funcArgs_not_array");
 			}
 		} catch (e) {
-			console.error('executeAction', a.id, 'funcArgs_parsing_error', e);
+			logAutoActionExecutionFailure(a, rootActionId, 'funcArgs_parsing_error', e);
 			await this.autoActionsModule.deactivateAutoActionWithError(a.userId, a.id, new Error('funcArgs_parsing_error'), rootActionId);
 			return {success: false};
 		}
@@ -174,10 +177,34 @@ export default class CronService {
 			result = await module[a.funcName].apply(module, [a.userId].concat(funcArgs));
 			await this.autoActionsModule.handleAutoActionSuccessfulExecution(a.userId, a.id, result, rootActionId);
 		} catch (error) {
-			console.error('executeAction', a.id, 'execute error', error);
+			logAutoActionExecutionFailure(a, rootActionId, 'execute_error', error);
 			await this.autoActionsModule.handleAutoActionFailedExecution(a.userId, a.id, error, rootActionId);
 			return {success: false};
 		}
 		return {success: true, result};
 	}
+}
+
+function logAutoActionExecutionFailure(a: IAutoAction, rootActionId, reason, error = null) {
+	helpers.logDebug(log, () => [
+		'executeAction',
+		{
+			actionId: a?.id,
+			rootActionId,
+			moduleName: a?.moduleName,
+			funcName: a?.funcName,
+			reason,
+			error: getAutoActionExecutionErrorMessage(error)
+		}
+	]);
+}
+
+function getAutoActionExecutionErrorMessage(error) {
+	if (!error) {
+		return null;
+	}
+	if (error.message) {
+		return error.message;
+	}
+	return String(error);
 }

--- a/test/autoActions.test.ts
+++ b/test/autoActions.test.ts
@@ -271,6 +271,47 @@ describe("autoActions", function () {
 		assert.deepEqual(expiredClaim.map(action => action.id), [dueAction.id]);
 	});
 
+	it('keeps handled execution failures out of stderr', async () => {
+		const testUser = (await app.ms.database.getAllUserList('user'))[0];
+		const action = await autoActions.addAutoAction(testUser.id, {
+			moduleName: 'missingModule',
+			funcName: 'run',
+			funcArgs: '[]',
+			isActive: true,
+			totalExecuteAttempts: 1,
+			currentExecuteAttempts: 1,
+			executeOn: new Date(Date.now() - 1000)
+		});
+		const originalConsoleError = console.error;
+		const consoleErrorCalls = [];
+
+		console.error = ((...args) => {
+			consoleErrorCalls.push(args);
+		}) as any;
+
+		try {
+			const cronService = new CronService(app, autoActions);
+			await cronService.getActionsAndAddToQueueAndRun();
+		} finally {
+			console.error = originalConsoleError;
+		}
+
+		const dbAction = await (autoActions as any).getAutoAction(action.id);
+		const [logs] = await app.ms.database.sequelize.query(`
+			SELECT error
+			FROM "autoActionLogs"
+			WHERE "actionId" = :actionId
+			ORDER BY id ASC
+		`, {
+			replacements: {actionId: action.id}
+		}) as any;
+
+		assert.deepEqual(consoleErrorCalls, []);
+		assert.equal(dbAction.isActive, false);
+		assert.equal(logs.length, 1);
+		assert.equal(JSON.parse(logs[0].error), 'module_dont_support_auto_actions');
+	});
+
 	it('stores long auto action log payloads', async () => {
 		const testUser = (await app.ms.database.getAllUserList('user'))[0];
 		const action = await autoActions.addAutoAction(testUser.id, {


### PR DESCRIPTION
## Summary
- route handled auto-action execution failures through the `geesome:app:autoActions:cron` debug namespace instead of unconditional stderr
- keep the existing DB failure/deactivation behavior for unsupported modules, disallowed actions, bad args, and execution errors
- add a regression test that unsupported-module actions stay logged/deactivated without touching `console.error`

## Verification
- `git diff --check`
- `npm run test:docker` (194 passing, 11 pending)

## Notes
- Host-side focused Mocha could not initialize in this workspace because local Postgres auth/IPFS host dependencies differ from the Docker test environment, so Docker was used as the authoritative test path.
