### PR TITLE
Auto-init IPFS repo on fresh installs via command instead of entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,11 @@ services:
     restart: always
     environment:
       - IPFS_PROFILE
-    entrypoint: ["ipfs", "daemon", "--migrate=true"]
+    # Use the image default entrypoint (start_ipfs) via command so the repo is
+    # auto-initialized (ipfs init) on a fresh server and IPFS_PROFILE is applied.
+    # Overriding entrypoint with a bare `ipfs daemon` skips init and crash-loops
+    # on first boot with "no IPFS repo found".
+    command: ["daemon", "--migrate=true"]
     expose:
       - 5001
     ports:


### PR DESCRIPTION
The ipfs service overrode the kubo entrypoint with a bare 'ipfs daemon', which skips the image's start_ipfs wrapper that runs 'ipfs init' on an empty repo and applies IPFS_PROFILE. On a brand-new server /data/ipfs is empty, so the daemon exits with 'no IPFS repo found' and crash-loops; the node then never connects to IPFS, the staticId module stays undefined, and /v1/setup 500s in registerUser.

Pass the args as 'command' and keep the default entrypoint so the repo is initialized automatically on first boot.