### PR TITLE
Allow app-published storage roots

### DIFF
--- a/app/interface.ts
+++ b/app/interface.ts
@@ -35,6 +35,8 @@ export interface IGeesomeApp {
 
   frontendStorageId;
 
+  docsStorageId;
+
   //modules
   ms: {
     api: IGeesomeApiModule;

--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -173,6 +173,21 @@ function getModule(app: IGeesomeApp) {
 		return error;
 	}
 
+	async function isStorageIdAllowedForApi(storageId) {
+		if (isPublishedAppStorageId(storageId)) {
+			return true;
+		}
+		return app.callHookCheckAllowed('content', 'isStorageIdAllowed', [storageId]);
+	}
+
+	function isPublishedAppStorageId(storageId) {
+		return storageId && (storageId === app.docsStorageId || storageId === app.frontendStorageId);
+	}
+
+	function isPublishedAppStorageRootPath(dataPath) {
+		return isPublishedAppStorageId(String(dataPath || '').replace(/\/+$/, ''));
+	}
+
 	function pickPublicContentMetadata(content) {
 		const contentData = toContentPlainObject(content);
 		if (!contentData) {
@@ -1181,7 +1196,7 @@ function getModule(app: IGeesomeApp) {
 				let content = storagePathMetadata.content;
 				helpers.logDebug(log, () => ['content', helpers.toLogValue(content)]);
 				if (!content) {
-					const storageIdAllowed = await app.callHookCheckAllowed('content', 'isStorageIdAllowed', [storageId]);
+					const storageIdAllowed = await isStorageIdAllowedForApi(storageId);
 					if (!storageIdAllowed) {
 						return res.send(423);
 					}
@@ -1208,7 +1223,7 @@ function getModule(app: IGeesomeApp) {
 			const {storageId} = storagePathMetadata;
 			const content = storagePathMetadata.content;
 			if (!content) {
-				const storageIdAllowed = await app.callHookCheckAllowed('content', 'isStorageIdAllowed', [storageId]);
+				const storageIdAllowed = await isStorageIdAllowedForApi(storageId);
 				if (!storageIdAllowed) {
 					return res.send(423);
 				}
@@ -1277,7 +1292,7 @@ function getModule(app: IGeesomeApp) {
 			const {storageId} = storagePathMetadata;
 			let content = storagePathMetadata.content;
 			if (!content) {
-				const storageIdAllowed = await app.callHookCheckAllowed('content', 'isStorageIdAllowed', [storageId]);
+				const storageIdAllowed = await isStorageIdAllowedForApi(storageId);
 				if (!storageIdAllowed) {
 					res.writeHead(423, {'Cross-Origin-Resource-Policy': 'cross-origin'});
 					return res.stream.end();
@@ -1337,15 +1352,19 @@ function getModule(app: IGeesomeApp) {
 		}
 
 		prepareContentStoragePathResponse(res, dataPath, content) {
-			const contentType = this.getContentStorageMimeType(dataPath, content);
+			const preparedDataPath = this.prepareContentStorageDataPath(dataPath, content);
+			const contentType = this.getContentStorageMimeType(content ? dataPath : preparedDataPath, content);
 			log('contentType', contentType);
 			if (contentType) {
 				res.setHeader('Content-Type', contentType);
 			}
-			return this.prepareContentStorageDataPath(dataPath, content);
+			return preparedDataPath;
 		}
 
 		prepareContentStorageDataPath(dataPath, content) {
+			if (!content && isPublishedAppStorageRootPath(dataPath)) {
+				return String(dataPath).replace(/\/+$/, '') + '/index.html';
+			}
 			if (content?.mimeType === ContentMimeType.Directory && !(last(dataPath.split('/')) as string).includes('.')) {
 				return dataPath + '/index.html';
 			}
@@ -1358,6 +1377,10 @@ function getModule(app: IGeesomeApp) {
 			}
 			if (dataPath.endsWith('.js')) {
 				return 'text/javascript';
+			}
+			const mimeType = mime.lookup(dataPath);
+			if (mimeType) {
+				return mimeType;
 			}
 			return '';
 		}

--- a/test/contentHeaders.test.ts
+++ b/test/contentHeaders.test.ts
@@ -379,6 +379,63 @@ describe("content headers", function () {
 		assert.equal(streamRequested, false);
 	});
 
+	it("allows the app published docs storage root without a database content row", async () => {
+		const responseStream = new PassThrough();
+		const finished = new Promise((resolve) => responseStream.on("finish", resolve));
+		const writes: any = {};
+		const sends: any[] = [];
+		let hookCalls = 0;
+		let streamPath = "";
+		responseStream.resume();
+		const content = await contentModule({
+			checkModules: () => null,
+			docsStorageId: "docs-root",
+			callHookCheckAllowed: async () => {
+				hookCalls += 1;
+				return false;
+			},
+			ms: {
+				api: getApiStub(),
+				database: {
+					getSharedStorageMetadataByStorageId: async () => null
+				},
+				storage: {
+					getFileStat: async () => ({size: 5}),
+					getFileStream: async (path) => {
+						streamPath = path;
+						return Readable.from(["hello"]);
+					}
+				}
+			}
+		} as unknown as IGeesomeApp);
+
+		await content.getFileStreamForApiRequest({
+			headers: {}
+		} as any, {
+			send: (...args) => sends.push(args),
+			setHeader: (name, value) => {
+				writes.headers = writes.headers || {};
+				writes.headers[name] = value;
+			},
+			writeHead: (status, responseHeaders) => {
+				writes.status = status;
+				writes.headers = {
+					...writes.headers,
+					...responseHeaders
+				};
+			},
+			stream: responseStream
+		} as any, "docs-root");
+		await finished;
+
+		assert.equal(writes.status, 200);
+		assert.equal(writes.headers["Content-Type"], "text/html");
+		assert.equal(writes.headers["Content-Length"], 5);
+		assert.equal(streamPath, "docs-root/index.html");
+		assert.equal(hookCalls, 0);
+		assert.deepEqual(sends, []);
+	});
+
 	it("streams non-range content when storage stats do not include a CID", async () => {
 		const responseStream = new PassThrough();
 		const finished = new Promise((resolve) => responseStream.on("finish", resolve));


### PR DESCRIPTION
## Summary

- Allow the content gateway to serve the app's own published storage roots (`docsStorageId` and `frontendStorageId`) even when those roots do not have content DB rows.
- Keep arbitrary unknown storage IDs locked behind the existing `isStorageIdAllowed` hook.
- Resolve bare published directory roots to `index.html`, so advertised docs links like `/ipfs/<docsCid>` can render instead of trying to stream the directory object.
- Add regression coverage for a published docs root that would otherwise return `423 Locked`.

Closes #1076

## Verification

- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/contentHeaders.test.ts test/contentRouteErrors.test.ts test/apiHeaders.test.ts test/apiCallbackHandling.test.ts`
- `node --import tsx -e "await import('./app/modules/content/index.ts'); await import('./app/interface.ts'); console.log('content imports ok')"`
- `git diff --check`

## Full test note

- `yarn test` is still blocked in this local environment by PostgreSQL authentication for user `geesome`, then cascades into module initialization failures and a port collision on `7772` during the existing app tests.
