### PR TITLE
Fix docker-build image name for compose v2 so rebuild actually runs

### DIFF
--- a/bash/docker-build.sh
+++ b/bash/docker-build.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-docker rmi -f geesome-node_web && docker compose build --no-cache && mkdir -p .docker-data
+# Compose v2 names the image geesome-node-web (dash); v1 used geesome-node_web.
+# Remove either if present, but do not gate the rebuild on it: rmi of a missing
+# image exits non-zero, and --no-cache already forces a clean rebuild anyway.
+docker rmi -f geesome-node-web geesome-node_web 2>/dev/null || true
+docker compose build --no-cache && mkdir -p .docker-data


### PR DESCRIPTION
docker-build.sh removed geesome-node_web (v1 underscore name) and gated the build on it with &&. Under compose v2 the image is geesome-node-web (dash), so rmi failed with 'No such image', the && short-circuited, and 'docker compose build --no-cache' never ran -- docker-rebuild-and-upgrade.sh then restarted on the stale image. Remove both possible names without gating the rebuild.