### PR TITLE
Fix converted image metadata and preview bloat

### DIFF
--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -1010,6 +1010,7 @@ function getModule(app: IGeesomeApp) {
 		
 		private async saveFileByStream(stream, mimeType, options, properties, extension, onError, onSuccess) {
 			const {name: driverName, params: driverParams, module: driverModule} = this.getDriverNameAndParams(options);
+			const isConvertDriver = !!(driverName && driverModule === 'convert');
 
 			const storageOptions = {
 				waitForPin: options.waitForPin
@@ -1018,16 +1019,27 @@ function getModule(app: IGeesomeApp) {
 
 			const propertiesPromise = new Promise(async (resolve) => {
 				log('mimeType', mimeType);
-				if (startsWith(mimeType, 'image')) {
+				if (startsWith(mimeType, 'image') && !isConvertDriver) {
 					properties = await app.ms.drivers.metadata['image'].processByStream(stream, {onError});
 					// log('metadata processByStream', properties);
 				}
 				resolve();
 			});
 
-			if (driverName && driverModule === 'convert') {
-				const watermarkResult = await app.ms.drivers.convert[driverName].processByStream(stream, driverParams);
-				stream = watermarkResult.stream;
+			if (isConvertDriver) {
+				const convertResult = await app.ms.drivers.convert[driverName].processByStream(stream, {
+					...driverParams,
+					inputExtension: extension,
+					inputMimeType: mimeType,
+					onError
+				});
+				stream = convertResult.stream;
+				if (convertResult.type) {
+					mimeType = convertResult.type;
+				}
+				if (convertResult.extension) {
+					extension = convertResult.extension;
+				}
 			}
 
 			let resultFile: IStorageFile;
@@ -1086,6 +1098,15 @@ function getModule(app: IGeesomeApp) {
 			}
 
 			await propertiesPromise;
+			if (isConvertDriver && startsWith(mimeType, 'image')) {
+				let propertiesStream;
+				if (resultFile.tempPath) {
+					propertiesStream = fs.createReadStream(resultFile.tempPath);
+				} else {
+					propertiesStream = await this.getFileStream(resultFile.id);
+				}
+				properties = await app.ms.drivers.metadata['image'].processByStream(propertiesStream, {onError});
+			}
 
 			onSuccess({
 				resultFile: resultFile,

--- a/app/modules/drivers/convert/imageWatermark.ts
+++ b/app/modules/drivers/convert/imageWatermark.ts
@@ -10,6 +10,7 @@
 // process.env.FONTCONFIG_PATH = '';
 
 import debug from 'debug';
+import fs from "fs";
 import sharp from "sharp";
 import {Stream} from "stream";
 import {DriverInput, OutputSize} from "../interface.js";
@@ -23,7 +24,8 @@ export class ImageWatermarkDriver extends AbstractDriver {
 
   async processByStream(inputStream, options: any = {}) {
     log('ImagePreviewDriver.processByStream');
-    const path = await helpers.writeStreamToRandomPath(inputStream, options.extension)
+    const outputExtension = normalizeImageExtension(options.extension || 'jpg');
+    const path = await helpers.writeStreamToRandomPath(inputStream, options.inputExtension || options.extension || 'image')
     const metadata = await sharp(path).metadata();
 
     const {color, background, spacing, font, sizeRatio} = options;
@@ -55,19 +57,55 @@ export class ImageWatermarkDriver extends AbstractDriver {
         {input: {text}, left: size, top: metadata.height + padding},
       ])
       .withMetadata()
-      .toFormat(options.extension);
+      .toFormat(outputExtension);
 
-    const resultStream = inputStream.pipe(watermarkStream) as Stream;
+    const resultStream = watermarkStream as Stream;
+    const cleanup = once(() => fs.rm(path, {force: true}, () => {}));
 
     resultStream.on("error", (err) => {
+      cleanup();
+      if (isStreamAbortError(err)) {
+        return;
+      }
       console.error('ImageWatermarkDriver resultStream error', err);
       options.onError && options.onError(err);
     });
+    resultStream.on("end", cleanup);
+    resultStream.on("close", cleanup);
 
-    return {stream: resultStream};
+    return {
+      stream: resultStream,
+      type: getImageMimeType(outputExtension),
+      extension: outputExtension
+    };
   }
 }
 
-function r(number) {
-  return Math.round(number);
+function normalizeImageExtension(extension) {
+  if (extension === 'jpeg') {
+    return 'jpg';
+  }
+  return extension;
+}
+
+function getImageMimeType(extension) {
+  if (extension === 'jpg') {
+    return 'image/jpeg';
+  }
+  return 'image/' + extension;
+}
+
+function once(callback) {
+  let called = false;
+  return () => {
+    if (called) {
+      return;
+    }
+    called = true;
+    callback();
+  };
+}
+
+function isStreamAbortError(error) {
+  return error?.code === 'ABORT_ERR';
 }

--- a/app/modules/drivers/preview/image.ts
+++ b/app/modules/drivers/preview/image.ts
@@ -22,7 +22,7 @@ export class ImagePreviewDriver extends AbstractDriver {
 
   async processByStream(inputStream, options: any = {}) {
     log('ImagePreviewDriver.processByStream');
-    const extension = options.extension || 'jpg';
+    const extension = normalizeImageExtension(options.extension || 'jpg');
 
     // TODO: get size by settings
     let size = {width: 1024};
@@ -47,8 +47,22 @@ export class ImagePreviewDriver extends AbstractDriver {
 
     return {
       stream: resultStream,
-      type: 'image/' + extension,
+      type: getImageMimeType(extension),
       extension: extension
     };
   }
+}
+
+function normalizeImageExtension(extension) {
+  if (extension === 'jpeg') {
+    return 'jpg';
+  }
+  return extension;
+}
+
+function getImageMimeType(extension) {
+  if (extension === 'jpg') {
+    return 'image/jpeg';
+  }
+  return 'image/' + extension;
 }

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -403,6 +403,44 @@ describe("app", function () {
 		assert.equal(ipfsHelper.isIpfsHash(contentObj.preview.medium.storageId), true);
 	});
 
+	it('should save converted image metadata using the converted format', async () => {
+		const testUser = (await app.ms.database.getAllUserList('user'))[0];
+		const testGroup = (await app.ms.group.getAllGroupList(admin.id, 'test').then(r => r.list))[0];
+
+		app.ms.storage.isStreamAddSupport = () => {
+			return false;
+		};
+
+		const pngImagePath = await resourcesHelper.prepare('input-image.png');
+		const imageContent = await app.ms.content.saveData(testUser.id, fs.createReadStream(pngImagePath), 'input-image.png', {
+			groupId: testGroup.id,
+			waitForPin: true,
+			driver: JSON.stringify({
+				name: 'imageWatermark',
+				module: 'convert',
+				params: {
+					text: 'test.com',
+					color: 'black',
+					background: '#ffffff80',
+					font: 'monospace',
+					spacing: 50,
+					sizeRatio: 1 / 50,
+					extension: 'jpg'
+				}
+			})
+		});
+
+		const properties = JSON.parse(imageContent.propertiesJson);
+		const contentObj = await app.ms.storage.getObject(imageContent.manifestStorageId);
+
+		assert.equal(imageContent.mimeType, 'image/jpeg');
+		assert.equal(imageContent.extension, 'jpg');
+		assert.equal(properties.format, 'jpeg');
+		assert.equal(contentObj.mimeType, 'image/jpeg');
+		assert.equal(contentObj.preview.medium.mimeType, 'image/jpeg');
+		assert.equal(imageContent.previewExtension, 'jpg');
+	});
+
 	it('should correctly save video', async () => {
 		const testUser = (await app.ms.database.getAllUserList('user'))[0];
 		const testGroup = (await app.ms.group.getAllGroupList(admin.id, 'test').then(r => r.list))[0];

--- a/test/drivers.test.ts
+++ b/test/drivers.test.ts
@@ -58,6 +58,8 @@ describe("drivers", function () {
         extension: 'jpg'
       });
       // console.log('result', result);
+      assert.equal(result.type, 'image/jpeg');
+      assert.equal(result.extension, 'jpg');
 
       const ouputStreamablePath = resourcesHelper.getOutputDir() + '/output-image.jpg';
       await new Promise(async (resolve, reject) => {


### PR DESCRIPTION
## Summary

- Propagate convert-driver output MIME/extension through content save so watermarked JPEG uploads are stored as JPEG content.
- Generate image previews with the converted JPEG extension instead of re-encoding converted uploads as PNG.
- Read converted image metadata from the stored converted bytes and add regression coverage.

Closes #1091

## Verification

- `npm run test:docker` (226 passing, 11 pending)
- Direct 103-image set estimate: 294.4 MiB source PNGs, 22.3 MiB converted JPEG originals, about 67.8 MiB total with JPEG previews.
