### PR TITLE
Sync models before migrations and guard setup against unready modules

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -148,6 +148,14 @@ function getModule(config, appPass) {
       if ((await this.ms.database.getUsersCount()) > 0) {
         throw new Error('already_setup');
       }
+      // Fail fast before creating any user row if storage-dependent modules are
+      // not ready yet (e.g. IPFS is still connecting). Otherwise registerUser
+      // inserts the user and then throws on this.ms.staticId, leaving a partial
+      // admin that makes the node look "already set up" on retry.
+      const notReady = ['storage', 'staticId', 'accountStorage'].filter((moduleName) => !this.ms[moduleName]);
+      if (notReady.length) {
+        throw new Error('modules_not_ready: ' + notReady.join(', '));
+      }
       const adminUser = await this.registerUser(userData);
       await this.ms.accountStorage.getOrCreateAccountStaticId('self', adminUser.id);
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "yarn --no-optional -W && ./node_modules/.bin/tsx --experimental-global-customevent ./index.ts",
-    "in-docker-start": "cd /geesome-node && yarn --no-optional -W && mkdir -p /geesome-node/frontend/docker-dist && rm -rf /geesome-node/frontend/docker-dist/* && UI_DIST=/geesome-node/node_modules/@geesome/ui/dist; UI_ROOT=/geesome-node/node_modules/@geesome/ui; if [ -f \"$UI_DIST/index.html\" ]; then cp -R \"$UI_DIST\"/* /geesome-node/frontend/docker-dist/; else cp -R \"$UI_ROOT\"/* /geesome-node/frontend/docker-dist/; fi && npm run migrate-all-database; npm run start",
+    "in-docker-start": "cd /geesome-node && yarn --no-optional -W && mkdir -p /geesome-node/frontend/docker-dist && rm -rf /geesome-node/frontend/docker-dist/* && UI_DIST=/geesome-node/node_modules/@geesome/ui/dist; UI_ROOT=/geesome-node/node_modules/@geesome/ui; if [ -f \"$UI_DIST/index.html\" ]; then cp -R \"$UI_DIST\"/* /geesome-node/frontend/docker-dist/; else cp -R \"$UI_ROOT\"/* /geesome-node/frontend/docker-dist/; fi && npm run database:sync-models && npm run migrate-all-database; npm run start",
     "recreate-database": "dropdb geesome_node && createdb geesome_node",
     "recreate-test-database": "dropdb --if-exists geesome_test && createdb geesome_test",
     "migrate-all-database": "npm run migrate-database; npm run ssg-migrate-database; npm run sci-migrate-database; npm run group-migrate-database;",


### PR DESCRIPTION
Fresh installs ran migrate-all-database before any table existed, so index/ alter migrations failed with 'relation "contents"/"posts" does not exist' (tables are created by model sync). Run database:sync-models first in in-docker-start, matching the order the performance harness already uses.

Also guard setup(): if storage/staticId/accountStorage are not ready yet (e.g. IPFS still connecting), throw modules_not_ready before registerUser instead of letting it insert a user row and then crash on this.ms.staticId, which left a partial admin and made the node look already-set-up on retry.