### PR TITLE
Fix corrupt yarn cache build failure and docker-compose chmod target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN npm i -g yarn
 COPY . /geesome-node
 WORKDIR "/geesome-node"
 #RUN git checkout improve
-RUN yarn -W --no-optional
+# Clean the inherited yarn cache first: the base image can ship a corrupt
+# cached tarball (e.g. ts-morph) that makes `yarn install` fail on extraction.
+RUN yarn cache clean && yarn -W --no-optional
 RUN npm rebuild youtube-dl #https://github.com/przemyslawpluta/node-youtube-dl/issues/131
 
 ENV STORAGE_MODULE=ipfs-http-client

--- a/bash/ubuntu-install-docker.sh
+++ b/bash/ubuntu-install-docker.sh
@@ -12,7 +12,7 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io -y
 
 sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
-sudo chmod +x /usr/local/bin/docker
+sudo chmod +x /usr/local/bin/docker-compose
 
 docker compose build --no-cache && mkdir -p .docker-data
 


### PR DESCRIPTION
The Dockerfile inherited yarn cache from the geesome-base image can ship a corrupt cached tarball (observed: ts-morph extraction ENOENT), failing `yarn -W --no-optional` even under `docker compose build --no-cache`, since that flag only invalidates Docker layers, not the in-image yarn cache. Clean the cache before install so packages are re-fetched.

Also fix ubuntu-install-docker.sh chmod'ing /usr/local/bin/docker (which does not exist) instead of the docker-compose binary it just downloaded.