### PR TITLE
Avoid gateway stat retry crashes

### DIFF
--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -188,6 +188,15 @@ function getModule(app: IGeesomeApp) {
 		return isPublishedAppStorageId(String(dataPath || '').replace(/\/+$/, ''));
 	}
 
+	function getGatewayFileStat(dataPath) {
+		return app.ms.storage.getFileStat(dataPath, {
+			attempts: 0,
+			attemptTimeout: 0,
+			withLocal: true,
+			size: true
+		});
+	}
+
 	function pickPublicContentMetadata(content) {
 		const contentData = toContentPlainObject(content);
 		if (!contentData) {
@@ -1167,6 +1176,16 @@ function getModule(app: IGeesomeApp) {
 			return dataSize;
 		}
 
+		async getGatewayFileSize(dataPath, content) {
+			let dataSize = content ? content.size : null;
+			const stat = await getGatewayFileStat(dataPath);
+			if (!stat) {
+				return null;
+			}
+			dataSize = stat.size;
+			return dataSize;
+		}
+
 		async getDataPath(dataPath) {
 			dataPath = trimStart(dataPath, '/')
 			log('dataPath', dataPath);
@@ -1203,7 +1222,7 @@ function getModule(app: IGeesomeApp) {
 				}
 
 				dataPath = this.prepareContentStoragePathResponse(res, dataPath, content);
-				const fileStat = await app.ms.storage.getFileStat(dataPath);
+				const fileStat = await getGatewayFileStat(dataPath);
 				log('getFileStat', fileStat);
 				if (!fileStat) {
 					return res.send(404);
@@ -1231,7 +1250,7 @@ function getModule(app: IGeesomeApp) {
 
 			const contentStoragePath = dataPath;
 			dataPath = this.prepareContentStorageDataPath(dataPath, content);
-			const dataSize = await this.getFileSize(dataPath, content);
+			const dataSize = await this.getGatewayFileSize(dataPath, content);
 			if (dataSize === null) {
 				return res.send(404);
 			}
@@ -1300,7 +1319,7 @@ function getModule(app: IGeesomeApp) {
 			}
 
 			dataPath = this.prepareContentStoragePathResponse(res, dataPath, content);
-			const fileStat = await app.ms.storage.getFileStat(dataPath);
+			const fileStat = await getGatewayFileStat(dataPath);
 			if (!fileStat) {
 				res.writeHead(404, {'Cross-Origin-Resource-Policy': 'cross-origin'});
 				return res.stream.end();

--- a/test/contentHeaders.test.ts
+++ b/test/contentHeaders.test.ts
@@ -73,6 +73,7 @@ describe("content headers", function () {
 	it("returns 404 for allowed HEAD paths missing from storage", async () => {
 		const writes: any = {};
 		let streamRequested = false;
+		let statOptions: any;
 		const content = await contentModule({
 			checkModules: () => null,
 			callHookCheckAllowed: async () => true,
@@ -82,7 +83,10 @@ describe("content headers", function () {
 					getSharedStorageMetadataByStorageId: async () => null
 				},
 				storage: {
-					getFileStat: async () => null,
+					getFileStat: async (_path, options) => {
+						statOptions = options;
+						return null;
+					},
 					getFileStream: async () => {
 						streamRequested = true;
 						return Readable.from(["unexpected"]);
@@ -108,6 +112,7 @@ describe("content headers", function () {
 		assert.equal(writes.headers["Cross-Origin-Resource-Policy"], "cross-origin");
 		assert.equal(writes.ended, true);
 		assert.equal(streamRequested, false);
+		assert.equal(statOptions.attempts, 0);
 	});
 
 	it("returns 423 for forbidden unknown HEAD storage paths before stat lookup", async () => {
@@ -341,6 +346,7 @@ describe("content headers", function () {
 
 	it("returns 404 for allowed storage paths missing from storage", async () => {
 		let streamRequested = false;
+		let statOptions: any;
 		const sends: any[] = [];
 		const content = await contentModule({
 			checkModules: () => null,
@@ -359,7 +365,10 @@ describe("content headers", function () {
 					getSharedStorageMetadataByStorageId: async () => null
 				},
 				storage: {
-					getFileStat: async () => null,
+					getFileStat: async (_path, options) => {
+						statOptions = options;
+						return null;
+					},
 					getFileStream: async () => {
 						streamRequested = true;
 						return Readable.from(["unexpected"]);
@@ -377,6 +386,7 @@ describe("content headers", function () {
 
 		assert.deepEqual(sends, [[404]]);
 		assert.equal(streamRequested, false);
+		assert.equal(statOptions.attempts, 0);
 	});
 
 	it("allows the app published docs storage root without a database content row", async () => {
@@ -496,6 +506,7 @@ describe("content headers", function () {
 
 	it("returns 404 for allowed ranged storage paths missing from storage", async () => {
 		let streamRequested = false;
+		let statOptions: any;
 		const sends: any[] = [];
 		const content = await contentModule({
 			checkModules: () => null,
@@ -514,7 +525,10 @@ describe("content headers", function () {
 					getSharedStorageMetadataByStorageId: async () => null
 				},
 				storage: {
-					getFileStat: async () => null,
+					getFileStat: async (_path, options) => {
+						statOptions = options;
+						return null;
+					},
 					getFileStream: async () => {
 						streamRequested = true;
 						return Readable.from(["unexpected"]);
@@ -532,6 +546,7 @@ describe("content headers", function () {
 
 		assert.deepEqual(sends, [[404]]);
 		assert.equal(streamRequested, false);
+		assert.equal(statOptions.attempts, 0);
 	});
 
 	it("returns 423 for forbidden unknown ranged storage paths before stat lookup", async () => {


### PR DESCRIPTION
## Summary

- Use no-retry storage stat calls for public content gateway GET, ranged GET, and HEAD serving paths.
- Keep normal content ingest/maintenance stat behavior unchanged.
- Add focused assertions that gateway stat calls pass `attempts: 0`, preventing delayed retry promises from surfacing after the route already handled a missing Kubo child link.

Closes #1078

## Verification

- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/contentHeaders.test.ts test/contentRouteErrors.test.ts test/apiHeaders.test.ts test/apiCallbackHandling.test.ts`
- `node --import tsx -e "await import('./app/modules/content/index.ts'); console.log('content import ok')"`
- `git diff --check`

## Full test note

- `yarn test` remains blocked in this local environment by PostgreSQL authentication for user `geesome`, then cascades into module initialization failures and a port collision on `7772` during existing app tests.
