### PR TITLE
[codex] Fix static site media filenames

### DIFF
--- a/app/modules/staticSiteGenerator/site/public/components/PostListItem/index.js
+++ b/app/modules/staticSiteGenerator/site/public/components/PostListItem/index.js
@@ -23,6 +23,12 @@ export default {
       return getRelativeRoot(this.$route.path) + 'content/';
     },
   },
+  methods: {
+    contentUrl(content) {
+      const extension = content.extension ? `.${content.extension}` : '';
+      return this.contentRoot + content.storageId + extension;
+    },
+  },
   template: `
     <article
         :key="post.key"
@@ -42,11 +48,11 @@ export default {
       <div v-if="postImages.length || postVideos.length">
         <!-- eslint-disable vue/no-v-html -->
         <div v-if="postImages.length">
-          <img :src="contentRoot + postImages[0].storageId" class="post-image">
+          <img :src="contentUrl(postImages[0])" class="post-image">
         </div>
         <div v-else-if="postVideos.length">
           <video controls>
-            <source :src="contentRoot + postVideos[0].storageId + '.mp4'" type="video/mp4">
+            <source :src="contentUrl(postVideos[0])" type="video/mp4">
             Your browser does not support the video tag.
           </video>
         </div>

--- a/app/modules/staticSiteGenerator/site/public/pages/Post/index.js
+++ b/app/modules/staticSiteGenerator/site/public/pages/Post/index.js
@@ -23,6 +23,12 @@ export default {
             return getRelativeRoot(this.$route.path) + 'content/';
         },
     },
+    methods: {
+        contentUrl(content) {
+            const extension = content.extension ? `.${content.extension}` : '';
+            return this.contentRoot + content.storageId + extension;
+        },
+    },
     template: `
       <layout>
       <template #page>
@@ -46,9 +52,9 @@ export default {
             <div class="post-page-content">
               <div v-for="c in post.contents">
                 <p v-if="c.type === 'text' && c.view === 'contents'" v-html="c.text"></p>
-                <img v-if="c.type === 'image'" :src="contentRoot + c.storageId">
+                <img v-if="c.type === 'image'" :src="contentUrl(c)">
                 <video v-if="c.type === 'video'" controls>
-                  <source :src="contentRoot + c.storageId + '.mp4'" type="video/mp4">
+                  <source :src="contentUrl(c)" type="video/mp4">
                   Your browser does not support the video tag.
                 </video>
               </div>

--- a/test/staticSiteGeneratorStreamingUnit.test.ts
+++ b/test/staticSiteGeneratorStreamingUnit.test.ts
@@ -23,6 +23,13 @@ describe('staticSiteGenerator streaming render state', function () {
 					view: 'contents',
 					text: 'streamed post body',
 					storageId: 'text-storage-id'
+				},
+				{
+					id: 2,
+					type: 'image',
+					view: 'media',
+					storageId: 'image-storage-id',
+					extension: 'png'
 				}
 			]
 		};
@@ -52,11 +59,13 @@ describe('staticSiteGenerator streaming render state', function () {
 			const indexHtml = await renderPage('/', headers);
 			assert.equal(indexHtml.includes('streamed intro'), true);
 			assert.equal(indexHtml.includes('./post/7/'), true);
+			assert.equal(indexHtml.includes('./content/image-storage-id.png'), true);
 
 			renderData.currentPosts = [];
 			renderData.currentPost = post;
 			const postHtml = await renderPage('/post/7', headers);
 			assert.equal(postHtml.includes('streamed post body'), true);
+			assert.equal(postHtml.includes('../../content/image-storage-id.png'), true);
 		} finally {
 			console.warn = originalWarn;
 		}


### PR DESCRIPTION
## Summary
- Fix generated group static-site media URLs to include the copied file extension.
- Use the same URL helper for post pages and post-list thumbnails.
- Add a lightweight SSR regression check for generated image URLs.
- Add a browser-shaped API regression test that preflights, uploads 20 async PNG files into one file-catalog folder, polls async operation results, and verifies the folder lists all 20 files.

## Root Cause
Group static-site rendering copied media into `content/<storageId>.<extension>`, but the generated Vue templates linked images as `content/<storageId>` and videos as `content/<storageId>.mp4`. Browsers then requested paths that were not present in the generated IPFS directory.

The production log check for the reported upload showed the backend accepted 10 `saveData` operations and did not log `Request_files_limit`, `Reach files limit`, `limit_reached`, `413`, or quota errors. The new test proves the server accepts more than 10 browser-style async image uploads when they actually reach `/v1/user/save-file`.

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/staticSiteGeneratorStreamingUnit.test.ts --exit -t 30000`
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/staticSiteGeneratorClientUnit.test.ts test/staticSiteGeneratorStreamingUnit.test.ts --exit -t 30000`
- `docker compose -f ./test/docker-compose.yml build test && docker compose -f ./test/docker-compose.yml run --rm test bash -lc 'npm run database:sync-models && npm run migrate-all-database && GROUP_DERIVED_STATE_ASYNC=0 GATEWAY_PORT=2083 PORT=7772 SSG_RUNTIME=1 DATA_DIR=test-data node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/fileCatalog.test.ts --grep "accepts more than ten" --exit -t 120000'`
- `npm run test:docker` reached 213 passing / 11 pending, but failed on 8 existing slow integration timeouts, including static-site/storage fixtures at their hardcoded 60s/30s limits.
