### PR TITLE
Build frontend dist before publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,sharing=locked \
     yarn -W --no-optional --frozen-lockfile --network-concurrency 1 \
     && npm rebuild youtube-dl
 
+RUN mkdir -p bash
+COPY bash/publish-frontend-dist.sh ./bash/publish-frontend-dist.sh
+RUN GEESOME_FRONTEND_PUBLISH_DIR=/tmp/geesome-frontend-build \
+    bash bash/publish-frontend-dist.sh \
+    && rm -rf /tmp/geesome-frontend-build
+
 COPY . .
 
 ENV STORAGE_MODULE=ipfs-http-client

--- a/bash/publish-frontend-dist.sh
+++ b/bash/publish-frontend-dist.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+UI_ROOT="${GEESOME_UI_ROOT:-/geesome-node/node_modules/@geesome/ui}"
+UI_DIST="${GEESOME_UI_DIST:-$UI_ROOT/dist}"
+PUBLISH_DIR="${GEESOME_FRONTEND_PUBLISH_DIR:-/geesome-node/frontend/docker-dist}"
+UI_NODE_VERSION="${GEESOME_UI_NODE_VERSION-18.20.8}"
+UI_NODE_MAX_OLD_SPACE_SIZE="${GEESOME_UI_NODE_MAX_OLD_SPACE_SIZE:-4096}"
+UI_PARCEL_WORKERS="${GEESOME_UI_PARCEL_WORKERS:-1}"
+
+setup_frontend_node() {
+  if [ -z "$UI_NODE_VERSION" ]; then
+    return
+  fi
+
+  local nvm_script="${NVM_DIR:-/usr/local/nvm}/nvm.sh"
+  if [ ! -s "$nvm_script" ]; then
+    echo "NVM not found at $nvm_script; building frontend with current Node $(node -v 2>/dev/null || echo unknown)"
+    return
+  fi
+
+  # shellcheck source=/dev/null
+  . "$nvm_script"
+  nvm install "$UI_NODE_VERSION"
+  nvm use "$UI_NODE_VERSION"
+
+  if ! command -v yarn >/dev/null 2>&1; then
+    npm i -g yarn@1.22.22
+  fi
+}
+
+build_frontend_dist() {
+  if [ -n "${GEESOME_UI_BUILD_COMMAND:-}" ]; then
+    eval "$GEESOME_UI_BUILD_COMMAND"
+    return
+  fi
+
+  YARN_IGNORE_ENGINES=1 yarn install --force --network-concurrency 1
+  rm -rf .parcel-cache ./dist
+  PARCEL_WORKERS="$UI_PARCEL_WORKERS" node "--max-old-space-size=$UI_NODE_MAX_OLD_SPACE_SIZE" \
+    ./node_modules/.bin/parcel build ./index.html --no-content-hash --no-optimize --dist-dir ./dist
+  node ./run-terser.js
+  cp package.json ./dist/
+}
+
+if [ -z "$PUBLISH_DIR" ] || [ "$PUBLISH_DIR" = "/" ]; then
+  echo "Refusing to publish frontend to an unsafe directory: '$PUBLISH_DIR'" >&2
+  exit 1
+fi
+
+if [ ! -d "$UI_ROOT" ]; then
+  echo "GeeSome UI package was not found at $UI_ROOT" >&2
+  exit 1
+fi
+
+if [ ! -f "$UI_DIST/index.html" ]; then
+  echo "GeeSome UI dist is missing; building frontend from $UI_ROOT..."
+  (
+    cd "$UI_ROOT"
+    setup_frontend_node
+    build_frontend_dist
+  )
+fi
+
+if [ ! -f "$UI_DIST/index.html" ]; then
+  echo "GeeSome UI build did not produce $UI_DIST/index.html" >&2
+  exit 1
+fi
+
+if grep -Eq 'src=["'\'']/src/main\.ts["'\'']' "$UI_DIST/index.html"; then
+  echo "Refusing to publish an unbuilt GeeSome UI index.html from $UI_DIST" >&2
+  exit 1
+fi
+
+mkdir -p "$PUBLISH_DIR"
+find "$PUBLISH_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+cp -R "$UI_DIST"/. "$PUBLISH_DIR"/
+
+if [ -e "$PUBLISH_DIR/src/main.ts" ] || [ -e "$PUBLISH_DIR/yarn.lock" ] || [ -e "$PUBLISH_DIR/tsconfig.json" ]; then
+  echo "Refusing to leave GeeSome UI source files in $PUBLISH_DIR" >&2
+  exit 1
+fi
+
+echo "Published GeeSome UI dist to $PUBLISH_DIR"

--- a/bash/ubuntu-init-swapfile.sh
+++ b/bash/ubuntu-init-swapfile.sh
@@ -1,10 +1,25 @@
 #!/bin/bash
 
-[ -z "$SIZE" ] && SIZE="8G"
+SIZE="${SIZE:-8G}"
 
-if [ -n "$(swapon --show)" ] || [ -f /swapfile ]; then
+ensure_swap_fstab() {
+  if ! grep -Eq '^[[:space:]]*/swapfile[[:space:]]+' /etc/fstab; then
+    echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab >/dev/null
+  fi
+}
+
+if [ -n "$(swapon --show)" ]; then
   echo "Swap is already initialized:"
   swapon --show
+  ensure_swap_fstab
+  exit 0
+fi
+
+if [ -f /swapfile ]; then
+  sudo chmod 600 /swapfile
+  sudo swapon /swapfile
+  sudo swapon --show
+  ensure_swap_fstab
   exit 0
 fi
 
@@ -13,3 +28,4 @@ sudo chmod 600 /swapfile
 sudo mkswap /swapfile
 sudo swapon /swapfile
 sudo swapon --show
+ensure_swap_fstab

--- a/bash/ubuntu-install-docker.sh
+++ b/bash/ubuntu-install-docker.sh
@@ -14,16 +14,16 @@ sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-
 
 sudo chmod +x /usr/local/bin/docker-compose
 
-# Low memory makes the yarn build corrupt its cache during extraction.
+# Low memory makes the yarn/frontend builds fail during extraction or bundling.
 # Analyze total available memory (RAM + swap) before the memory-heavy build.
 MEM_MB=$(free -m | awk '/^Mem:/{print $2}')
 SWAP_MB=$(free -m | awk '/^Swap:/{print $2}')
 TOTAL_MB=$((MEM_MB + SWAP_MB))
-MIN_MB=2048
+MIN_MB=8192
 if [ "$TOTAL_MB" -lt "$MIN_MB" ]; then
   echo "WARNING: only ${TOTAL_MB}MB total memory (RAM ${MEM_MB}MB + swap ${SWAP_MB}MB),"
-  echo "below the ${MIN_MB}MB recommended for the build. The 'docker compose build' yarn"
-  echo "step can run out of memory and fail with 'file appears to be corrupt' errors."
+  echo "below the ${MIN_MB}MB recommended for the build. The 'docker compose build'"
+  echo "step can run out of memory while installing dependencies or bundling the frontend."
   echo "Run 'sudo bash/ubuntu-init-swapfile.sh' first to add swap, then re-run this script."
 else
   echo "Memory OK: ${TOTAL_MB}MB total (RAM ${MEM_MB}MB + swap ${SWAP_MB}MB)."

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "yarn --no-optional -W && ./node_modules/.bin/tsx --experimental-global-customevent ./index.ts",
-    "in-docker-start": "cd /geesome-node && yarn --no-optional -W && mkdir -p /geesome-node/frontend/docker-dist && rm -rf /geesome-node/frontend/docker-dist/* && UI_DIST=/geesome-node/node_modules/@geesome/ui/dist; UI_ROOT=/geesome-node/node_modules/@geesome/ui; if [ -f \"$UI_DIST/index.html\" ]; then cp -R \"$UI_DIST\"/* /geesome-node/frontend/docker-dist/; else cp -R \"$UI_ROOT\"/* /geesome-node/frontend/docker-dist/; fi && npm run database:sync-models && npm run migrate-all-database && npm run start",
+    "in-docker-start": "cd /geesome-node && yarn --no-optional -W && bash bash/publish-frontend-dist.sh && npm run database:sync-models && npm run migrate-all-database && npm run start",
     "recreate-database": "dropdb geesome_node && createdb geesome_node",
     "recreate-test-database": "dropdb --if-exists geesome_test && createdb geesome_test",
     "migrate-all-database": "npm run migrate-database && npm run ssg-migrate-database && npm run sci-migrate-database && npm run group-migrate-database",
@@ -53,6 +53,7 @@
     "test:docker:cold": "bash bash/docker-test --cold",
     "test:docker:no-build": "bash bash/docker-test --no-build",
     "test:docker:run": "bash bash/docker-test-run.sh",
+    "test:frontend-dist-publish": "bash test/frontendDistPublish.test.sh",
     "testCoverage": "GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/nyc -r lcov -e .ts -x \"*.test.ts\" ./node_modules/.bin/mocha test/**/*.test.ts && nyc report",
     "docker": "STORAGE_STAGING=$PWD/.docker-data/ipfs-staging STORAGE_DATA=$PWD/.docker-data/ipfs GEESOME_DATA=$PWD/.docker-data/geesome-data GEESOME_FRONTEND_DIST=$PWD/.docker-data/geesome-frontend docker compose up",
     "docker-build": "bash/docker-build.sh",

--- a/test/frontendDistPublish.test.sh
+++ b/test/frontendDistPublish.test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+UI_ROOT="$TMP_DIR/ui"
+PUBLISH_DIR="$TMP_DIR/published"
+mkdir -p "$UI_ROOT/src" "$PUBLISH_DIR"
+
+cat > "$UI_ROOT/index.html" <<'HTML'
+<script type="module" src="/src/main.ts"></script>
+HTML
+cat > "$UI_ROOT/src/main.ts" <<'TS'
+window.__sourceEntryLoaded = true;
+TS
+cat > "$UI_ROOT/package.json" <<'JSON'
+{"name":"@geesome/ui-test"}
+JSON
+cat > "$UI_ROOT/yarn.lock" <<'YARN'
+# source marker
+YARN
+cat > "$UI_ROOT/tsconfig.json" <<'JSON'
+{}
+JSON
+cat > "$PUBLISH_DIR/stale.txt" <<'TXT'
+old
+TXT
+
+GEESOME_UI_ROOT="$UI_ROOT" \
+GEESOME_FRONTEND_PUBLISH_DIR="$PUBLISH_DIR" \
+GEESOME_UI_NODE_VERSION= \
+GEESOME_UI_BUILD_COMMAND='mkdir -p dist/assets && printf "%s\n" "<script type=\"module\" src=\"/assets/app.js\"></script>" > dist/index.html && printf "%s\n" "console.log(\"built\")" > dist/assets/app.js && cp package.json dist/package.json' \
+  bash "$ROOT_DIR/bash/publish-frontend-dist.sh"
+
+test -f "$PUBLISH_DIR/index.html"
+test -f "$PUBLISH_DIR/assets/app.js"
+test -f "$PUBLISH_DIR/package.json"
+test ! -e "$PUBLISH_DIR/stale.txt"
+test ! -e "$PUBLISH_DIR/src/main.ts"
+test ! -e "$PUBLISH_DIR/yarn.lock"
+test ! -e "$PUBLISH_DIR/tsconfig.json"
+! grep -q '/src/main.ts' "$PUBLISH_DIR/index.html"


### PR DESCRIPTION
## Summary
- build @geesome/ui dist before publishing the bundled client files
- publish only dist into the Nginx frontend bind mount instead of falling back to the package source root
- stop the upgrade script from chmod-mutating tracked shell files during deploy
- make the swap helper reactivate/persist an existing /swapfile and raise the new-install memory warning for frontend bundling

## Live repair
- rebuilt @geesome/ui on geesome.microwavedev.io with Node 18, one Parcel worker, and the existing 8G swapfile enabled
- republished /var/www/geesome-frontend from the built dist
- cleaned the test server worktree after the old deploy script flipped bash/publish-frontend-dist.sh executable locally

## Verification
- npm run test:frontend-dist-publish
- bash -n bash/publish-frontend-dist.sh test/frontendDistPublish.test.sh bash/ubuntu-init-swapfile.sh bash/ubuntu-install-docker.sh bash/docker-rebuild-and-upgrade.sh bash/docker-upgrade-run.sh
- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"
- docker compose config
- live curl: / returns 200 text/html, /index.4072ae5c.js returns application/javascript, /src/main.ts returns 404