### PR TITLE
Add ActivityPub public URL helpers

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -29,5 +29,10 @@ export default {
     },
     goNode: {url: process.env.STORAGE_URL || 'http://127.0.0.1:5001'}
   },
+  activityPubConfig: {
+    enabled: process.env.ACTIVITYPUB_ENABLED === '1',
+    publicUrl: process.env.ACTIVITYPUB_PUBLIC_URL || '',
+    domain: process.env.ACTIVITYPUB_DOMAIN || ''
+  },
   modules: process.env.MODULES ? process.env.MODULES.split(',') : modulePacks.main.concat(modulePacks.improve).concat(modulePacks.socNet)
 };

--- a/app/modules/activityPub/helpers.ts
+++ b/app/modules/activityPub/helpers.ts
@@ -1,0 +1,140 @@
+import helpers from '../../helpers.js';
+import type {
+	IActivityPubConfig,
+	IActivityPubGroupActorUrls,
+	IActivityPubGroupInput,
+	IActivityPubWebFingerResponse,
+	IResolvedActivityPubConfig
+} from './interface.js';
+
+export function resolveActivityPubConfig(config: IActivityPubConfig = {}): IResolvedActivityPubConfig {
+	const parsedPublicUrl = parseActivityPubPublicUrl(config.publicUrl);
+
+	return {
+		enabled: isActivityPubEnabled(config),
+		publicUrl: getActivityPubPublicUrl(parsedPublicUrl),
+		domain: getActivityPubDomain(config.domain, parsedPublicUrl)
+	};
+}
+
+export function getActivityPubGroupPreferredUsername(group: IActivityPubGroupInput): string {
+	const name = typeof group === 'string' ? group : group?.name;
+	const preferredUsername = String(name || '').trim();
+	if (!preferredUsername) {
+		throw new Error('activitypub_group_name_required');
+	}
+	if (!helpers.validateUsername(preferredUsername)) {
+		throw new Error('activitypub_group_name_invalid');
+	}
+	return preferredUsername;
+}
+
+export function getActivityPubGroupActorUrls(config: IActivityPubConfig, group: IActivityPubGroupInput): IActivityPubGroupActorUrls {
+	const resolvedConfig = resolveActivityPubConfig(config);
+	const actorUrl = `${resolvedConfig.publicUrl}/ap/groups/${encodeActivityPubPathSegment(getActivityPubGroupPreferredUsername(group))}`;
+
+	return {
+		actorUrl,
+		inboxUrl: `${actorUrl}/inbox`,
+		outboxUrl: `${actorUrl}/outbox`,
+		followersUrl: `${actorUrl}/followers`,
+		followingUrl: `${actorUrl}/following`,
+		sharedInboxUrl: getActivityPubSharedInboxUrl(resolvedConfig)
+	};
+}
+
+export function getActivityPubGroupPostObjectUrl(config: IActivityPubConfig, group: IActivityPubGroupInput, localId: number | string): string {
+	const resolvedConfig = resolveActivityPubConfig(config);
+	const postLocalId = normalizeActivityPubPostLocalId(localId);
+	const preferredUsername = getActivityPubGroupPreferredUsername(group);
+
+	return `${resolvedConfig.publicUrl}/ap/groups/${encodeActivityPubPathSegment(preferredUsername)}/posts/${postLocalId}`;
+}
+
+export function getActivityPubWebFingerResource(config: IActivityPubConfig, group: IActivityPubGroupInput): string {
+	const resolvedConfig = resolveActivityPubConfig(config);
+	return `acct:${getActivityPubGroupPreferredUsername(group)}@${resolvedConfig.domain}`;
+}
+
+export function getActivityPubWebFingerUrl(config: IActivityPubConfig, group: IActivityPubGroupInput): string {
+	const resolvedConfig = resolveActivityPubConfig(config);
+	const resource = getActivityPubWebFingerResource(resolvedConfig, group);
+
+	return `${resolvedConfig.publicUrl}/.well-known/webfinger?resource=${encodeURIComponent(resource)}`;
+}
+
+export function buildActivityPubGroupWebFingerResponse(config: IActivityPubConfig, group: IActivityPubGroupInput): IActivityPubWebFingerResponse {
+	const urls = getActivityPubGroupActorUrls(config, group);
+	const subject = getActivityPubWebFingerResource(config, group);
+
+	return {
+		subject,
+		aliases: [urls.actorUrl],
+		links: [
+			{
+				rel: 'self',
+				type: 'application/activity+json',
+				href: urls.actorUrl
+			}
+		]
+	};
+}
+
+export function isActivityPubEnabled(config: IActivityPubConfig): boolean {
+	return config.enabled === true || config.enabled === '1' || config.enabled === 'true';
+}
+
+function parseActivityPubPublicUrl(publicUrl) {
+	const rawPublicUrl = String(publicUrl || '').trim();
+	if (!rawPublicUrl) {
+		throw new Error('activitypub_public_url_required');
+	}
+	try {
+		const parsedUrl = new URL(rawPublicUrl);
+		if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+			throw new Error('activitypub_public_url_protocol_invalid');
+		}
+		parsedUrl.search = '';
+		parsedUrl.hash = '';
+		return parsedUrl;
+	} catch (e) {
+		if (e?.message === 'activitypub_public_url_protocol_invalid') {
+			throw e;
+		}
+		throw new Error('activitypub_public_url_invalid');
+	}
+}
+
+function getActivityPubPublicUrl(parsedPublicUrl: URL): string {
+	const normalizedPath = parsedPublicUrl.pathname === '/'
+		? ''
+		: parsedPublicUrl.pathname.replace(/\/+$/, '');
+	return `${parsedPublicUrl.origin}${normalizedPath}`;
+}
+
+function getActivityPubDomain(configDomain, parsedPublicUrl: URL): string {
+	const domain = String(configDomain || '').trim();
+	if (!domain) {
+		return parsedPublicUrl.host.toLowerCase();
+	}
+	if (domain.includes('://')) {
+		return new URL(domain).host.toLowerCase();
+	}
+	return domain.replace(/^@/, '').replace(/\/+$/, '').toLowerCase();
+}
+
+function getActivityPubSharedInboxUrl(config: IResolvedActivityPubConfig): string {
+	return `${config.publicUrl}/ap/shared-inbox`;
+}
+
+function normalizeActivityPubPostLocalId(localId: number | string): string {
+	const postLocalId = Number(localId);
+	if (!Number.isInteger(postLocalId) || postLocalId <= 0) {
+		throw new Error('activitypub_post_local_id_invalid');
+	}
+	return String(postLocalId);
+}
+
+function encodeActivityPubPathSegment(value: string): string {
+	return encodeURIComponent(value);
+}

--- a/app/modules/activityPub/interface.ts
+++ b/app/modules/activityPub/interface.ts
@@ -1,0 +1,36 @@
+import type {IGroup} from '../group/interface.js';
+
+export interface IActivityPubConfig {
+	enabled?: boolean | string;
+	publicUrl?: string;
+	domain?: string;
+}
+
+export interface IResolvedActivityPubConfig {
+	enabled: boolean;
+	publicUrl: string;
+	domain: string;
+}
+
+export interface IActivityPubGroupActorUrls {
+	actorUrl: string;
+	inboxUrl: string;
+	outboxUrl: string;
+	followersUrl: string;
+	followingUrl: string;
+	sharedInboxUrl: string;
+}
+
+export interface IActivityPubWebFingerLink {
+	rel: string;
+	type?: string;
+	href: string;
+}
+
+export interface IActivityPubWebFingerResponse {
+	subject: string;
+	aliases: string[];
+	links: IActivityPubWebFingerLink[];
+}
+
+export type IActivityPubGroupInput = IGroup | string;

--- a/docs/activitypub-research.md
+++ b/docs/activitypub-research.md
@@ -98,6 +98,8 @@ Suggested WebFinger:
 - `/.well-known/webfinger?resource=acct:{groupName}@{nodeDomain}`
 - Return `application/activity+json` self link to the actor URL.
 
+Implementation status: the first config/helper slice added explicit `activityPubConfig.enabled`, `activityPubConfig.publicUrl`, and `activityPubConfig.domain` values, sourced from `ACTIVITYPUB_ENABLED`, `ACTIVITYPUB_PUBLIC_URL`, and `ACTIVITYPUB_DOMAIN`. The helper layer normalizes the public URL, derives the domain from it when needed, and builds group actor, inbox/outbox/followers/following, shared-inbox, post-object, WebFinger resource, WebFinger URL, and WebFinger response data. It requires the group name to pass GeeSome username validation before producing an `acct:` handle.
+
 ## Post Mapping
 
 GeeSome public post to ActivityPub:
@@ -327,7 +329,7 @@ Recommendation: create a short Fedify spike before implementation. If Node 22 is
 - Decide whether the ActivityPub actor is `Group`, `Service`, or compatibility `Person`.
 - Decide whether runtime can move to Node 22 for Fedify.
 - Define database records for actor keypairs, remote actors, follows, and delivery attempts.
-- Document exact public URL shape.
+- Document exact public URL shape. Status: group actor and post-object URL helpers now pin the `/ap/groups/{groupName}` and `/ap/groups/{groupName}/posts/{localId}` shapes, plus WebFinger `acct:{groupName}@{domain}` resources. The remaining design decision is whether later route/signature implementation uses Fedify or the minimal custom module.
 
 ### Slice 1: Discovery And Read-Only Federation
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -325,14 +325,14 @@ Goal: make GeeSome groups/posts visible and interoperable through ActivityPub wi
 
 This is an important protocol-facing feature, not only a generic integration. The first delivery should define a minimal compatible ActivityPub surface before implementing broad Mastodon-style behavior.
 
-Status: first API prerequisite slice landed. The API module now supports unversioned JSON `POST` handlers, accepts `application/*+json` payloads, and exposes captured raw JSON bytes for signed/protocol-style posts such as future ActivityPub inbox/shared-inbox routes. Next slices should add explicit ActivityPub config, local actor URL helpers, and read-only WebFinger/actor/outbox serializers before accepting inbound federation activities.
+Status: first API prerequisite and public identity helper slices landed. The API module now supports unversioned JSON `POST` handlers, accepts `application/*+json` payloads, and exposes captured raw JSON bytes for signed/protocol-style posts such as future ActivityPub inbox/shared-inbox routes. ActivityPub config now has explicit `enabled`, `publicUrl`, and `domain` fields sourced from `ACTIVITYPUB_*` env vars, and deterministic helpers build group actor, inbox/outbox/followers/following, shared-inbox, post-object, and WebFinger URLs. Next slices should add read-only WebFinger/actor/outbox serializers and routes before accepting inbound federation activities.
 
 Research note: [activitypub-research.md](./activitypub-research.md).
 
 Scope:
 
-- Map GeeSome identities/groups to ActivityPub actors.
-- Expose WebFinger discovery for local actors.
+- Map GeeSome identities/groups to ActivityPub actors. Group actor URL helpers now use `/ap/groups/{groupName}` and require GeeSome-valid group names so WebFinger `acct:` handles stay valid.
+- Expose WebFinger discovery for local actors. WebFinger resource/URL/response helpers exist; the route still needs the dedicated ActivityPub module.
 - Add actor, outbox, inbox, followers, and following endpoints. The API layer can now register unversioned POST inbox routes; no ActivityPub route is exposed until the dedicated module lands.
 - Represent published group posts as ActivityPub `Create` activities with `Note`/attachment objects and stable GeeSome/IPFS links.
 - Verify HTTP signatures for inbound activities and sign outbound activities. Raw JSON request bytes are now available to route callbacks for future digest/signature checks.

--- a/test/activityPubHelpers.test.ts
+++ b/test/activityPubHelpers.test.ts
@@ -1,0 +1,90 @@
+import assert from 'assert';
+import {
+	buildActivityPubGroupWebFingerResponse,
+	getActivityPubGroupActorUrls,
+	getActivityPubGroupPostObjectUrl,
+	getActivityPubWebFingerResource,
+	getActivityPubWebFingerUrl,
+	isActivityPubEnabled,
+	resolveActivityPubConfig
+} from '../app/modules/activityPub/helpers.js';
+
+describe('activityPub helpers', () => {
+	it('normalizes explicit public URL config without deriving internal node URLs', () => {
+		const config = resolveActivityPubConfig({
+			enabled: '1',
+			publicUrl: 'https://node.example.com:8443/geesome/?debug=1#fragment'
+		});
+
+		assert.deepEqual(config, {
+			enabled: true,
+			publicUrl: 'https://node.example.com:8443/geesome',
+			domain: 'node.example.com:8443'
+		});
+		assert.equal(isActivityPubEnabled({enabled: true}), true);
+		assert.equal(isActivityPubEnabled({enabled: false}), false);
+	});
+
+	it('builds stable group actor and collection URLs', () => {
+		const urls = getActivityPubGroupActorUrls(getConfig(), {name: 'test-channel'} as any);
+
+		assert.deepEqual(urls, {
+			actorUrl: 'https://social.example/ap/groups/test-channel',
+			inboxUrl: 'https://social.example/ap/groups/test-channel/inbox',
+			outboxUrl: 'https://social.example/ap/groups/test-channel/outbox',
+			followersUrl: 'https://social.example/ap/groups/test-channel/followers',
+			followingUrl: 'https://social.example/ap/groups/test-channel/following',
+			sharedInboxUrl: 'https://social.example/ap/shared-inbox'
+		});
+	});
+
+	it('builds WebFinger resource and response data for a group actor', () => {
+		const config = getConfig();
+		const group = {name: 'test-channel'} as any;
+
+		assert.equal(getActivityPubWebFingerResource(config, group), 'acct:test-channel@example.com');
+		assert.equal(
+			getActivityPubWebFingerUrl(config, group),
+			'https://social.example/.well-known/webfinger?resource=acct%3Atest-channel%40example.com'
+		);
+		assert.deepEqual(buildActivityPubGroupWebFingerResponse(config, group), {
+			subject: 'acct:test-channel@example.com',
+			aliases: ['https://social.example/ap/groups/test-channel'],
+			links: [
+				{
+					rel: 'self',
+					type: 'application/activity+json',
+					href: 'https://social.example/ap/groups/test-channel'
+				}
+			]
+		});
+	});
+
+	it('rejects group names that cannot be used as WebFinger acct usernames', () => {
+		const config = getConfig();
+		const group = {name: 'Test Space'} as any;
+
+		assert.throws(() => getActivityPubGroupActorUrls(config, group), /activitypub_group_name_invalid/);
+	});
+
+	it('builds post object URLs from local group post ids', () => {
+		assert.equal(
+			getActivityPubGroupPostObjectUrl(getConfig(), 'test-channel', 42),
+			'https://social.example/ap/groups/test-channel/posts/42'
+		);
+	});
+
+	it('rejects missing public URL and invalid post ids', () => {
+		assert.throws(() => resolveActivityPubConfig({}), /activitypub_public_url_required/);
+		assert.throws(() => getActivityPubGroupPostObjectUrl(getConfig(), 'test-channel', 0), /activitypub_post_local_id_invalid/);
+		assert.throws(() => getActivityPubGroupActorUrls(getConfig(), {name: ''} as any), /activitypub_group_name_required/);
+	});
+});
+
+function getConfig() {
+	return {
+		enabled: true,
+		publicUrl: 'https://social.example/',
+		domain: 'example.com'
+	};
+}


### PR DESCRIPTION
## Summary

- Add explicit ActivityPub config knobs (`ACTIVITYPUB_ENABLED`, `ACTIVITYPUB_PUBLIC_URL`, `ACTIVITYPUB_DOMAIN`).
- Add deterministic helpers for group actor, inbox/outbox/followers/following, shared-inbox, post object, and WebFinger URLs/responses.
- Require GeeSome-valid group names before producing WebFinger `acct:` handles, and document the landed public identity helper slice.

## Why

This pins the public ActivityPub identity shape before the next PR adds read-only WebFinger/actor/outbox serializers and routes. It does not expose federation routes or accept inbound activities yet.

## Validation

- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/activityPubHelpers.test.ts --exit -t 10000`
- `git diff --check`

Not run: `npm run test:docker` (focused helper/config slice).
