### PR TITLE
Keep failed login attempts out of stderr

### DIFF
--- a/app/modules/api/api.ts
+++ b/app/modules/api/api.ts
@@ -1,9 +1,12 @@
+import _ from 'lodash';
+import debug from 'debug';
+import http from 'node:http';
 import IGeesomeApiModule from "./interface.js";
 import {CorePermissionName} from "../database/interface.js";
 import {IGeesomeApp} from "../../interface.js";
-import http from 'node:http';
-import _ from 'lodash';
+import {sendForbiddenOnAuthRouteError} from "./routeErrorHelpers.js";
 const {isNumber} = _;
+const log = debug('geesome:api:routes');
 
 export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 	//TODO: move to core module
@@ -146,10 +149,10 @@ export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 	module.onPost('login/password', async (req, res) => {
 		app.loginPassword(req.body.username, req.body.password)
 			.then(user => module.handleAuthResult(res, user))
-			.catch((err) => {
-				console.error(err);
-				res.send(403)
-			});
+			.catch(sendForbiddenOnAuthRouteError(log, res, () => ({
+				route: 'login/password',
+				username: req.body?.username
+			})));
 	});
 
 	/**

--- a/app/modules/api/routeErrorHelpers.ts
+++ b/app/modules/api/routeErrorHelpers.ts
@@ -19,6 +19,19 @@ export function sendBadRequestOnContentRouteError(log: DebugLog, res: IApiModule
 	};
 }
 
+export function sendForbiddenOnAuthRouteError(log: DebugLog, res: IApiModuleCommonOutput, getContext: () => any = () => ({})) {
+	return (error) => {
+		helpers.logDebug(log, () => [
+			'auth route request failed',
+			{
+				...getContext(),
+				error: getErrorMessage(error)
+			}
+		]);
+		res.send(403);
+	};
+}
+
 function getErrorMessage(error) {
 	if (error && error.message) {
 		return error.message;

--- a/app/modules/ethereumAuthorization/api.ts
+++ b/app/modules/ethereumAuthorization/api.ts
@@ -1,5 +1,8 @@
+import debug from 'debug';
 import {IGeesomeApp} from "../../interface.js";
 import IGeesomeEthereumAuthorizationModule from "./interface.js";
+import {sendForbiddenOnAuthRouteError} from "../api/routeErrorHelpers.js";
+const log = debug('geesome:ethereum-authorization:api');
 
 export default (app: IGeesomeApp, ethereumAuthorizationModule: IGeesomeEthereumAuthorizationModule) => {
 	/**
@@ -40,9 +43,10 @@ export default (app: IGeesomeApp, ethereumAuthorizationModule: IGeesomeEthereumA
 	app.ms.api.onPost('login/auth-message', async (req, res) => {
 		ethereumAuthorizationModule.loginAuthMessage(req.body.authMessageId, req.body.accountAddress, req.body.signature, req.body.params)
 			.then(user => app.ms.api.handleAuthResult(res, user))
-			.catch((err) => {
-				console.error(err);
-				res.send(403)
-			});
+			.catch(sendForbiddenOnAuthRouteError(log, res, () => ({
+				route: 'login/auth-message',
+				authMessageId: req.body?.authMessageId,
+				accountAddress: req.body?.accountAddress
+			})));
 	});
 }

--- a/test/authRouteErrors.test.ts
+++ b/test/authRouteErrors.test.ts
@@ -1,0 +1,111 @@
+import assert from "assert";
+import coreApi from "../app/modules/api/api.js";
+import ethereumAuthorizationApi from "../app/modules/ethereumAuthorization/api.js";
+import {IGeesomeApp} from "../app/interface.js";
+
+describe("auth route errors", function () {
+	it("keeps failed password login attempts out of stderr", async () => {
+		const routes: any = {};
+		const consoleErrors = await captureConsoleErrors(async () => {
+			coreApi({
+				loginPassword: async () => {
+					throw new Error("invalid_password");
+				}
+			} as unknown as IGeesomeApp, {
+				...getApiRouteStub(routes),
+				handleAuthResult: async () => null
+			} as any);
+
+			const response = getResponseStub();
+			await routes["POST login/password"]({
+				body: {
+					username: "alice",
+					password: "wrong-password"
+				}
+			} as any, response);
+			await flushAsyncHandlers();
+
+			assert.deepEqual(response.sent, [[403]]);
+		});
+
+		assert.deepEqual(consoleErrors, []);
+	});
+
+	it("keeps failed signature login attempts out of stderr", async () => {
+		const routes: any = {};
+		const consoleErrors = await captureConsoleErrors(async () => {
+			ethereumAuthorizationApi({
+				ms: {
+					api: {
+						...getApiRouteStub(routes),
+						handleAuthResult: async () => null
+					}
+				}
+			} as unknown as IGeesomeApp, {
+				generateUserAccountAuthMessage: async () => ({}),
+				loginAuthMessage: async () => {
+					throw new Error("not_valid");
+				}
+			} as any);
+
+			const response = getResponseStub();
+			await routes["POST login/auth-message"]({
+				body: {
+					authMessageId: 1,
+					accountAddress: "0x0000000000000000000000000000000000000000",
+					signature: "bad-signature"
+				}
+			} as any, response);
+			await flushAsyncHandlers();
+
+			assert.deepEqual(response.sent, [[403]]);
+		});
+
+		assert.deepEqual(consoleErrors, []);
+	});
+});
+
+function getApiRouteStub(routes) {
+	return {
+		onGet: (route, handler) => {
+			routes[`GET ${route}`] = handler;
+		},
+		onPost: (route, handler) => {
+			routes[`POST ${route}`] = handler;
+		},
+		onAuthorizedGet: (route, handler) => {
+			routes[`AUTHORIZED_GET ${route}`] = handler;
+		},
+		onAuthorizedPost: (route, handler) => {
+			routes[`AUTHORIZED_POST ${route}`] = handler;
+		},
+		setStorageHeaders: () => null
+	};
+}
+
+function getResponseStub() {
+	return {
+		sent: [] as any[],
+		send(...args) {
+			this.sent.push(args);
+		}
+	};
+}
+
+async function captureConsoleErrors(callback) {
+	const originalConsoleError = console.error;
+	const consoleErrors: any[] = [];
+	console.error = ((...args) => {
+		consoleErrors.push(args);
+	}) as any;
+	try {
+		await callback();
+		return consoleErrors;
+	} finally {
+		console.error = originalConsoleError;
+	}
+}
+
+async function flushAsyncHandlers() {
+	await new Promise((resolve) => setImmediate(resolve));
+}


### PR DESCRIPTION
## Summary
- Add a shared auth-route error helper that preserves `403` responses while logging details only through lazy debug logging.
- Use it for password login and Ethereum signature login failures so expected bad credentials/signatures do not write to stderr.
- Add regression coverage for both failed login routes.

## Validation
- `GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/authRouteErrors.test.ts --exit -t 10000`
- `npm run security:route-inventory`
- `npm run test:docker` (`206 passing`, `11 pending`)
