### PR TITLE
Handle non-promise API callbacks

### DIFF
--- a/app/modules/api/index.ts
+++ b/app/modules/api/index.ts
@@ -95,13 +95,19 @@ async function getModule(app: IGeesomeApp, version, port) {
 		}
 		async handleCallback(req, res, callback) {
 			try {
-				await callback(reqToModuleInput(req), resToModuleOutput(res)).catch(error => {
-					console.error(error);
-					return res.send({message: error.message || error, errorCode: 3}, error.code || 500);
-				});
+				await Promise.resolve(callback(reqToModuleInput(req), resToModuleOutput(res)));
 			} catch (error) {
+				const callbackError = error as any;
 				console.error(error);
-				return res.send({message: error.message || error, errorCode: 3}, error.code || 500);
+				if (isResponseClosed(res)) {
+					return;
+				}
+				const statusCode = Number.isInteger(callbackError?.code) ? callbackError.code : 500;
+				const body = {message: callbackError.message || callbackError, errorCode: 3};
+				if (typeof res.status === 'function') {
+					return res.status(statusCode).send(body);
+				}
+				return res.send(body, statusCode);
 			}
 		}
 
@@ -254,6 +260,10 @@ async function getModule(app: IGeesomeApp, version, port) {
 			writeHead: res.writeHead.bind(res),
 			stream: res,
 		};
+	}
+
+	function isResponseClosed(res) {
+		return res.headersSent || res.writableEnded || res.stream?.headersSent || res.stream?.writableEnded;
 	}
 
 	const apiModule = new GeesomeApiModule(port);

--- a/test/apiCallbackHandling.test.ts
+++ b/test/apiCallbackHandling.test.ts
@@ -1,0 +1,108 @@
+import assert from "assert";
+import net from "node:net";
+import apiModule from "../app/modules/api/index.js";
+import {IGeesomeApp} from "../app/interface.js";
+
+describe("api callback handling", function () {
+	this.timeout(10000);
+
+	it("allows handlers to send a response and return no promise", async () => {
+		const port = await getAvailablePort();
+		const previousPort = process.env.PORT;
+		let api;
+		delete process.env.PORT;
+
+		let consoleErrors;
+		try {
+			consoleErrors = await captureConsoleErrors(async () => {
+				try {
+					api = await apiModule({
+						config: {port},
+						ms: {
+							database: {getUsersCount: async () => 0},
+							storage: {remoteNodeAddressList: async () => []},
+							communicator: {nodeAddressList: async () => []}
+						}
+					} as unknown as IGeesomeApp);
+
+					const response = getResponseStub();
+					await (api as any).handleCallback(getRequestStub("/sync-send"), response, (_req, res) => {
+						res.send({ok: true}, 200);
+					});
+
+					assert.deepEqual(response.sent, [[{ok: true}, 200]]);
+				} finally {
+					api?.stop();
+				}
+			});
+		} finally {
+			if (previousPort === undefined) {
+				delete process.env.PORT;
+			} else {
+				process.env.PORT = previousPort;
+			}
+		}
+		assert.deepEqual(consoleErrors, []);
+	});
+});
+
+async function getAvailablePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.on("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			const port = typeof address === "object" && address ? address.port : 0;
+			server.close(() => resolve(port));
+		});
+	});
+}
+
+function getRequestStub(path: string) {
+	return {
+		headers: {},
+		params: {},
+		url: path,
+		originalUrl: path
+	};
+}
+
+function getResponseStub() {
+	return {
+		headersSent: false,
+		writableEnded: false,
+		statusCode: undefined as number | undefined,
+		sent: [] as any[],
+		send(...args) {
+			this.sent.push(args);
+			this.headersSent = true;
+			return this;
+		},
+		setHeader() {
+			return this;
+		},
+		status(statusCode) {
+			this.statusCode = statusCode;
+			return this;
+		},
+		writeHead(statusCode) {
+			this.statusCode = statusCode;
+			this.headersSent = true;
+			return this;
+		}
+	};
+}
+
+async function captureConsoleErrors(callback) {
+	const originalConsoleError = console.error;
+	const consoleErrors: any[] = [];
+	console.error = ((...args) => {
+		consoleErrors.push(args);
+	}) as any;
+	try {
+		await callback();
+		return consoleErrors;
+	} finally {
+		console.error = originalConsoleError;
+	}
+}


### PR DESCRIPTION
## Summary

- Wrap API route callback results with `Promise.resolve(...)` so handlers that send/stream a response and return `undefined` do not crash the shared wrapper.
- Skip wrapper error responses once Express has already sent or ended the response, including module-output wrappers backed by a stream.
- Add a regression test for a sync-style handler that sends a response and returns no Promise.

Closes #1074

## Verification

- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/apiCallbackHandling.test.ts test/apiHeaders.test.ts test/contentRouteErrors.test.ts test/storageRouteErrors.test.ts`
- `node --import tsx -e "await import('./app/modules/api/index.ts'); console.log('api module import ok')"`
- `git diff --check`

## Full test note

- `yarn test` is blocked in this local environment by PostgreSQL authentication for user `geesome`, then cascades into module initialization failures and a port collision on `7772` during the existing app tests.
