### PR TITLE
Serialize yarn extraction and make docker gpg keyring non-interactive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,11 @@ RUN npm i -g yarn
 COPY . /geesome-node
 WORKDIR "/geesome-node"
 #RUN git checkout improve
-# Clean the inherited yarn cache first: the base image can ship a corrupt
-# cached tarball (e.g. ts-morph) that makes `yarn install` fail on extraction.
-RUN yarn cache clean && yarn -W --no-optional
+# yarn v1 corrupts its own cache when parallel tar extraction races (a
+# different package fails "appears to be corrupt" on each run, often when the
+# droplet runs low on memory mid-extract). Clean the inherited cache and
+# serialize fetch+extract with --network-concurrency 1 to avoid the race.
+RUN yarn cache clean && yarn -W --no-optional --network-concurrency 1
 RUN npm rebuild youtube-dl #https://github.com/przemyslawpluta/node-youtube-dl/issues/131
 
 ENV STORAGE_MODULE=ipfs-http-client

--- a/bash/ubuntu-install-docker.sh
+++ b/bash/ubuntu-install-docker.sh
@@ -3,7 +3,7 @@
 sudo apt-get update -y
 
 sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release -y
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 sudo apt-get update -y


### PR DESCRIPTION
yarn -W still failed with random 'file appears to be corrupt' tar-extraction errors (typescript, ts-morph) even after cache clean, because yarn v1 races during parallel extraction and corrupts its own cache, typically when the droplet runs low on memory. Add --network-concurrency 1 to serialize fetch and extraction.

Also pass --batch --yes to gpg --dearmor so re-running ubuntu-install-docker.sh overwrites the existing docker keyring instead of blocking on a y/N prompt.