### PR TITLE
Make rebuild prune safe and log each stage

### DIFF
--- a/bash/docker-prune.sh
+++ b/bash/docker-prune.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-docker system prune -af && docker volume ls -qf dangling=true | xargs -r docker volume rm
+# Reclaim space without nuking in-use or tagged base images. `docker system
+# prune -af` removes ALL unused images (postgres/nginx/ipfs, and even a freshly
+# built geesome-node-web when no container is holding it), which forces a full
+# re-pull and rebuild on the next start. Prune only dangling images and the
+# build cache instead, and drop dangling volumes.
+docker image prune -f
+docker builder prune -af
+docker volume ls -qf dangling=true | xargs -r docker volume rm

--- a/bash/docker-rebuild-and-upgrade.sh
+++ b/bash/docker-rebuild-and-upgrade.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
+set -e
 
 # TODO: ask user if there is uncomitted changes
+echo "==> [1/4] Updating source (git pull)..."
 git checkout -- .
 git pull
 
-sudo chmod +x bash/*.sh && ./bash/docker-build.sh && ./bash/docker-prune.sh
+sudo chmod +x bash/*.sh
 
+echo "==> [2/4] Building geesome-node-web image (--no-cache; can take several minutes)..."
+./bash/docker-build.sh
+
+# Restart BEFORE prune so the new image and base images are held by running
+# containers; otherwise prune would remove the just-built image and force a
+# full rebuild/re-pull on the next start.
+echo "==> [3/4] Restarting geesome-docker (recreating containers with the new image)..."
 systemctl daemon-reload
 systemctl restart geesome-docker
+
+echo "==> [4/4] Pruning dangling images and build cache..."
+./bash/docker-prune.sh
+
+echo "==> Done. Current containers:"
+docker compose ps || true
+echo "Follow node startup with: docker compose logs -f web"


### PR DESCRIPTION
docker-prune.sh used 'docker system prune -af', which removes ALL unused images (postgres/nginx/ipfs and even the freshly built geesome-node-web when no container holds it). Combined with running prune before the restart, an upgrade deleted the just-built image and silently triggered a full rebuild/re-pull under systemd, looking like a hang. Prune only dangling images and build cache, run it after the restart so running containers protect their images, and echo each stage so progress is visible.