### PR TITLE
[codex] Fix upload temp cleanup and storage mount

### DIFF
--- a/app/modules/content/asyncBusboy.ts
+++ b/app/modules/content/asyncBusboy.ts
@@ -58,9 +58,16 @@ function onFile (filePromises, file, stream, info) {
             readStream.filename = filename
             readStream.transferEncoding = readStream.encoding = encoding
             readStream.mimeType = readStream.mime = mimeType
+            readStream.tempPath = saveTo
+            readStream.emitFinish = (callback) => {
+              fs.rm(saveTo, { force: true }, function () {
+                callback && callback()
+              })
+            }
             resolve(readStream)
           }))
       .on('error', (err) => {
+        fs.rm(saveTo, { force: true }, () => {})
         stream.resume()
           .on('error', reject)
         reject(err)

--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -623,39 +623,51 @@ function getModule(app: IGeesomeApp) {
 				fileStream = dataToSave;
 			}
 
-			const {resultFile: storageFile, resultMimeType: mimeType, resultExtension: extension, resultProperties} = await this.checkFileSizeAndSaveByStream(userId, fileStream, options.mimeType || mime.lookup(fileName) || extensionFromName, {
-				extension: extensionFromName,
-				driver: options.driver,
-				onProgress: options.onProgress,
-				waitForPin: options.waitForPin
-			}).catch(e => {
-				logContentStreamSaveFailure(e);
-				dataToSave.emit && dataToSave.emit('end');
-				dataToSave.destroy && dataToSave.destroy();
-				throw e;
-			});
-			log('checkFileSizeAndSaveByStream extension', extension, 'mimeType', mimeType);
+			let storageFile: IStorageFile;
+			try {
+				const {
+					resultFile,
+					resultMimeType: mimeType,
+					resultExtension: extension,
+					resultProperties
+				} = await this.checkFileSizeAndSaveByStream(userId, fileStream, options.mimeType || mime.lookup(fileName) || extensionFromName, {
+					extension: extensionFromName,
+					driver: options.driver,
+					onProgress: options.onProgress,
+					waitForPin: options.waitForPin
+				}).catch(e => {
+					logContentStreamSaveFailure(e);
+					dataToSave.emit && dataToSave.emit('end');
+					dataToSave.destroy && dataToSave.destroy();
+					throw e;
+				});
+				storageFile = resultFile;
+				log('checkFileSizeAndSaveByStream extension', extension, 'mimeType', mimeType);
 
-			let existsContent = await app.ms.database.getContentByStorageAndUserId(storageFile.id, userId);
-			log('existsContent', !!existsContent);
-			if (existsContent) {
-				log(`Content ${storageFile.id} already exists in database, check preview and folder placement`);
-				await this.updateExistsContentMetadata(userId, existsContent, options);
-				await app.callHook('content', 'existsContentAdding', [userId, existsContent, options]);
-				return existsContent;
+				let existsContent = await app.ms.database.getContentByStorageAndUserId(storageFile.id, userId);
+				log('existsContent', !!existsContent);
+				if (existsContent) {
+					log(`Content ${storageFile.id} already exists in database, check preview and folder placement`);
+					await this.updateExistsContentMetadata(userId, existsContent, options);
+					await app.callHook('content', 'existsContentAdding', [userId, existsContent, options]);
+					return existsContent;
+				}
+
+				log('this.addContentWithPreview(storageFile, {resultProperties', resultProperties);
+				return await this.addContentWithPreview(userId, storageFile, {
+					extension,
+					mimeType,
+					storageType: ContentStorageType.IPFS,
+					view: options.view || ContentView.Contents,
+					storageId: storageFile.id,
+					size: storageFile.size,
+					name: fileName,
+					propertiesJson: JSON.stringify(merge(resultProperties || {}, options.properties || {}))
+				}, options);
+			} finally {
+				finishStorageFileTemp(storageFile);
+				finishStorageFileTemp(fileStream);
 			}
-
-			log('this.addContentWithPreview(storageFile, {resultProperties', resultProperties);
-			return this.addContentWithPreview(userId, storageFile, {
-				extension,
-				mimeType,
-				storageType: ContentStorageType.IPFS,
-				view: options.view || ContentView.Contents,
-				storageId: storageFile.id,
-				size: storageFile.size,
-				name: fileName,
-				propertiesJson: JSON.stringify(merge(resultProperties || {}, options.properties || {}))
-			}, options);
 		}
 
 		getDriverNameAndParams(options: {driver}) {
@@ -747,46 +759,45 @@ function getModule(app: IGeesomeApp) {
 
 		async addContentWithPreview(userId: number, storageFile: IStorageFile, contentData, options, source?) {
 			log('addContentWithPreview');
-			let previewData = {};
-			log('options.previews', options.previews);
-			const isRaw = !!this.getDriverNameAndParams(options).raw;
-			if (isRaw) {
-				// Raw driver: store original bytes only, skip preview generation.
-				log('driver raw, skip previews');
-			} else if (options.previews) {
-				await pIteration.forEachSeries(options.previews, async (p: any) => {
-					const result = await this.checkFileSizeAndSaveByStream(userId, p.content, p.mimeType, {waitForPin: options.waitForPin});
-					log('result', result);
-					previewData[p.previewSize + 'PreviewStorageId'] = result.resultFile.id;
-					previewData[p.previewSize + 'PreviewSize'] = result.resultFile.size;
-					//TODO: separate previews types
-					previewData['previewMimeType'] = result.resultMimeType;
-					previewData['previewExtension'] = result.resultExtension;
-				});
-				log('previewData', previewData);
-			} else {
-				const {
-					storageFile: forPreviewStorageFile,
-					extension: forPreviewExtension,
-					fullType: forPreviewFullType,
-					properties
-				} = await this.prepareStorageFileAndGetPreview(storageFile, contentData.extension, contentData.mimeType);
-				log('getPreview');
-				previewData = await this.getPreview(forPreviewStorageFile, forPreviewExtension, forPreviewFullType, source);
-				if (properties) {
-					contentData.propertiesJson = JSON.stringify(properties);
+			try {
+				let previewData = {};
+				log('options.previews', options.previews);
+				const isRaw = !!this.getDriverNameAndParams(options).raw;
+				if (isRaw) {
+					// Raw driver: store original bytes only, skip preview generation.
+					log('driver raw, skip previews');
+				} else if (options.previews) {
+					await pIteration.forEachSeries(options.previews, async (p: any) => {
+						const result = await this.checkFileSizeAndSaveByStream(userId, p.content, p.mimeType, {waitForPin: options.waitForPin});
+						log('result', result);
+						previewData[p.previewSize + 'PreviewStorageId'] = result.resultFile.id;
+						previewData[p.previewSize + 'PreviewSize'] = result.resultFile.size;
+						//TODO: separate previews types
+						previewData['previewMimeType'] = result.resultMimeType;
+						previewData['previewExtension'] = result.resultExtension;
+					});
+					log('previewData', previewData);
+				} else {
+					const {
+						storageFile: forPreviewStorageFile,
+						extension: forPreviewExtension,
+						fullType: forPreviewFullType,
+						properties
+					} = await this.prepareStorageFileAndGetPreview(storageFile, contentData.extension, contentData.mimeType);
+					log('getPreview');
+					previewData = await this.getPreview(forPreviewStorageFile, forPreviewExtension, forPreviewFullType, source);
+					if (properties) {
+						contentData.propertiesJson = JSON.stringify(properties);
+					}
 				}
-			}
 
-			if (storageFile.emitFinish) {
-				storageFile.emitFinish();
-				storageFile.emitFinish = null;
+				return await this.addContent(userId, {
+					...contentData,
+					...previewData
+				}, options);
+			} finally {
+				finishStorageFileTemp(storageFile);
 			}
-
-			return this.addContent(userId, {
-				...contentData,
-				...previewData
-			}, options);
 		}
 
 		async saveDirectoryToStorage(userId: number, dirPath, options: { userApiKeyId? } = {}) {
@@ -893,10 +904,13 @@ function getModule(app: IGeesomeApp) {
 				if (!uploadResult) {
 					return; // onError handled
 				}
-				log('saveDirectory', uploadResult['tempPath'] + '/');
-				resultFile = await app.ms.storage.saveDirectory(uploadResult['tempPath'] + '/', storageOptions);
-				if (uploadResult['emitFinish']) {
-					uploadResult['emitFinish']();
+				try {
+					log('saveDirectory', uploadResult['tempPath'] + '/');
+					resultFile = await app.ms.storage.saveDirectory(uploadResult['tempPath'] + '/', storageOptions);
+				} finally {
+					if (uploadResult['emitFinish']) {
+						uploadResult['emitFinish']();
+					}
 				}
 				mimeType = 'directory';
 				extension = 'none';
@@ -913,7 +927,14 @@ function getModule(app: IGeesomeApp) {
 						onError
 					});
 					log('saveFileByPath(uploadResult.tempPath)', uploadResult['tempPath']);
-					resultFile = await app.ms.storage.saveFileByPath(uploadResult['tempPath'], storageOptions);
+					try {
+						resultFile = await app.ms.storage.saveFileByPath(uploadResult['tempPath'], storageOptions);
+					} catch (e) {
+						if (uploadResult['emitFinish']) {
+							uploadResult['emitFinish']();
+						}
+						throw e;
+					}
 					resultFile.tempPath = uploadResult['tempPath'];
 					resultFile.emitFinish = uploadResult['emitFinish'];
 				}
@@ -1271,6 +1292,19 @@ function getContentErrorMessage(error) {
 		return error.message;
 	}
 	return String(error);
+}
+
+function finishStorageFileTemp(storageFile) {
+	if (!storageFile || !storageFile.emitFinish) {
+		return;
+	}
+	const emitFinish = storageFile.emitFinish;
+	storageFile.emitFinish = null;
+	try {
+		emitFinish();
+	} catch (e) {
+		log('storage temp cleanup failed', e);
+	}
 }
 
 interface IStorageFile {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - "${GEESOME_DATA:-./.docker-data/geesome-data}:/geesome-node/data"
       - "${GEESOME_FRONTEND_DIST:-./.docker-data/geesome-frontend}:/geesome-node/frontend/docker-dist"
+      - "${GEESOME_TEMP:-./.docker-data/geesome-temp}:/tmp"
     environment:
       - IPFS_PROFILE
       - SSG_RUNTIME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,25 @@ services:
     volumes:
       - "${GEESOME_FRONTEND_DIST:-./.docker-data/geesome-frontend}:/usr/share/nginx/html"
 
+  temp-cleaner:
+    container_name: geesome_temp_cleaner
+    image: alpine:3.20
+    restart: always
+    volumes:
+      - "${GEESOME_TEMP:-./.docker-data/geesome-temp}:/geesome-temp"
+    environment:
+      - GEESOME_TEMP_MAX_AGE_MINUTES=${GEESOME_TEMP_MAX_AGE_MINUTES:-1440}
+      - GEESOME_TEMP_CLEAN_INTERVAL_SECONDS=${GEESOME_TEMP_CLEAN_INTERVAL_SECONDS:-3600}
+    # Last-resort cleanup for temp files left after crashes or killed uploads.
+    command:
+      - sh
+      - -ec
+      - |
+        while true; do
+          find /geesome-temp -mindepth 1 -maxdepth 1 -mmin +"$${GEESOME_TEMP_MAX_AGE_MINUTES}" -exec rm -rf {} +
+          sleep "$${GEESOME_TEMP_CLEAN_INTERVAL_SECONDS}"
+        done
+
   ipfs:
     container_name: go_ipfs
     image: "ipfs/kubo:v0.21.0"

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -320,6 +320,22 @@ describe("app", function () {
 			1
 		);
 
+		const tempSourcePath = `/tmp/geesome-save-data-temp-${Date.now()}.txt`;
+		fs.writeFileSync(tempSourcePath, 'test');
+		let tempSourceCleaned = false;
+		const tempSourceStream: any = fs.createReadStream(tempSourcePath);
+		tempSourceStream.emitFinish = () => {
+			tempSourceCleaned = true;
+			fs.rmSync(tempSourcePath, {force: true});
+		};
+		const duplicateStreamContent = await app.ms.content.saveData(saveDataTestUser.id, tempSourceStream, 'text.txt', {
+			waitForPin: true,
+			mimeType: 'text/plain'
+		});
+		assert.equal(duplicateStreamContent.id, textContent.id);
+		assert.equal(tempSourceCleaned, true);
+		assert.equal(fs.existsSync(tempSourcePath), false);
+
 		const secondSaveDataUser = await app.registerUser({
 			email: 'user-save-data-2@user.com',
 			name: 'user-save-data-2',


### PR DESCRIPTION
## Source of truth

Production debugging on `geesome-test` showed `POST /api/v1/user/save-file` failing when the Geesome host root disk filled. The largest consumer was the running `geesome` container writable layer, specifically stale files under `/tmp`.

## Summary

- Mount the web container `/tmp` through configurable `GEESOME_TEMP` storage so upload temp files do not live on the small root filesystem.
- Attach cleanup hooks to `asyncBusboy` upload temp files and run temp cleanup through save-data duplicate, preview, storage-save, and error paths.
- Add a regression assertion that stream-backed duplicate saves still call the temp cleanup hook.

Closes #1052

## Scope

This is limited to Geesome upload temp storage and cleanup. It does not change upload API contracts, content storage IDs, or generated site behavior.

## Production Recovery

- Cleared 8,288 stale image temp files older than one hour from the live `geesome` container.
- Root disk recovered from 100% used to about 59% used; container `/tmp` dropped from about 16G to under 1G.

## Verification

- `docker compose config`
- Focused Docker regression: `docker compose -f ./test/docker-compose.yml run --rm test ... test/app.test.ts --grep "should correctly save data"` -> 2 passing
- Full `npm run test:docker` reached 199 passing / 11 pending, then failed late in `staticSiteGenerator` beforeEach with Postgres `sorry, too many clients already`; the touched upload/content regression passed earlier in that run.
