### PR TITLE
Quiet static-site render warnings

### DIFF
--- a/app/modules/staticSiteGenerator/site/index.js
+++ b/app/modules/staticSiteGenerator/site/index.js
@@ -10,26 +10,23 @@ export default {
     async prepareRender(storageData) {
         // const storageData = {path: url.split('?')[0], urlQuery, ...additionalData};
         loadAssets(storageData);
-        const [{app, router}, {css}] = await Promise.all([
-            createApp(storageData),// VueSSR: init simple Vue app with components, pages and routes
-            sass['default'].compileAsync(getFilePath('styles/index.scss'))
-        ]);
+        const {css} = await compileStyles();
         const rootContent = getFileContent('index.html');
         return {
             css,
             // VueSSR: call for each page and save to fs
             renderPage: (url, headers) => {
-                return renderApp(app, router, rootContent, url, headers, 'en');
+                return renderApp(storageData, rootContent, url, headers, 'en');
             }
         };
     },
 };
 
-async function renderApp(app, router, rootContent, url, headers, lang) {
+async function renderApp(storageData, rootContent, url, headers, lang) {
     // console.log('app', app);
+    const {app} = await createApp(storageData, url);
     const slashSplit = url.split('/');
     const relativeRoot = slashSplit.length > 2 ? slashSplit.slice(1).map(() => '../').join('') : './';
-    await router.push(url);
     // app.use(Notifications);
     // installFakeComponent(app, '$notify', 'Notifications');
 
@@ -44,6 +41,10 @@ async function renderApp(app, router, rootContent, url, headers, lang) {
         .replace('{{lang}}', lang)
         .replace('{{headers}}', `<title>${title}</title>\n` + headers.map(([tag, attr]) => `<${tag} name="${attr['name']}" content="${attr['content']}"/>`).join('\n'))
         .replace('{{content}}', content);
+}
+
+function compileStyles() {
+    return sass.compileAsync(getFilePath('styles/index.scss'));
 }
 
 function loadAssets(data) {

--- a/app/modules/staticSiteGenerator/site/public/index.js
+++ b/app/modules/staticSiteGenerator/site/public/index.js
@@ -3,7 +3,7 @@ import { createSSRApp } from 'vue';
 import createRouter from './router.js';
 import asyncModal from "./components/AsyncModal/index.js";
 
-export async function createApp(store) {
+export async function createApp(store, serverRoute = null) {
     const app = createSSRApp({
         template: `
             <div>
@@ -19,13 +19,27 @@ export async function createApp(store) {
 
     const isServer = typeof window === 'undefined';
     const router = createRouter(isServer ? null : store.defaultRoute);
-    if (isServer) {
-        await router.push((store.path || '/') + '?' + store.urlQuery);
-    } else {
-        await router.push('/');
-    }
+    await router.push(getInitialRoute(isServer, store, serverRoute));
     // await router.isReady();
     app.use(router);
     app.provide('store', store);
     return {app, router, store};
+}
+
+function getInitialRoute(isServer, store, serverRoute) {
+    if (!isServer) {
+        return '/';
+    }
+    if (serverRoute) {
+        return serverRoute;
+    }
+    return getStoreRoute(store);
+}
+
+function getStoreRoute(store) {
+    const path = store.path || '/';
+    if (!store.urlQuery) {
+        return path;
+    }
+    return `${path}?${store.urlQuery}`;
 }

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -164,6 +164,11 @@ async createGroup(userId, groupData) {
 
 `throw new Error("snake_case_reason")`. The string is the API contract — do not change wording on existing errors without considering callers.
 
+### Static-site SSR
+
+- Create a fresh Vue SSR app/router for each rendered page. Cache shared render inputs, assets, and compiled styles outside page rendering, but do not reuse one Vue app across multiple `renderToString` calls because Vue stores per-render SSR context on the app.
+- Use Sass namespace imports directly: `import * as sass from 'sass';` then `sass.compileAsync(...)`. Do not access `sass.default`, which re-enables Sass's deprecated default-import path warning.
+
 ### Comments
 
 - Default to no comment. Code with good identifiers reads itself.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -196,7 +196,7 @@ Verification:
 
 ### 6. Static Site Generator Polish
 
-Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is implemented for generated group-site favicons. [#494](https://github.com/galtproject/geesome-node/issues/494) is the active static-site settings slice.
+Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is implemented for generated group-site favicons. [#494](https://github.com/galtproject/geesome-node/issues/494) is the active static-site settings slice. The renderer now avoids Sass's deprecated default-import path and creates a fresh Vue SSR app/router per page render, so repeated generated-page renders do not emit `Symbol(v-scx)` context warnings or risk cross-page SSR state reuse.
 
 Goal: deliver visible improvements without redesigning the protocol.
 

--- a/test/staticSiteGeneratorStreamingUnit.test.ts
+++ b/test/staticSiteGeneratorStreamingUnit.test.ts
@@ -5,6 +5,9 @@ describe('staticSiteGenerator streaming render state', function () {
 	this.timeout(10000);
 
 	it('renders list and post pages from current page/post state without a full posts array', async () => {
+		const warnings: any[] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args) => warnings.push(args);
 		const post = {
 			id: 7,
 			lang: 'en',
@@ -42,15 +45,21 @@ describe('staticSiteGenerator streaming render state', function () {
 			indexById: {}
 		};
 		const headers = [['meta', {name: 'og:title', content: 'Stream Site'}]];
-		const {renderPage} = await site.prepareRender(renderData);
 
-		const indexHtml = await renderPage('/', headers);
-		assert.equal(indexHtml.includes('streamed intro'), true);
-		assert.equal(indexHtml.includes('./post/7/'), true);
+		try {
+			const {renderPage} = await site.prepareRender(renderData);
 
-		renderData.currentPosts = [];
-		renderData.currentPost = post;
-		const postHtml = await renderPage('/post/7', headers);
-		assert.equal(postHtml.includes('streamed post body'), true);
+			const indexHtml = await renderPage('/', headers);
+			assert.equal(indexHtml.includes('streamed intro'), true);
+			assert.equal(indexHtml.includes('./post/7/'), true);
+
+			renderData.currentPosts = [];
+			renderData.currentPost = post;
+			const postHtml = await renderPage('/post/7', headers);
+			assert.equal(postHtml.includes('streamed post body'), true);
+		} finally {
+			console.warn = originalWarn;
+		}
+		assert.equal(warnings.some(args => args.join(' ').includes('Symbol(v-scx)')), false);
 	});
 });


### PR DESCRIPTION
## Summary
- avoid Sass's deprecated default-import path by calling sass.compileAsync directly
- render each generated page with a fresh Vue SSR app/router instead of reusing one app across renderToString calls
- cover repeated page rendering so Vue's Symbol(v-scx) SSR context warning stays out of default output
- document the static-site SSR rule in the code style guide and TODO status

## Validation
- git diff --check
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/staticSiteGeneratorStreamingUnit.test.ts --exit -t 10000
- Node SSR smoke rendering two pages with warning capture
- npm run test:docker (197 passing, 11 pending)