### PR TITLE
Fix /v1/setup apiDoc example to use name, not username

### DIFF
--- a/app/modules/api/api.ts
+++ b/app/modules/api/api.ts
@@ -115,7 +115,7 @@ export default (app: IGeesomeApp, module: IGeesomeApiModule) => {
 	 * @apiExample {curl} Example usage
 	 *   curl -X POST http://localhost:2052/v1/setup \
 	 *     -H "Content-Type: application/json" \
-	 *     -d '{"username":"admin","password":"secret","email":"admin@example.com"}'
+	 *     -d '{"name":"admin","password":"secret","email":"admin@example.com"}'
 	 */
 	module.onPost('setup', async (req, res) => {
 		res.send(await app.setup(req.body), 200);


### PR DESCRIPTION
The setup handler runs registerUser, which reads the 'name' field; the example body used 'username', which would fail with name_cant_be_null. Match the example to the IUserInput contract.