### PR TITLE
Prepare ActivityPub unversioned inbox posts

### DIFF
--- a/app/modules/api/index.ts
+++ b/app/modules/api/index.ts
@@ -37,7 +37,11 @@ async function getModule(app: IGeesomeApp, version, port) {
 
 	const maxBodySizeMb = 2000;
 	service.use(express.static('frontend/dist'));
-	service.use(bodyParser.json({limit: maxBodySizeMb + 'mb'}));
+	service.use(bodyParser.json({
+		limit: maxBodySizeMb + 'mb',
+		type: ['application/json', 'application/*+json'],
+		verify: captureRawBody
+	}));
 	service.use(bodyParser.urlencoded({extended: true}));
 	service.use(bearerToken());
 	if (helpers.isAccessLogEnabled()) {
@@ -123,6 +127,12 @@ async function getModule(app: IGeesomeApp, version, port) {
 			service.get(`/${routeName}`, (req, res) => this.handleCallback(req, res, callback));
 		}
 
+		onUnversionPost(routeName: string, callback: (req: IApiModulePotInput, res: IApiModuleCommonOutput) => any) {
+			routeName = trimStart(routeName, '/');
+			trackRoute('POST', `/${routeName}`);
+			service.post(`/${routeName}`, (req, res) => this.handleCallback(req, res, callback));
+		}
+
 		onPost(routeName: string, callback: (req: IApiModulePotInput, res: IApiModuleCommonOutput) => any) {
 			routeName = trimStart(routeName, '/');
 			trackRoute('POST', `/${version}/${routeName}`);
@@ -192,11 +202,20 @@ async function getModule(app: IGeesomeApp, version, port) {
 				onGet: (routeName: string, callback: (req: IApiModuleGetInput, res: IApiModuleCommonOutput) => any) => {
 					return this.onGet(routePrefix + routeName, callback);
 				},
+				onUnversionGet: (routeName: string, callback: (req: IApiModuleGetInput, res: IApiModuleCommonOutput) => any) => {
+					return this.onUnversionGet(routePrefix + routeName, callback);
+				},
 				onPost: (routeName: string, callback: (req: IApiModuleGetInput, res: IApiModuleCommonOutput) => any) => {
 					return this.onPost(routePrefix + routeName, callback);
 				},
+				onUnversionPost: (routeName: string, callback: (req: IApiModulePotInput, res: IApiModuleCommonOutput) => any) => {
+					return this.onUnversionPost(routePrefix + routeName, callback);
+				},
 				onHead: (routeName: string, callback: (req: IApiModuleGetInput, res: IApiModuleCommonOutput) => any) => {
 					return this.onHead(routePrefix + routeName, callback);
+				},
+				onUnversionHead: (routeName: string, callback: (req: IApiModuleGetInput, res: IApiModuleCommonOutput) => any) => {
+					return this.onUnversionHead(routePrefix + routeName, callback);
 				},
 				onAuthorizedGet: (routeName: string, callback: (req: IApiModuleGetInput, res: IApiModuleCommonOutput) => any) => {
 					return this.onAuthorizedGet(routePrefix + routeName, callback);
@@ -247,6 +266,9 @@ async function getModule(app: IGeesomeApp, version, port) {
 		if (req.body) {
 			input['body'] = req.body;
 		}
+		if (req.rawBody) {
+			input['rawBody'] = req.rawBody;
+		}
 		return input;
 	}
 
@@ -264,6 +286,26 @@ async function getModule(app: IGeesomeApp, version, port) {
 
 	function isResponseClosed(res) {
 		return res.headersSent || res.writableEnded || res.stream?.headersSent || res.stream?.writableEnded;
+	}
+
+	function captureRawBody(req, _res, buf) {
+		if (!shouldCaptureRawBody(req)) {
+			return;
+		}
+		req.rawBody = buf;
+	}
+
+	function shouldCaptureRawBody(req) {
+		const method = String(req.method || '').toUpperCase();
+		if (method !== 'POST') {
+			return false;
+		}
+		const url = String(req.originalUrl || req.url || '');
+		const path = url.split('?')[0];
+		if (path.startsWith('/ap/')) {
+			return true;
+		}
+		return Boolean(req.headers?.signature || req.headers?.digest || req.headers?.['content-digest']);
 	}
 
 	const apiModule = new GeesomeApiModule(port);

--- a/app/modules/api/interface.ts
+++ b/app/modules/api/interface.ts
@@ -8,6 +8,8 @@ export default interface IGeesomeApiModule {
 
 	onUnversionGet(routeName: string, callback: (IApiModuleGetInput, IApiModuleCommonOutput) => any): any;
 
+	onUnversionPost(routeName: string, callback: (IApiModulePotInput, IApiModuleCommonOutput) => any): any;
+
 	onHead(routeName: string, callback: (IApiModuleGetInput, IApiModuleCommonOutput) => any): any;
 
 	onUnversionHead(routeName: string, callback: (IApiModuleGetInput, IApiModuleCommonOutput) => any): any;
@@ -49,6 +51,7 @@ export interface IApiModuleCommonInput {
 	user?: IUser;
 	apiKey?: IUserApiKey;
 	query?: any;
+	rawBody?: Buffer;
 	stream: Stream;
 }
 

--- a/docs/activitypub-research.md
+++ b/docs/activitypub-research.md
@@ -205,19 +205,19 @@ Do not federate directly from the existing public `group/:groupId/posts` endpoin
 
 ### API Layer Changes Needed
 
-The current API wrapper in `app/modules/api/index.ts` supports:
+The API wrapper in `app/modules/api/index.ts` supports:
 
 - versioned GET/POST/HEAD through `/v1/...`
-- unversioned GET/HEAD through `/...`
+- unversioned GET/POST/HEAD through `/...`
 
 ActivityPub needs unversioned POST for actor inbox and shared inbox routes:
 
 - `POST /ap/groups/:groupName/inbox`
 - `POST /ap/shared-inbox`
 
-So add `onUnversionPost()` to `IGeesomeApiModule`, implement it in `app/modules/api/index.ts`, and expose it through `prefix()` if useful.
+`IGeesomeApiModule.onUnversionPost()` is available for these routes and through `prefix()`.
 
-Signed POST verification also needs the raw request body to verify `Digest`/`Content-Digest`. The current global `bodyParser.json()` consumes JSON before modules see the stream. Add raw-body capture in the JSON parser `verify` option, e.g. attach `req.rawBody = buf`, then include `rawBody` in `reqToModuleInput()`. Without this, inbound HTTP signature verification will be fragile or impossible.
+Signed POST verification needs the raw request body to verify `Digest`/`Content-Digest`. The JSON parser now accepts `application/*+json` payloads and captures raw request bytes for signed/protocol-style JSON posts such as `/ap/*`, exposing them as `req.rawBody` on module inputs. Future ActivityPub inbox code should use that exact buffer for HTTP digest/signature verification instead of serializing the parsed body again.
 
 ActivityPub responses should set:
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -325,18 +325,20 @@ Goal: make GeeSome groups/posts visible and interoperable through ActivityPub wi
 
 This is an important protocol-facing feature, not only a generic integration. The first delivery should define a minimal compatible ActivityPub surface before implementing broad Mastodon-style behavior.
 
+Status: first API prerequisite slice landed. The API module now supports unversioned JSON `POST` handlers, accepts `application/*+json` payloads, and exposes captured raw JSON bytes for signed/protocol-style posts such as future ActivityPub inbox/shared-inbox routes. Next slices should add explicit ActivityPub config, local actor URL helpers, and read-only WebFinger/actor/outbox serializers before accepting inbound federation activities.
+
 Research note: [activitypub-research.md](./activitypub-research.md).
 
 Scope:
 
 - Map GeeSome identities/groups to ActivityPub actors.
 - Expose WebFinger discovery for local actors.
-- Add actor, outbox, inbox, followers, and following endpoints.
+- Add actor, outbox, inbox, followers, and following endpoints. The API layer can now register unversioned POST inbox routes; no ActivityPub route is exposed until the dedicated module lands.
 - Represent published group posts as ActivityPub `Create` activities with `Note`/attachment objects and stable GeeSome/IPFS links.
-- Verify HTTP signatures for inbound activities and sign outbound activities.
+- Verify HTTP signatures for inbound activities and sign outbound activities. Raw JSON request bytes are now available to route callbacks for future digest/signature checks.
 - Store inbound follows/accepts and minimal remote actor metadata.
 - Keep moderation, deletes/updates, rich media federation, and full timeline syncing for later slices.
-- Decide whether to adopt Fedify. Current Fedify 2.2.0 covers WebFinger, ActivityStreams vocabulary, HTTP Signatures, HTTP Message Signatures, testing, and Express integration, but declares Node `>=22`; this repo currently declares Node `>=18`.
+- Decide whether to adopt Fedify or keep a minimal custom module. The repo now targets Node 22, so the earlier Node-floor concern is gone; the remaining decision is dependency weight, integration shape, and whether Fedify's helpers fit GeeSome's IPFS/IPNS-first identity model.
 
 Likely modules:
 

--- a/test/apiUnversionPost.test.ts
+++ b/test/apiUnversionPost.test.ts
@@ -1,0 +1,101 @@
+import assert from 'assert';
+import http from 'node:http';
+import net from 'node:net';
+import apiModule from '../app/modules/api/index.js';
+import {IGeesomeApp} from '../app/interface.js';
+
+describe('api unversioned POST routes', function () {
+	this.timeout(10000);
+
+	it('exposes unversioned JSON POST handlers with the raw body', async () => {
+		const port = await getAvailablePort();
+		const previousPort = process.env.PORT;
+		let api;
+		let handlerInput: any;
+		delete process.env.PORT;
+
+		try {
+			api = await apiModule(getAppStub(port));
+			api.onUnversionPost('ap/shared-inbox', async (req, res) => {
+				handlerInput = req;
+				res.stream.status(202).send({ok: true});
+			});
+
+			const body = '{"type":"Follow","actor":"https://remote.example/users/alice"}';
+			const response = await requestPostJson(port, '/ap/shared-inbox', body, 'application/activity+json');
+
+			assert.equal(response.statusCode, 202);
+			assert.deepEqual(JSON.parse(response.body), {ok: true});
+			assert.deepEqual(handlerInput.body, {
+				type: 'Follow',
+				actor: 'https://remote.example/users/alice'
+			});
+			assert.equal(Buffer.isBuffer(handlerInput.rawBody), true);
+			assert.equal(handlerInput.rawBody.toString('utf8'), body);
+		} finally {
+			restorePort(previousPort);
+			api?.stop();
+		}
+	});
+});
+
+async function getAvailablePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.on('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			const port = typeof address === 'object' && address ? address.port : 0;
+			server.close(() => resolve(port));
+		});
+	});
+}
+
+function getAppStub(port: number): IGeesomeApp {
+	return {
+		config: {port},
+		ms: {
+			database: {getUsersCount: async () => 0},
+			storage: {remoteNodeAddressList: async () => []},
+			communicator: {nodeAddressList: async () => []}
+		}
+	} as unknown as IGeesomeApp;
+}
+
+function requestPostJson(port: number, path: string, body: string, contentType = 'application/json'): Promise<any> {
+	return new Promise((resolve, reject) => {
+		const req = http.request({
+			host: '127.0.0.1',
+			port,
+			path,
+			method: 'POST',
+			headers: {
+				'content-type': contentType,
+				'content-length': Buffer.byteLength(body)
+			}
+		}, (res) => {
+			let responseBody = '';
+			res.setEncoding('utf8');
+			res.on('data', (chunk) => {
+				responseBody += chunk;
+			});
+			res.on('end', () => {
+				resolve({
+					statusCode: res.statusCode,
+					body: responseBody
+				});
+			});
+		});
+		req.on('error', reject);
+		req.write(body);
+		req.end();
+	});
+}
+
+function restorePort(previousPort) {
+	if (previousPort === undefined) {
+		delete process.env.PORT;
+		return;
+	}
+	process.env.PORT = previousPort;
+}


### PR DESCRIPTION
## Summary

- Add `onUnversionPost()` to the API module and prefix wrapper so future ActivityPub inbox/shared-inbox routes can live outside `/v1`.
- Parse `application/*+json` bodies and expose `req.rawBody` for signed/protocol-style JSON POSTs such as `/ap/*` without retaining raw buffers for every JSON request.
- Update the ActivityPub TODO/research notes to mark this API prerequisite as landed and correct the stale Node 18/Fedify note.

## Validation

- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/apiUnversionPost.test.ts test/apiCallbackHandling.test.ts test/apiHeaders.test.ts --exit -t 10000`
- `npm run security:route-inventory:update`
- `npm run security:route-inventory`
- `git diff --check`

Not run: `npm run test:docker` (focused API prerequisite slice).
