### PR TITLE
[codex] Speed up Docker deploy rebuilds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 .docker-data
+.docker-build-cache
 .DS_Store
 .env
 .git
@@ -13,6 +14,9 @@ coverage
 .nyc_output
 frontend/.parcel-cache
 app/modules/socNetImport/config
+backups
+.cache
+.local
 test/resources
 test/.geesome-data
 test/.geesome-frontend

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ app/modules/socNetImport/config
 docs
 *.sqlite
 .docker-data
+.docker-build-cache
 frontend/.parcel-cache
 *.zip
 .env

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+registry "https://registry.npmjs.org"
+network-timeout 600000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ These instructions are repo-specific. Follow them when working inside `/Users/mi
 
 - When a user asks how to update a production Geesome server over SSH, point them to the repo's existing upgrade script as the efficient path: `cd <geesome-node-dir> && npm run docker-upgrade` (or `bash/docker-rebuild-and-upgrade.sh`).
 - To find the deployed repo directory from a running container, use `docker inspect geesome --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}'`.
-- Mention that the upgrade script pulls source, rebuilds the Docker image, restarts the `geesome-docker` systemd service, then prunes dangling images/build cache after restart.
+- Mention that the upgrade script pulls source, rebuilds the Docker image with warm BuildKit/Yarn caches, then restarts the `geesome-docker` systemd service. External `.docker-build-cache` export is used when the host builder supports it, and Docker caches are pruned only after a failed build before retrying.
 - Do not tell users to run `bash/docker-prune.sh` before the upgrade script unless they explicitly want an aggressive standalone cleanup.
-- Warn that the upgrade script runs `git checkout -- .`, so server-side local edits must be committed or stashed before running it.
+- Warn that the upgrade script refuses to run with uncommitted local edits, so server-side edits must be committed or stashed before running it.
 
 ## Workflow
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 FROM microwavedev/geesome-base
 
 # https://github.com/lovell/sharp/issues/3161
@@ -15,17 +15,21 @@ RUN \. $NVM_DIR/nvm.sh
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-RUN npm i -g yarn
-
-COPY . /geesome-node
 WORKDIR "/geesome-node"
-#RUN git checkout improve
-# yarn v1 corrupts its own cache when parallel tar extraction races (a
-# different package fails "appears to be corrupt" on each run, often when the
-# droplet runs low on memory mid-extract). Clean the inherited cache and
-# serialize fetch+extract with --network-concurrency 1 to avoid the race.
-RUN yarn cache clean && yarn -W --no-optional --network-concurrency 1
-RUN npm rebuild youtube-dl #https://github.com/przemyslawpluta/node-youtube-dl/issues/131
+RUN npm i -g yarn@1.22.22
+
+ENV YARN_CACHE_FOLDER=/usr/local/share/.cache/yarn
+ENV NODE_OPTIONS=--dns-result-order=ipv4first
+
+COPY package.json yarn.lock .yarnrc ./
+# Keep dependency installation reusable for source-only rebuilds. The Yarn v1
+# cache mount preserves fetched package archives between BuildKit builds, while
+# --network-concurrency 1 avoids the tar extraction race seen on small servers.
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,sharing=locked \
+    yarn -W --no-optional --frozen-lockfile --network-concurrency 1 \
+    && npm rebuild youtube-dl
+
+COPY . .
 
 ENV STORAGE_MODULE=ipfs-http-client
 ENV STORAGE_URL=http://go_ipfs:5001

--- a/README.MD
+++ b/README.MD
@@ -139,9 +139,11 @@ Note: You can generate a static site from Geesome groups by UI and get IPNS or I
 ```
 npm run docker-upgrade
 ```
-This runs `bash/docker-rebuild-and-upgrade.sh`: it pulls the latest source, rebuilds the Docker image, restarts the `geesome-docker` systemd service, then prunes dangling images and build cache after the new containers are running.
+This runs `bash/docker-rebuild-and-upgrade.sh`: it pulls the latest source, rebuilds the Docker image, and restarts the `geesome-docker` systemd service.
 
-Warning: the upgrade script reverts uncommitted local git changes before pulling. Commit or stash server-side edits before running it.
+The Docker rebuild keeps dependency and BuildKit caches warm, so source-only updates should not redownload packages. When the Docker builder supports external cache exports, the build also imports/exports `.docker-build-cache`; otherwise it falls back to normal Docker layer caching. If the first build fails, the script prunes Docker caches and retries once.
+
+Warning: the upgrade script refuses to run with uncommitted local git changes. Commit or stash server-side edits before running it.
 
 # Optional media tools
 YouTube thumbnail and video import drivers use the local `yt-dlp` binary. Install `yt-dlp` on hosts that need YouTube imports, or set `YT_DLP_BINARY=/path/to/yt-dlp` before starting GeeSome Node.

--- a/bash/docker-build.sh
+++ b/bash/docker-build.sh
@@ -1,7 +1,53 @@
 #!/bin/bash
+set -euo pipefail
 
-# Compose v2 names the image geesome-node-web (dash); v1 used geesome-node_web.
-# Remove either if present, but do not gate the rebuild on it: rmi of a missing
-# image exits non-zero, and --no-cache already forces a clean rebuild anyway.
-docker rmi -f geesome-node-web geesome-node_web 2>/dev/null || true
-docker compose build --no-cache && mkdir -p .docker-data
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+mkdir -p .docker-data .docker-build-cache
+
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+
+CACHE_LOG="$(mktemp)"
+trap 'rm -f "$CACHE_LOG"' EXIT
+
+BUILDX_DRIVER="$(docker buildx inspect 2>/dev/null | awk -F': *' '/^Driver:/ { print $2; exit }' || true)"
+CACHE_EXPORT_MODE="${GEESOME_DOCKER_CACHE_EXPORT:-auto}"
+USE_EXTERNAL_CACHE="0"
+
+case "$CACHE_EXPORT_MODE" in
+  1|true|yes)
+    USE_EXTERNAL_CACHE="1"
+    ;;
+  0|false|no)
+    USE_EXTERNAL_CACHE="0"
+    ;;
+  auto)
+    if [ -n "$BUILDX_DRIVER" ] && [ "$BUILDX_DRIVER" != "docker" ]; then
+      USE_EXTERNAL_CACHE="1"
+    fi
+    ;;
+  *)
+    echo "GEESOME_DOCKER_CACHE_EXPORT must be auto, 1, or 0."
+    exit 1
+    ;;
+esac
+
+if [ "$USE_EXTERNAL_CACHE" = "1" ]; then
+  if docker compose -f docker-compose.yml -f docker-compose.build-cache.yml build web 2>&1 | tee "$CACHE_LOG"; then
+    exit 0
+  fi
+
+  if ! grep -qi "cache export is not supported" "$CACHE_LOG"; then
+    exit 1
+  fi
+
+  echo "Docker build cache export is not supported by this builder; retrying without external cache export."
+fi
+
+if [ "$CACHE_EXPORT_MODE" = "auto" ] && [ "$BUILDX_DRIVER" = "docker" ]; then
+  echo "Docker buildx driver is docker; using normal Docker layer cache without external cache export."
+fi
+
+docker compose build web

--- a/bash/docker-prune.sh
+++ b/bash/docker-prune.sh
@@ -1,10 +1,39 @@
 #!/bin/bash
+set -euo pipefail
 
-# Reclaim space without nuking in-use or tagged base images. `docker system
-# prune -af` removes ALL unused images (postgres/nginx/ipfs, and even a freshly
-# built geesome-node-web when no container is holding it), which forces a full
-# re-pull and rebuild on the next start. Prune only dangling images and the
-# build cache instead, and drop dangling volumes.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+MODE="standard"
+REMOVE_REPO_CACHE="0"
+
+for arg in "$@"; do
+  case "$arg" in
+    --aggressive|aggressive)
+      MODE="aggressive"
+      ;;
+    --repo-build-cache)
+      REMOVE_REPO_CACHE="1"
+      ;;
+    *)
+      echo "Usage: bash/docker-prune.sh [--aggressive] [--repo-build-cache]"
+      exit 1
+      ;;
+  esac
+done
+
+# Reclaim space without nuking in-use images. Normal upgrades preserve build
+# caches; this script is for explicit cleanup or failed-build retry fallback.
 docker image prune -f
-docker builder prune -af
-docker volume ls -qf dangling=true | xargs -r docker volume rm
+
+if [ "$MODE" = "aggressive" ]; then
+  docker builder prune -af
+  docker volume prune -f
+else
+  docker builder prune -f
+  docker volume ls -qf dangling=true | xargs -r docker volume rm
+fi
+
+if [ "$REMOVE_REPO_CACHE" = "1" ] && [ -d "$ROOT_DIR/.docker-build-cache" ]; then
+  rm -rf "$ROOT_DIR/.docker-build-cache"
+fi

--- a/bash/docker-rebuild-and-upgrade.sh
+++ b/bash/docker-rebuild-and-upgrade.sh
@@ -1,26 +1,23 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# TODO: ask user if there is uncomitted changes
-echo "==> [1/4] Updating source (git pull)..."
-git checkout -- .
-git pull
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> [1/3] Updating source (git pull --ff-only)..."
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Refusing to upgrade with uncommitted local changes:"
+  git status --short
+  echo "Commit or stash the local changes, then rerun npm run docker-upgrade."
+  exit 1
+fi
+
+git pull --ff-only
+
+if [ -f .gitmodules ]; then
+  git submodule update --init --recursive
+fi
 
 sudo chmod +x bash/*.sh
 
-echo "==> [2/4] Building geesome-node-web image (--no-cache; can take several minutes)..."
-./bash/docker-build.sh
-
-# Restart BEFORE prune so the new image and base images are held by running
-# containers; otherwise prune would remove the just-built image and force a
-# full rebuild/re-pull on the next start.
-echo "==> [3/4] Restarting geesome-docker (recreating containers with the new image)..."
-systemctl daemon-reload
-systemctl restart geesome-docker
-
-echo "==> [4/4] Pruning dangling images and build cache..."
-./bash/docker-prune.sh
-
-echo "==> Done. Current containers:"
-docker compose ps || true
-echo "Follow node startup with: docker compose logs -f web"
+exec bash "$ROOT_DIR/bash/docker-upgrade-run.sh"

--- a/bash/docker-upgrade-run.sh
+++ b/bash/docker-upgrade-run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> [2/3] Building geesome-node-web image with Docker cache..."
+if ! ./bash/docker-build.sh; then
+  echo "==> Build failed. Pruning Docker caches and retrying once..."
+  ./bash/docker-prune.sh --aggressive --repo-build-cache
+  ./bash/docker-build.sh
+fi
+
+echo "==> [3/3] Restarting geesome-docker (recreating containers with the new image)..."
+systemctl daemon-reload
+systemctl restart geesome-docker
+
+echo "==> Build caches preserved for faster future upgrades."
+echo "==> Done. Current containers:"
+docker compose ps || true
+echo "Follow node startup with: docker compose logs -f web"

--- a/bash/ubuntu-install-docker.sh
+++ b/bash/ubuntu-install-docker.sh
@@ -29,7 +29,7 @@ else
   echo "Memory OK: ${TOTAL_MB}MB total (RAM ${MEM_MB}MB + swap ${SWAP_MB}MB)."
 fi
 
-docker compose build --no-cache && mkdir -p .docker-data
+bash bash/docker-build.sh
 
 sudo sed "s|/root/geesome-node|$PWD|g" < bash/geesome-docker.service > /etc/systemd/system/geesome-docker.service
 

--- a/docker-compose.build-cache.yml
+++ b/docker-compose.build-cache.yml
@@ -1,0 +1,7 @@
+services:
+  web:
+    build:
+      cache_from:
+        - type=local,src=.docker-build-cache
+      cache_to:
+        - type=local,dest=.docker-build-cache,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   web:
     container_name: geesome
-    build: .
+    build:
+      context: .
     command: npm run in-docker-start
     restart: always
     ports:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.ts",
   "type": "module",
+  "packageManager": "yarn@1.22.22",
   "engines": {
     "node": ">=22 <25"
   },


### PR DESCRIPTION
## Summary

- Split the production Dockerfile so Yarn dependencies install from package metadata before application source is copied.
- Pin Yarn Classic, add a BuildKit cache mount for Yarn package archives, and keep Docker context/cache directories out of build uploads.
- Change the deploy build path to preserve caches, use external `.docker-build-cache` export when the host builder supports it, and prune only as a failed-build retry fallback.
- Update the upgrade docs and repo-local agent notes to match the safer deploy behavior.

## Source of truth

- User request: use `/Users/microwavedev/Downloads/Telegram Desktop/fast-docker-rebuild-handoff.md` to improve Geesome deploy.
- Tracking issue: Closes #1060.

## Scope

- Production Docker image build and Compose build-cache configuration.
- Docker upgrade/build/prune helper scripts.
- README and repo-local agent deployment notes.

## Verification

- `bash -n bash/docker-build.sh bash/docker-prune.sh bash/docker-rebuild-and-upgrade.sh bash/docker-upgrade-run.sh bash/ubuntu-install-docker.sh`
- `docker compose config --quiet`
- `docker compose -f docker-compose.yml -f docker-compose.build-cache.yml config --quiet`
- `node -e "JSON.parse(require('fs').readFileSync('package.json', 'utf8')); console.log('package.json ok')"`
- `bash bash/docker-build.sh`
- Warm rerun of `bash bash/docker-build.sh` confirmed the Yarn dependency install/rebuild layer was cached.
