### PR TITLE
Keep handled content route failures out of stderr

### DIFF
--- a/app/modules/api/routeErrorHelpers.ts
+++ b/app/modules/api/routeErrorHelpers.ts
@@ -1,0 +1,27 @@
+import helpers from "../../helpers.js";
+import {IApiModuleCommonOutput} from "./interface.js";
+
+type DebugLog = {
+	enabled: boolean;
+	(...args: any[]): void;
+};
+
+export function sendBadRequestOnContentRouteError(log: DebugLog, res: IApiModuleCommonOutput, getContext: () => any = () => ({})) {
+	return (error) => {
+		helpers.logDebug(log, () => [
+			'content route request failed',
+			{
+				...getContext(),
+				error: getErrorMessage(error)
+			}
+		]);
+		res.send(400);
+	};
+}
+
+function getErrorMessage(error) {
+	if (error && error.message) {
+		return error.message;
+	}
+	return String(error);
+}

--- a/app/modules/content/api.ts
+++ b/app/modules/content/api.ts
@@ -1,9 +1,12 @@
 import _ from 'lodash';
+import debug from 'debug';
 import {UserLimitName} from "../database/interface.js";
 import IGeesomeContentModule from "./interface.js";
 import {IGeesomeApp} from "../../interface.js";
 import asyncBusboy from "./asyncBusboy.js";
+import {sendBadRequestOnContentRouteError} from "../api/routeErrorHelpers.js";
 const {pick} = _;
+const log = debug('geesome:content:api');
 
 export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
 
@@ -216,7 +219,9 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
      */
     app.ms.api.onGet('content-data/*', async (req, res) => {
         const dataPath = req.route.replace('content-data/', '');
-        contentModule.getFileStreamForApiRequest(req, res, dataPath).catch((e) => {console.error(e); res.send(400)});
+        contentModule.getFileStreamForApiRequest(req, res, dataPath).catch(
+            sendBadRequestOnContentRouteError(log, res, () => ({route: 'content-data', dataPath}))
+        );
     });
 
     /**
@@ -229,7 +234,9 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
      */
     app.ms.api.onHead('content-data/*', async (req, res) => {
         const dataPath = req.route.replace('content-data/', '');
-        contentModule.getContentHead(req, res, dataPath).catch((e) => {console.error(e); res.send(400)});
+        contentModule.getContentHead(req, res, dataPath).catch(
+            sendBadRequestOnContentRouteError(log, res, () => ({route: 'content-data:head', dataPath}))
+        );
     });
 
     /**
@@ -242,7 +249,9 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
     */
     app.ms.api.onUnversionGet('/ipfs/*', async (req, res) => {
         const ipfsPath = req.route.replace('/ipfs/', '');
-        contentModule.getFileStreamForApiRequest(req, res, ipfsPath).catch((e) => {console.error(e); res.send(400)});
+        contentModule.getFileStreamForApiRequest(req, res, ipfsPath).catch(
+            sendBadRequestOnContentRouteError(log, res, () => ({route: 'ipfs', dataPath: ipfsPath}))
+        );
     });
 
     /**
@@ -255,7 +264,9 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
      */
     app.ms.api.onUnversionHead('/ipfs/*', async (req, res) => {
         const ipfsPath = req.route.replace('/ipfs/', '');
-        contentModule.getContentHead(req, res, ipfsPath).catch((e) => {console.error(e); res.send(400)});
+        contentModule.getContentHead(req, res, ipfsPath).catch(
+            sendBadRequestOnContentRouteError(log, res, () => ({route: 'ipfs:head', dataPath: ipfsPath}))
+        );
     });
 
 
@@ -276,7 +287,10 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
             if (!path || path === '/') {
                 path = '/index.html';
             }
-            contentModule.getFileStreamForApiRequest(req, res, app.frontendStorageId + path).catch((e) => {console.error(e); res.send(400)});
+            const dataPath = app.frontendStorageId + path;
+            contentModule.getFileStreamForApiRequest(req, res, dataPath).catch(
+                sendBadRequestOnContentRouteError(log, res, () => ({route: 'frontend-node', dataPath}))
+            );
         });
     }
 };

--- a/app/modules/gateway/api.ts
+++ b/app/modules/gateway/api.ts
@@ -1,7 +1,10 @@
 import _ from 'lodash';
+import debug from 'debug';
 import IGeesomeApiModule from "./interface.js";
 import {IGeesomeApp} from "../../interface.js";
+import {sendBadRequestOnContentRouteError} from "../api/routeErrorHelpers.js";
 const {trim} = _;
+const log = debug('geesome:gateway:api');
 
 export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 
@@ -17,11 +20,15 @@ export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 
 	module.onGetRequest(async (req, res) => {
 		const contentPath = await getGatewayContentPath(req);
-		app.ms.content.getFileStreamForApiRequest(req, res, contentPath).catch((e) => {console.error(e); res.send(400)});
+		app.ms.content.getFileStreamForApiRequest(req, res, contentPath).catch(
+			sendBadRequestOnContentRouteError(log, res, () => ({route: 'gateway', dataPath: contentPath}))
+		);
 	});
 
 	module.onHeadRequest(async (req, res) => {
 		const contentPath = await getGatewayContentPath(req);
-		app.ms.content.getContentHead(req, res, contentPath).catch((e) => {console.error(e); res.send(400)});
+		app.ms.content.getContentHead(req, res, contentPath).catch(
+			sendBadRequestOnContentRouteError(log, res, () => ({route: 'gateway:head', dataPath: contentPath}))
+		);
 	});
 }

--- a/app/modules/staticId/api.ts
+++ b/app/modules/staticId/api.ts
@@ -1,7 +1,10 @@
 import _ from 'lodash';
+import debug from 'debug';
 import IGeesomeStaticIdModule from "./interface.js";
 import {IGeesomeApp} from "../../interface.js";
+import {sendBadRequestOnContentRouteError} from "../api/routeErrorHelpers.js";
 const {trim} = _;
+const log = debug('geesome:static-id:api');
 
 export default (app: IGeesomeApp, staticIdModule: IGeesomeStaticIdModule) => {
 
@@ -28,7 +31,10 @@ export default (app: IGeesomeApp, staticIdModule: IGeesomeStaticIdModule) => {
         const ipnsPath = req.route.replace('/ipns/', '').split('?')[0];
         const ipnsId = trim(ipnsPath, '/').split('/').slice(0, 1)[0];
         const ipfsId = await staticIdModule.resolveStaticId(ipnsId);
-        app.ms.content.getFileStreamForApiRequest(req, res, ipnsPath.replace(ipnsId, ipfsId)).catch((e) => {console.error(e); res.send(400)});
+        const dataPath = ipnsPath.replace(ipnsId, ipfsId);
+        app.ms.content.getFileStreamForApiRequest(req, res, dataPath).catch(
+            sendBadRequestOnContentRouteError(log, res, () => ({route: 'ipns', ipnsPath, dataPath}))
+        );
     });
 
     /**
@@ -43,7 +49,10 @@ export default (app: IGeesomeApp, staticIdModule: IGeesomeStaticIdModule) => {
         const ipnsPath = req.route.replace('/ipns/', '').split('?')[0];
         const ipnsId = trim(ipnsPath, '/').split('/').slice(0, 1)[0];
         const ipfsId = await staticIdModule.resolveStaticId(ipnsId);
-        app.ms.content.getContentHead(req, res, ipnsPath.replace(ipnsId, ipfsId)).catch((e) => {console.error(e); res.send(400)});
+        const dataPath = ipnsPath.replace(ipnsId, ipfsId);
+        app.ms.content.getContentHead(req, res, dataPath).catch(
+            sendBadRequestOnContentRouteError(log, res, () => ({route: 'ipns:head', ipnsPath, dataPath}))
+        );
     });
 
     /**

--- a/test/contentRouteErrors.test.ts
+++ b/test/contentRouteErrors.test.ts
@@ -1,0 +1,166 @@
+import assert from "assert";
+import contentApi from "../app/modules/content/api.js";
+import gatewayApi from "../app/modules/gateway/api.js";
+import staticIdApi from "../app/modules/staticId/api.js";
+import {IGeesomeApp} from "../app/interface.js";
+
+describe("content route errors", function () {
+	it("keeps handled content route failures out of stderr", async () => {
+		const routes: any = {};
+		const consoleErrors = await captureConsoleErrors(async () => {
+			contentApi({
+				ms: {
+					api: getApiRouteStub(routes),
+					storage: {
+						getFileStat: async () => null
+					}
+				}
+			} as unknown as IGeesomeApp, {
+				getFileStreamForApiRequest: async () => {
+					throw new Error("missing content stream");
+				},
+				getContentHead: async () => {
+					throw new Error("missing content head");
+				}
+			} as any);
+
+			const getResponse = getResponseStub();
+			await routes["GET content-data/*"]({route: "content-data/missing.txt"} as any, getResponse);
+			await flushAsyncHandlers();
+			assert.deepEqual(getResponse.sent, [[400]]);
+
+			const headResponse = getResponseStub();
+			await routes["HEAD content-data/*"]({route: "content-data/missing.txt"} as any, headResponse);
+			await flushAsyncHandlers();
+			assert.deepEqual(headResponse.sent, [[400]]);
+		});
+
+		assert.deepEqual(consoleErrors, []);
+	});
+
+	it("keeps handled gateway route failures out of stderr", async () => {
+		let getHandler;
+		let headHandler;
+		const consoleErrors = await captureConsoleErrors(async () => {
+			gatewayApi({
+				ms: {
+					content: {
+						getFileStreamForApiRequest: async () => {
+							throw new Error("gateway stream failed");
+						},
+						getContentHead: async () => {
+							throw new Error("gateway head failed");
+						}
+					},
+					staticId: {
+						resolveStaticId: async (id) => id
+					}
+				}
+			} as unknown as IGeesomeApp, {
+				getDnsLinkPathFromRequest: async () => "ipfs/root-cid",
+				onGetRequest: (handler) => {
+					getHandler = handler;
+				},
+				onHeadRequest: (handler) => {
+					headHandler = handler;
+				}
+			} as any);
+
+			const getResponse = getResponseStub();
+			await getHandler({headers: {}, route: "/file.txt"} as any, getResponse);
+			await flushAsyncHandlers();
+			assert.deepEqual(getResponse.sent, [[400]]);
+
+			const headResponse = getResponseStub();
+			await headHandler({headers: {}, route: "/file.txt"} as any, headResponse);
+			await flushAsyncHandlers();
+			assert.deepEqual(headResponse.sent, [[400]]);
+		});
+
+		assert.deepEqual(consoleErrors, []);
+	});
+
+	it("keeps handled ipns route failures out of stderr", async () => {
+		const routes: any = {};
+		const consoleErrors = await captureConsoleErrors(async () => {
+			staticIdApi({
+				ms: {
+					api: getApiRouteStub(routes),
+					content: {
+						getFileStreamForApiRequest: async () => {
+							throw new Error("ipns stream failed");
+						},
+						getContentHead: async () => {
+							throw new Error("ipns head failed");
+						}
+					}
+				}
+			} as unknown as IGeesomeApp, {
+				getSelfStaticAccountId: async () => "self-id",
+				resolveStaticId: async () => "resolved-cid"
+			} as any);
+
+			const getResponse = getResponseStub();
+			await routes["UNVERSION_GET /ipns/*"]({route: "/ipns/static-id/path.txt?x=1"} as any, getResponse);
+			await flushAsyncHandlers();
+			assert.deepEqual(getResponse.sent, [[400]]);
+
+			const headResponse = getResponseStub();
+			await routes["UNVERSION_HEAD /ipns/*"]({route: "/ipns/static-id/path.txt?x=1"} as any, headResponse);
+			await flushAsyncHandlers();
+			assert.deepEqual(headResponse.sent, [[400]]);
+		});
+
+		assert.deepEqual(consoleErrors, []);
+	});
+});
+
+function getApiRouteStub(routes) {
+	return {
+		onGet: (route, handler) => {
+			routes[`GET ${route}`] = handler;
+		},
+		onHead: (route, handler) => {
+			routes[`HEAD ${route}`] = handler;
+		},
+		onUnversionGet: (route, handler) => {
+			routes[`UNVERSION_GET ${route}`] = handler;
+		},
+		onUnversionHead: (route, handler) => {
+			routes[`UNVERSION_HEAD ${route}`] = handler;
+		},
+		onAuthorizedGet: (route, handler) => {
+			routes[`AUTHORIZED_GET ${route}`] = handler;
+		},
+		onAuthorizedPost: (route, handler) => {
+			routes[`AUTHORIZED_POST ${route}`] = handler;
+		}
+	};
+}
+
+function getResponseStub() {
+	return {
+		sent: [] as any[],
+		send(...args) {
+			this.sent.push(args);
+		}
+	};
+}
+
+async function captureConsoleErrors(callback) {
+	const originalConsoleError = console.error;
+	const consoleErrors: any[] = [];
+	console.error = ((...args) => {
+		consoleErrors.push(args);
+	}) as any;
+	try {
+		await callback();
+		return consoleErrors;
+	} finally {
+		console.error = originalConsoleError;
+	}
+}
+
+async function flushAsyncHandlers() {
+	await new Promise((resolve) => setImmediate(resolve));
+}


### PR DESCRIPTION
## Summary
- Add a shared API route helper for handled content stream/head failures.
- Replace content, IPFS, IPNS, and gateway route `console.error` handlers with lazy debug logging while preserving the existing `400` responses.
- Add regression coverage that exercises the handled failure paths without writing to stderr.

## Validation
- `GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/contentRouteErrors.test.ts --exit -t 10000`
- `npm run test:docker` (`203 passing`, `11 pending`)

## Note
- `npm run test:run` was attempted locally, but this machine's local Postgres rejects user `geesome`; Docker validation ran against a clean Postgres/IPFS stack.
