### PR TITLE
Allow owner auth on content metadata lookup

### DIFF
--- a/app/modules/content/api.ts
+++ b/app/modules/content/api.ts
@@ -9,6 +9,19 @@ const {pick} = _;
 const log = debug('geesome:content:api');
 
 export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
+    async function getOptionalAuthenticatedUserId(req) {
+        if (!req.token) {
+            return null;
+        }
+        try {
+            const {user} = await app.getUserByApiToken(req.token);
+            return user?.id || null;
+        } catch (e) {
+            log('optional content metadata auth failed', e?.message || e);
+            return null;
+        }
+    }
+
 
     /**
      * @api {post} /v1/user/save-file Save file
@@ -228,7 +241,7 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
 
     /**
      * @api {get} /v1/content/:contentId Get public-safe content metadata
-     * @apiDescription Numeric database ids are visible only for public content rows. Storage ids resolve through deterministic shared metadata and omit owner/library-only fields unless the selected row is public.
+     * @apiDescription Numeric database ids are visible only for public content rows unless the request includes a valid bearer token for the content owner. Storage ids resolve through deterministic shared metadata and omit owner/library-only fields unless the selected row is public.
      * @apiName ContentGet
      * @apiGroup Content
      *
@@ -241,14 +254,16 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
      * @apiSuccess {String} [largePreviewStorageId] Large preview storage id.
      * @apiSuccess {String} [mediumPreviewStorageId] Medium preview storage id.
      * @apiSuccess {String} [smallPreviewStorageId] Small preview storage id.
-     * @apiSuccess {Number} [id] Public content database id, only for public rows.
-     * @apiSuccess {String} [name] Public content name, only for public rows.
-     * @apiSuccess {String} [description] Public content description, only for public rows.
-     * @apiSuccess {String} [manifestStorageId] Public content manifest id, only for public rows.
+     * @apiHeader {String} [Authorization] Optional bearer API key. When present and valid for the content owner, private numeric database ids resolve to the owner's full content metadata for backward compatibility.
+     * @apiSuccess {Number} [id] Public content database id, or owner content database id when authorized.
+     * @apiSuccess {String} [name] Public content name, or owner content name when authorized.
+     * @apiSuccess {String} [description] Public content description, or owner content description when authorized.
+     * @apiSuccess {String} [manifestStorageId] Public content manifest id, or owner content manifest id when authorized.
      * @apiUse ValidationErrors
      */
     app.ms.api.onGet('content/:contentId', async (req, res) => {
-        res.send(await contentModule.getPublicContentMetadata(req.params.contentId));
+        const userId = await getOptionalAuthenticatedUserId(req);
+        res.send(await contentModule.getPublicContentMetadata(req.params.contentId, userId));
     });
 
     /**

--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -348,13 +348,20 @@ function getModule(app: IGeesomeApp) {
 			return app.ms.database.getContent(contentId);
 		}
 
-		async getPublicContentMetadata(contentId) {
+		async getPublicContentMetadata(contentId, userId?) {
 			if (isDatabaseContentId(contentId)) {
 				const content = await app.ms.database.getContent(contentId);
-				if (!content || !content.isPublic) {
+				if (!content) {
 					throw createContentNotFoundError();
 				}
-				return pickPublicContentMetadata(content);
+				const contentData = toContentPlainObject(content);
+				if (contentData.isPublic) {
+					return pickPublicContentMetadata(contentData);
+				}
+				if (helpers.hasId(userId) && Number(contentData.userId) === Number(userId)) {
+					return contentData;
+				}
+				throw createContentNotFoundError();
 			}
 
 			const content = await app.ms.database.getSharedStorageMetadataByStorageId(contentId, {includePreviews: true});

--- a/app/modules/content/interface.ts
+++ b/app/modules/content/interface.ts
@@ -16,7 +16,7 @@ export default interface IGeesomeContentModule {
 
 	getContent(contentId): Promise<IContent>;
 
-	getPublicContentMetadata(contentId): Promise<Partial<IContent>>;
+	getPublicContentMetadata(contentId, userId?): Promise<Partial<IContent>>;
 
 	getContentByStorageId(storageId): Promise<IContent>;
 

--- a/test/contentApiUnit.test.ts
+++ b/test/contentApiUnit.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import registerContentApi from '../app/modules/content/api.js';
 import {CorePermissionName} from '../app/modules/database/interface.js';
 
-function createContentApiHarness(contentModuleOverrides: any = {}) {
+function createContentApiHarness(contentModuleOverrides: any = {}, appOverrides: any = {}) {
 	const routes = {};
 	const permissionChecks = [];
 	const module = {
@@ -35,12 +35,15 @@ function createContentApiHarness(contentModuleOverrides: any = {}) {
 		checkUserCan: async (userId, permission) => {
 			permissionChecks.push({userId, permission});
 		},
+		getUserByApiToken: async () => ({user: null, apiKey: null}),
+		...appOverrides,
 	};
 	const contentModule = {
 		getDeletedContentList: async () => null,
 		getDeletedContentPurgeCandidates: async () => null,
 		purgeDeletedContentTombstones: async () => null,
 		restoreDeletedContent: async () => null,
+		getPublicContentMetadata: async () => null,
 		...contentModuleOverrides,
 	};
 
@@ -71,6 +74,53 @@ function createContentApiHarness(contentModuleOverrides: any = {}) {
 }
 
 describe('content admin API', function () {
+	it('passes optional bearer owner id to public content metadata route', async () => {
+		let contentCall;
+		let tokenCall;
+		const {call} = createContentApiHarness({
+			getPublicContentMetadata: async (...args) => {
+				contentCall = args;
+				return {id: 42};
+			},
+		}, {
+			getUserByApiToken: async (token) => {
+				tokenCall = token;
+				return {user: {id: 7}, apiKey: {id: 11, userId: 7}};
+			},
+		});
+
+		const response = await call('GET', 'content/:contentId', {
+			params: {contentId: '42'},
+			token: 'valid-token',
+		});
+
+		assert.equal(tokenCall, 'valid-token');
+		assert.deepEqual(contentCall, ['42', 7]);
+		assert.deepEqual(response, {id: 42});
+	});
+
+	it('ignores invalid optional bearer tokens on public content metadata route', async () => {
+		let contentCall;
+		const {call} = createContentApiHarness({
+			getPublicContentMetadata: async (...args) => {
+				contentCall = args;
+				return {storageId: 'public-storage'};
+			},
+		}, {
+			getUserByApiToken: async () => {
+				throw new Error('bad_token');
+			},
+		});
+
+		const response = await call('GET', 'content/:contentId', {
+			params: {contentId: 'public-storage'},
+			token: 'invalid-token',
+		});
+
+		assert.deepEqual(contentCall, ['public-storage', null]);
+		assert.deepEqual(response, {storageId: 'public-storage'});
+	});
+
 	it('requires AdminRead before listing deleted content tombstones', async () => {
 		let contentCall;
 		const {call, permissionChecks} = createContentApiHarness({

--- a/test/contentHeaders.test.ts
+++ b/test/contentHeaders.test.ts
@@ -220,6 +220,62 @@ describe("content headers", function () {
 		);
 	});
 
+	it("returns owner content rows by database id when optional auth user matches", async () => {
+		const content = await contentModule({
+			checkModules: () => null,
+			ms: {
+				api: getApiStub(),
+				database: {
+					getContent: async () => ({
+						id: 7,
+						userId: 12,
+						name: "private-name.txt",
+						description: "private description",
+						storageId: "private-storage",
+						mimeType: ContentMimeType.Text,
+						propertiesJson: "{\"private\":true}",
+						isPublic: false
+					})
+				},
+				storage: {}
+			}
+		} as unknown as IGeesomeApp);
+
+		const metadata: any = await content.getPublicContentMetadata("7", 12);
+
+		assert.equal(metadata.id, 7);
+		assert.equal(metadata.userId, 12);
+		assert.equal(metadata.name, "private-name.txt");
+		assert.equal(metadata.description, "private description");
+		assert.equal(metadata.storageId, "private-storage");
+		assert.equal(metadata.propertiesJson, "{\"private\":true}");
+	});
+
+	it("does not expose another user's private content by database id with optional auth", async () => {
+		const content = await contentModule({
+			checkModules: () => null,
+			ms: {
+				api: getApiStub(),
+				database: {
+					getContent: async () => ({
+						id: 7,
+						userId: 12,
+						name: "private-name.txt",
+						storageId: "private-storage",
+						mimeType: ContentMimeType.Text,
+						isPublic: false
+					})
+				},
+				storage: {}
+			}
+		} as unknown as IGeesomeApp);
+
+		await assert.rejects(
+			() => content.getPublicContentMetadata("7", 99),
+			(error: Error & {code?: number}) => error.message === "content_not_found" && error.code === 404
+		);
+	});
+
 	it("returns public-safe storage metadata without private library fields", async () => {
 		const content = await contentModule({
 			checkModules: () => null,


### PR DESCRIPTION
## Summary
- keep unauthenticated numeric /v1/content/:contentId lookups public-only
- allow the same route to return private content metadata when the bearer token belongs to the content owner
- ignore invalid optional bearer tokens so public metadata remains public-compatible
- document the optional auth behavior in the route apiDoc

## Verification
- node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/contentHeaders.test.ts test/contentApiUnit.test.ts --exit -t 30000
- npm run generate-docs
- npm run security:route-inventory:update
- npm run security:route-inventory