### PR TITLE
Quiet generated static-site client console

### DIFF
--- a/app/modules/staticSiteGenerator/site/public/client.js
+++ b/app/modules/staticSiteGenerator/site/public/client.js
@@ -4,3 +4,15 @@ import clientData from 'clientData';
 createApp(clientData).then(({app}) => {
     app.mount('#app');
 });
+
+console.log(`
+🦈
+🦈 🦈
+🦈 🦈 🦈
+👋 Developer? Check out examples in https://github.com/galtproject/geesome-node repo tests and check/geesomeClientStaticSite.ts script.
+
+⭐️ Don't forget to put a star to repo!
+🦈 🦈 🦈
+🦈 🦈
+🦈
+`);

--- a/app/modules/staticSiteGenerator/site/public/client.js
+++ b/app/modules/staticSiteGenerator/site/public/client.js
@@ -1,19 +1,6 @@
 import { createApp } from './index.js';
 import clientData from 'clientData';
-// import Notifications from '@kyvg/vue3-notification';
 
 createApp(clientData).then(({app}) => {
-    app.mount('#app'); // .use(Notifications)
+    app.mount('#app');
 });
-
-console.log(`
-🦈
-🦈 🦈
-🦈 🦈 🦈
-👋 Developer? Check out examples in https://github.com/galtproject/geesome-node repo tests and check/geesomeClientStaticSite.ts script. 
-
-⭐️ Don't forget to put a star to repo!
-🦈 🦈 🦈
-🦈 🦈
-🦈
-`);

--- a/app/modules/staticSiteGenerator/site/public/index.js
+++ b/app/modules/staticSiteGenerator/site/public/index.js
@@ -13,7 +13,6 @@ export async function createApp(store, serverRoute = null) {
         `,
         mounted() {
             this.$root.$modal = this.$refs.modal;
-            console.log('this.$root.$modal', this.$root.$modal);
         },
     }).use(asyncModal);
 

--- a/app/modules/staticSiteGenerator/site/public/pages/ContentList/index.js
+++ b/app/modules/staticSiteGenerator/site/public/pages/ContentList/index.js
@@ -8,9 +8,6 @@ export default {
         EmptyLayout,
     },
     inject: ['store'],
-    created() {
-      // console.log('post page', this.$route.params.postId);
-    },
     computed: {
         contents() {
             return this.store.contents;
@@ -21,7 +18,6 @@ export default {
     },
     methods: {
       openMedia(imageIndex) {
-          console.log('openMedia', imageIndex);
           this.$root.$modal.open({
               id: 'image-modal',
               component: markRaw(ImageModal),

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -170,7 +170,7 @@ async createGroup(userId, groupData) {
 
 - Create a fresh Vue SSR app/router for each rendered page. Cache shared render inputs, assets, and compiled styles outside page rendering, but do not reuse one Vue app across multiple `renderToString` calls because Vue stores per-render SSR context on the app.
 - Use Sass namespace imports directly: `import * as sass from 'sass';` then `sass.compileAsync(...)`. Do not access `sass.default`, which re-enables Sass's deprecated default-import path warning.
-- Generated static-site client files should not write to the browser console by default. Keep debug banners, mounted refs, and click diagnostics out of published site assets unless there is an explicit opt-in debug mode.
+- Generated static-site client files should not write incidental diagnostics to the browser console by default. Keep mounted refs, click diagnostics, and internal state dumps out of published site assets unless there is an explicit opt-in debug mode. Intentional visitor/developer-facing console messages, such as the generated-site examples banner, may stay when they are part of the product experience.
 
 ### Comments
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -170,6 +170,7 @@ async createGroup(userId, groupData) {
 
 - Create a fresh Vue SSR app/router for each rendered page. Cache shared render inputs, assets, and compiled styles outside page rendering, but do not reuse one Vue app across multiple `renderToString` calls because Vue stores per-render SSR context on the app.
 - Use Sass namespace imports directly: `import * as sass from 'sass';` then `sass.compileAsync(...)`. Do not access `sass.default`, which re-enables Sass's deprecated default-import path warning.
+- Generated static-site client files should not write to the browser console by default. Keep debug banners, mounted refs, and click diagnostics out of published site assets unless there is an explicit opt-in debug mode.
 
 ### Comments
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -196,7 +196,7 @@ Verification:
 
 ### 6. Static Site Generator Polish
 
-Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is implemented for generated group-site favicons. [#494](https://github.com/galtproject/geesome-node/issues/494) is the active static-site settings slice. The renderer now avoids Sass's deprecated default-import path and creates a fresh Vue SSR app/router per page render, so repeated generated-page renders do not emit `Symbol(v-scx)` context warnings or risk cross-page SSR state reuse.
+Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is implemented for generated group-site favicons. [#494](https://github.com/galtproject/geesome-node/issues/494) is the active static-site settings slice. The renderer now avoids Sass's deprecated default-import path and creates a fresh Vue SSR app/router per page render, so repeated generated-page renders do not emit `Symbol(v-scx)` context warnings or risk cross-page SSR state reuse. Generated static-site clients no longer print the default promo banner, mounted modal refs, or media-click diagnostics into visitor browser consoles.
 
 Goal: deliver visible improvements without redesigning the protocol.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -196,7 +196,7 @@ Verification:
 
 ### 6. Static Site Generator Polish
 
-Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is implemented for generated group-site favicons. [#494](https://github.com/galtproject/geesome-node/issues/494) is the active static-site settings slice. The renderer now avoids Sass's deprecated default-import path and creates a fresh Vue SSR app/router per page render, so repeated generated-page renders do not emit `Symbol(v-scx)` context warnings or risk cross-page SSR state reuse. Generated static-site clients no longer print the default promo banner, mounted modal refs, or media-click diagnostics into visitor browser consoles.
+Status: in progress. [#564](https://github.com/galtproject/geesome-node/issues/564) is implemented for generated group-site favicons. [#494](https://github.com/galtproject/geesome-node/issues/494) is the active static-site settings slice. The renderer now avoids Sass's deprecated default-import path and creates a fresh Vue SSR app/router per page render, so repeated generated-page renders do not emit `Symbol(v-scx)` context warnings or risk cross-page SSR state reuse. Generated static-site clients no longer print mounted modal refs or media-click diagnostics into visitor browser consoles while preserving the useful developer/examples banner.
 
 Goal: deliver visible improvements without redesigning the protocol.
 

--- a/test/staticSiteGeneratorClientUnit.test.ts
+++ b/test/staticSiteGeneratorClientUnit.test.ts
@@ -4,17 +4,21 @@ import assert from 'assert';
 import appHelpers from '../app/helpers.js';
 
 const publicPath = path.join(appHelpers.getCurDir(), 'modules/staticSiteGenerator/site/public');
-const quietClientFiles = [
-	'client.js',
+const diagnosticQuietFiles = [
 	'index.js',
 	'pages/ContentList/index.js'
 ];
 
 describe('staticSiteGenerator client bundle source', () => {
-	it('keeps generated site visitor consoles quiet by default', () => {
-		quietClientFiles.forEach((filePath) => {
+	it('keeps incidental diagnostics out of generated site client code', () => {
+		diagnosticQuietFiles.forEach((filePath) => {
 			const content = fs.readFileSync(path.join(publicPath, filePath), 'utf8');
-			assert.equal(content.includes('console.'), false, `${filePath} should not write to console`);
+			assert.equal(content.includes('console.'), false, `${filePath} should not write diagnostic console output`);
 		});
+	});
+
+	it('keeps the generated site developer banner available', () => {
+		const content = fs.readFileSync(path.join(publicPath, 'client.js'), 'utf8');
+		assert.equal(content.includes('Check out examples in https://github.com/galtproject/geesome-node'), true);
 	});
 });

--- a/test/staticSiteGeneratorClientUnit.test.ts
+++ b/test/staticSiteGeneratorClientUnit.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import assert from 'assert';
+import appHelpers from '../app/helpers.js';
+
+const publicPath = path.join(appHelpers.getCurDir(), 'modules/staticSiteGenerator/site/public');
+const quietClientFiles = [
+	'client.js',
+	'index.js',
+	'pages/ContentList/index.js'
+];
+
+describe('staticSiteGenerator client bundle source', () => {
+	it('keeps generated site visitor consoles quiet by default', () => {
+		quietClientFiles.forEach((filePath) => {
+			const content = fs.readFileSync(path.join(publicPath, filePath), 'utf8');
+			assert.equal(content.includes('console.'), false, `${filePath} should not write to console`);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- remove the generated static-site promo console banner
- stop logging mounted modal refs and content-list media clicks in published client assets
- add a static source guard so generated client files stay console-quiet by default
- document the static-site client console rule

## Validation
- git diff --check
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/staticSiteGeneratorClientUnit.test.ts --exit -t 10000
- npm run test:docker (199 passing, 11 pending)