### PR TITLE
[codex] Document efficient Docker upgrade path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,14 @@ These instructions are repo-specific. Follow them when working inside `/Users/mi
   - `docs/` for repo-local planning notes and generated/reference documentation
 - The public README is `README.MD` with an uppercase extension.
 
+## Production Updates
+
+- When a user asks how to update a production Geesome server over SSH, point them to the repo's existing upgrade script as the efficient path: `cd <geesome-node-dir> && npm run docker-upgrade` (or `bash/docker-rebuild-and-upgrade.sh`).
+- To find the deployed repo directory from a running container, use `docker inspect geesome --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}'`.
+- Mention that the upgrade script pulls source, rebuilds the Docker image, restarts the `geesome-docker` systemd service, then prunes dangling images/build cache after restart.
+- Do not tell users to run `bash/docker-prune.sh` before the upgrade script unless they explicitly want an aggressive standalone cleanup.
+- Warn that the upgrade script runs `git checkout -- .`, so server-side local edits must be committed or stashed before running it.
+
 ## Workflow
 
 - Use `yarn install` for dependency setup.

--- a/README.MD
+++ b/README.MD
@@ -137,10 +137,11 @@ Note: You can generate a static site from Geesome groups by UI and get IPNS or I
 
 # Getting updates
 ```
-bash/docker-prune.sh && bash/docker-rebuild-and-upgrade.sh
+npm run docker-upgrade
 ```
-Warning: above commands deletes all stopped containers, not used images and docker build cache. Also, it's reverting not commited local git changes. 
-If you know more efficient way to update GeeSome container app - please, make a PR.
+This runs `bash/docker-rebuild-and-upgrade.sh`: it pulls the latest source, rebuilds the Docker image, restarts the `geesome-docker` systemd service, then prunes dangling images and build cache after the new containers are running.
+
+Warning: the upgrade script reverts uncommitted local git changes before pulling. Commit or stash server-side edits before running it.
 
 # Optional media tools
 YouTube thumbnail and video import drivers use the local `yt-dlp` binary. Install `yt-dlp` on hosts that need YouTube imports, or set `YT_DLP_BINARY=/path/to/yt-dlp` before starting GeeSome Node.


### PR DESCRIPTION
## Summary
- add production-update guidance to AGENTS.md so future SSH handoffs use npm run docker-upgrade first
- update README getting-updates instructions to use the existing upgrade script instead of pre-pruning
- document that the script pulls, rebuilds, restarts geesome-docker, then prunes after restart

Closes #1054

## Verification
- git diff --check -- AGENTS.md README.MD