### PR TITLE
Add ActivityPub read-only serializers

### DIFF
--- a/app/modules/activityPub/helpers.ts
+++ b/app/modules/activityPub/helpers.ts
@@ -7,6 +7,9 @@ import type {
 	IResolvedActivityPubConfig
 } from './interface.js';
 
+export const activityPubContext = 'https://www.w3.org/ns/activitystreams';
+export const activityPubPublicCollection = 'https://www.w3.org/ns/activitystreams#Public';
+
 export function resolveActivityPubConfig(config: IActivityPubConfig = {}): IResolvedActivityPubConfig {
 	const parsedPublicUrl = parseActivityPubPublicUrl(config.publicUrl);
 

--- a/app/modules/activityPub/interface.ts
+++ b/app/modules/activityPub/interface.ts
@@ -1,4 +1,5 @@
 import type {IGroup} from '../group/interface.js';
+import type {IContentData} from '../database/interface.js';
 
 export interface IActivityPubConfig {
 	enabled?: boolean | string;
@@ -34,3 +35,23 @@ export interface IActivityPubWebFingerResponse {
 }
 
 export type IActivityPubGroupInput = IGroup | string;
+
+export interface IActivityPubActorOptions {
+	publicKeyPem?: string;
+}
+
+export interface IActivityPubPostSerializerOptions {
+	contents?: IContentData[];
+}
+
+export interface IActivityPubOutboxOptions {
+	contentsByPostId?: Map<number, IContentData[]>;
+}
+
+export type IActivityPubActorObject = Record<string, any>;
+
+export type IActivityPubNoteObject = Record<string, any>;
+
+export type IActivityPubCreateActivity = Record<string, any>;
+
+export type IActivityPubOutboxCollection = Record<string, any>;

--- a/app/modules/activityPub/serializers.ts
+++ b/app/modules/activityPub/serializers.ts
@@ -1,0 +1,218 @@
+import type {IContentData} from '../database/interface.js';
+import {GroupType, PostStatus} from '../group/interface.js';
+import type {IGroup, IPost} from '../group/interface.js';
+import {
+	activityPubContext,
+	activityPubPublicCollection,
+	getActivityPubGroupActorUrls,
+	getActivityPubGroupPostObjectUrl
+} from './helpers.js';
+import type {
+	IActivityPubActorObject,
+	IActivityPubActorOptions,
+	IActivityPubConfig,
+	IActivityPubCreateActivity,
+	IActivityPubNoteObject,
+	IActivityPubOutboxCollection,
+	IActivityPubOutboxOptions,
+	IActivityPubPostSerializerOptions
+} from './interface.js';
+
+export function buildActivityPubGroupActor(config: IActivityPubConfig, group: IGroup, options: IActivityPubActorOptions = {}): IActivityPubActorObject {
+	assertActivityPubGroupFederatable(group);
+	const urls = getActivityPubGroupActorUrls(config, group);
+	const actor: IActivityPubActorObject = {
+		'@context': activityPubContext,
+		id: urls.actorUrl,
+		type: 'Group',
+		preferredUsername: group.name,
+		name: group.title || group.name,
+		summary: group.description || '',
+		url: group.homePage || urls.actorUrl,
+		inbox: urls.inboxUrl,
+		outbox: urls.outboxUrl,
+		followers: urls.followersUrl,
+		following: urls.followingUrl,
+		manuallyApprovesFollowers: group.isOpen === false,
+		discoverable: true,
+		endpoints: {
+			sharedInbox: urls.sharedInboxUrl
+		}
+	};
+
+	const icon = buildActivityPubImageLink(group.avatarImage);
+	if (icon) {
+		actor.icon = icon;
+	}
+	const image = buildActivityPubImageLink(group.coverImage);
+	if (image) {
+		actor.image = image;
+	}
+	if (options.publicKeyPem) {
+		actor.publicKey = {
+			id: `${urls.actorUrl}#main-key`,
+			owner: urls.actorUrl,
+			publicKeyPem: options.publicKeyPem
+		};
+	}
+
+	return actor;
+}
+
+export function buildActivityPubPostNote(config: IActivityPubConfig, group: IGroup, post: IPost, options: IActivityPubPostSerializerOptions = {}): IActivityPubNoteObject {
+	assertActivityPubPostFederatable(group, post);
+	const urls = getActivityPubGroupActorUrls(config, group);
+	const objectUrl = getActivityPubGroupPostObjectUrl(config, group, post.localId);
+	const contents = options.contents || [];
+
+	return {
+		'@context': activityPubContext,
+		id: objectUrl,
+		type: 'Note',
+		attributedTo: urls.actorUrl,
+		to: [activityPubPublicCollection],
+		cc: [urls.followersUrl],
+		content: getActivityPubPostContent(contents),
+		url: objectUrl,
+		published: toActivityPubDate(post.publishedAt),
+		attachment: buildActivityPubAttachments(contents)
+	};
+}
+
+export function buildActivityPubPostCreateActivity(config: IActivityPubConfig, group: IGroup, post: IPost, options: IActivityPubPostSerializerOptions = {}): IActivityPubCreateActivity {
+	const urls = getActivityPubGroupActorUrls(config, group);
+	const object = buildActivityPubPostNote(config, group, post, options);
+
+	return {
+		'@context': activityPubContext,
+		id: `${object.id}/activity/create`,
+		type: 'Create',
+		actor: urls.actorUrl,
+		to: object.to,
+		cc: object.cc,
+		published: object.published,
+		object
+	};
+}
+
+export function buildActivityPubOutboxCollection(config: IActivityPubConfig, group: IGroup, posts: IPost[] = [], options: IActivityPubOutboxOptions = {}): IActivityPubOutboxCollection {
+	assertActivityPubGroupFederatable(group);
+	const urls = getActivityPubGroupActorUrls(config, group);
+	const orderedItems = posts
+		.filter((post) => isActivityPubPostFederatable(group, post))
+		.map((post) => buildActivityPubPostCreateActivity(config, group, post, {
+			contents: getPostContents(options.contentsByPostId, post)
+		}));
+
+	return {
+		'@context': activityPubContext,
+		id: urls.outboxUrl,
+		type: 'OrderedCollection',
+		totalItems: orderedItems.length,
+		orderedItems
+	};
+}
+
+export function isActivityPubGroupFederatable(group: IGroup): boolean {
+	return group?.isPublic === true
+		&& group?.isEncrypted !== true
+		&& group?.type !== GroupType.PersonalChat
+		&& group?.isRemote !== true;
+}
+
+export function isActivityPubPostFederatable(group: IGroup, post: IPost): boolean {
+	return isActivityPubGroupFederatable(group)
+		&& post?.status === PostStatus.Published
+		&& post?.isDeleted !== true
+		&& post?.isEncrypted !== true
+		&& hasActivityPubDateValue(post?.publishedAt)
+		&& !!post?.localId;
+}
+
+export function assertActivityPubGroupFederatable(group: IGroup): void {
+	if (!isActivityPubGroupFederatable(group)) {
+		throw new Error('activitypub_group_not_federatable');
+	}
+}
+
+export function assertActivityPubPostFederatable(group: IGroup, post: IPost): void {
+	if (!isActivityPubPostFederatable(group, post)) {
+		throw new Error('activitypub_post_not_federatable');
+	}
+}
+
+function getPostContents(contentsByPostId: Map<number, IContentData[]> | undefined, post: IPost): IContentData[] {
+	if (!post?.id || !contentsByPostId) {
+		return [];
+	}
+	return contentsByPostId.get(post.id) || [];
+}
+
+function buildActivityPubImageLink(content: any) {
+	if (!content?.url) {
+		return null;
+	}
+	return {
+		type: 'Image',
+		mediaType: content.mimeType,
+		url: content.url
+	};
+}
+
+function buildActivityPubAttachments(contents: IContentData[]) {
+	return contents
+		.filter((content) => content?.url && content.type !== 'text')
+		.map((content) => ({
+			type: getActivityPubAttachmentType(content),
+			mediaType: content.mimeType,
+			url: content.url,
+			name: content['name'] || content.storageId
+		}));
+}
+
+function getActivityPubAttachmentType(content: IContentData): string {
+	if (content.type === 'image') {
+		return 'Image';
+	}
+	if (content.type === 'video') {
+		return 'Video';
+	}
+	return 'Document';
+}
+
+function getActivityPubPostContent(contents: IContentData[]): string {
+	const textContent = contents.find((content) => content?.type === 'text' && typeof content.text === 'string');
+	if (!textContent) {
+		return '';
+	}
+	return escapeActivityPubHtml(textContent.text);
+}
+
+function escapeActivityPubHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+		.replace(/\n/g, '<br>');
+}
+
+function toActivityPubDate(value): string {
+	if (!value) {
+		throw new Error('activitypub_post_published_at_required');
+	}
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		throw new Error('activitypub_post_published_at_invalid');
+	}
+	return date.toISOString();
+}
+
+function hasActivityPubDateValue(value): boolean {
+	if (!value) {
+		return false;
+	}
+	const date = value instanceof Date ? value : new Date(value);
+	return !Number.isNaN(date.getTime());
+}

--- a/docs/activitypub-research.md
+++ b/docs/activitypub-research.md
@@ -100,6 +100,8 @@ Suggested WebFinger:
 
 Implementation status: the first config/helper slice added explicit `activityPubConfig.enabled`, `activityPubConfig.publicUrl`, and `activityPubConfig.domain` values, sourced from `ACTIVITYPUB_ENABLED`, `ACTIVITYPUB_PUBLIC_URL`, and `ACTIVITYPUB_DOMAIN`. The helper layer normalizes the public URL, derives the domain from it when needed, and builds group actor, inbox/outbox/followers/following, shared-inbox, post-object, WebFinger resource, WebFinger URL, and WebFinger response data. It requires the group name to pass GeeSome username validation before producing an `acct:` handle.
 
+Read-only serializer status: group actor, Note, Create, and outbox collection payload builders exist behind safety gates that reject private, encrypted, remote, deleted, draft, and personal-chat data. The next implementation slice should expose those serializers through read-only ActivityPub routes, still without accepting inbound activities.
+
 ## Post Mapping
 
 GeeSome public post to ActivityPub:

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -325,7 +325,7 @@ Goal: make GeeSome groups/posts visible and interoperable through ActivityPub wi
 
 This is an important protocol-facing feature, not only a generic integration. The first delivery should define a minimal compatible ActivityPub surface before implementing broad Mastodon-style behavior.
 
-Status: first API prerequisite and public identity helper slices landed. The API module now supports unversioned JSON `POST` handlers, accepts `application/*+json` payloads, and exposes captured raw JSON bytes for signed/protocol-style posts such as future ActivityPub inbox/shared-inbox routes. ActivityPub config now has explicit `enabled`, `publicUrl`, and `domain` fields sourced from `ACTIVITYPUB_*` env vars, and deterministic helpers build group actor, inbox/outbox/followers/following, shared-inbox, post-object, and WebFinger URLs. Next slices should add read-only WebFinger/actor/outbox serializers and routes before accepting inbound federation activities.
+Status: first API prerequisite, public identity helper, and read-only serializer slices landed. The API module now supports unversioned JSON `POST` handlers, accepts `application/*+json` payloads, and exposes captured raw JSON bytes for signed/protocol-style posts such as future ActivityPub inbox/shared-inbox routes. ActivityPub config now has explicit `enabled`, `publicUrl`, and `domain` fields sourced from `ACTIVITYPUB_*` env vars, deterministic helpers build group actor, inbox/outbox/followers/following, shared-inbox, post-object, and WebFinger URLs, and serializers build group actor, Note/Create, and outbox collection payloads behind public/non-encrypted/published safety gates. Next slices should add read-only WebFinger/actor/outbox routes before accepting inbound federation activities.
 
 Research note: [activitypub-research.md](./activitypub-research.md).
 
@@ -334,7 +334,7 @@ Scope:
 - Map GeeSome identities/groups to ActivityPub actors. Group actor URL helpers now use `/ap/groups/{groupName}` and require GeeSome-valid group names so WebFinger `acct:` handles stay valid.
 - Expose WebFinger discovery for local actors. WebFinger resource/URL/response helpers exist; the route still needs the dedicated ActivityPub module.
 - Add actor, outbox, inbox, followers, and following endpoints. The API layer can now register unversioned POST inbox routes; no ActivityPub route is exposed until the dedicated module lands.
-- Represent published group posts as ActivityPub `Create` activities with `Note`/attachment objects and stable GeeSome/IPFS links.
+- Represent published group posts as ActivityPub `Create` activities with `Note`/attachment objects and stable GeeSome/IPFS links. Read-only serializers now cover Note/Create and outbox collection payloads; route wiring still needs the dedicated ActivityPub module.
 - Verify HTTP signatures for inbound activities and sign outbound activities. Raw JSON request bytes are now available to route callbacks for future digest/signature checks.
 - Store inbound follows/accepts and minimal remote actor metadata.
 - Keep moderation, deletes/updates, rich media federation, and full timeline syncing for later slices.

--- a/test/activityPubSerializers.test.ts
+++ b/test/activityPubSerializers.test.ts
@@ -1,0 +1,188 @@
+import assert from 'assert';
+import {ContentMimeType} from '../app/modules/database/interface.js';
+import {GroupType, GroupView, PostStatus} from '../app/modules/group/interface.js';
+import {
+	buildActivityPubGroupActor,
+	buildActivityPubOutboxCollection,
+	buildActivityPubPostCreateActivity,
+	buildActivityPubPostNote,
+	isActivityPubGroupFederatable,
+	isActivityPubPostFederatable
+} from '../app/modules/activityPub/serializers.js';
+
+describe('activityPub serializers', () => {
+	it('builds a group actor document with public identity URLs', () => {
+		const actor = buildActivityPubGroupActor(getConfig(), getGroup(), {
+			publicKeyPem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----'
+		});
+
+		assert.deepEqual(actor, {
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://social.example/ap/groups/test-channel',
+			type: 'Group',
+			preferredUsername: 'test-channel',
+			name: 'Test Channel',
+			summary: 'A public test channel',
+			url: 'https://social.example/groups/test-channel',
+			inbox: 'https://social.example/ap/groups/test-channel/inbox',
+			outbox: 'https://social.example/ap/groups/test-channel/outbox',
+			followers: 'https://social.example/ap/groups/test-channel/followers',
+			following: 'https://social.example/ap/groups/test-channel/following',
+			manuallyApprovesFollowers: false,
+			discoverable: true,
+			endpoints: {
+				sharedInbox: 'https://social.example/ap/shared-inbox'
+			},
+			icon: {
+				type: 'Image',
+				mediaType: 'image/png',
+				url: 'https://social.example/ipfs/avatar'
+			},
+			image: {
+				type: 'Image',
+				mediaType: 'image/jpeg',
+				url: 'https://social.example/ipfs/cover'
+			},
+			publicKey: {
+				id: 'https://social.example/ap/groups/test-channel#main-key',
+				owner: 'https://social.example/ap/groups/test-channel',
+				publicKeyPem: '-----BEGIN PUBLIC KEY-----\nabc\n-----END PUBLIC KEY-----'
+			}
+		});
+	});
+
+	it('builds Note and Create payloads from a published group post', () => {
+		const note = buildActivityPubPostNote(getConfig(), getGroup(), getPublishedPost(), {contents: getContents()});
+
+		assert.deepEqual(note, {
+			'@context': 'https://www.w3.org/ns/activitystreams',
+			id: 'https://social.example/ap/groups/test-channel/posts/7',
+			type: 'Note',
+			attributedTo: 'https://social.example/ap/groups/test-channel',
+			to: ['https://www.w3.org/ns/activitystreams#Public'],
+			cc: ['https://social.example/ap/groups/test-channel/followers'],
+			content: 'Hello &lt;fediverse&gt;<br>from GeeSome',
+			url: 'https://social.example/ap/groups/test-channel/posts/7',
+			published: '2026-06-01T12:00:00.000Z',
+			attachment: [
+				{
+					type: 'Image',
+					mediaType: 'image/png',
+					url: 'https://social.example/ipfs/image-storage',
+					name: 'image-storage'
+				}
+			]
+		});
+
+		const activity = buildActivityPubPostCreateActivity(getConfig(), getGroup(), getPublishedPost(), {contents: getContents()});
+
+		assert.equal(activity.id, 'https://social.example/ap/groups/test-channel/posts/7/activity/create');
+		assert.equal(activity.type, 'Create');
+		assert.equal(activity.actor, 'https://social.example/ap/groups/test-channel');
+		assert.deepEqual(activity.object, note);
+	});
+
+	it('builds an outbox collection and filters non-federatable posts', () => {
+		const group = getGroup();
+		const published = getPublishedPost();
+		const draft = {...getPublishedPost(), id: 12, localId: 8, status: PostStatus.Draft};
+		const outbox = buildActivityPubOutboxCollection(getConfig(), group, [published, draft], {
+			contentsByPostId: new Map([[published.id, getContents()]])
+		});
+
+		assert.equal(outbox.id, 'https://social.example/ap/groups/test-channel/outbox');
+		assert.equal(outbox.type, 'OrderedCollection');
+		assert.equal(outbox.totalItems, 1);
+		assert.equal(outbox.orderedItems.length, 1);
+		assert.equal(outbox.orderedItems[0].object.id, 'https://social.example/ap/groups/test-channel/posts/7');
+		assert.equal(outbox.orderedItems[0].object.content, 'Hello &lt;fediverse&gt;<br>from GeeSome');
+	});
+
+	it('rejects private, encrypted, remote, deleted, and chat-only data', () => {
+		const group = getGroup();
+		const post = getPublishedPost();
+
+		assert.equal(isActivityPubGroupFederatable(group), true);
+		assert.equal(isActivityPubPostFederatable(group, post), true);
+		assert.equal(isActivityPubGroupFederatable({...group, isPublic: false}), false);
+		assert.equal(isActivityPubGroupFederatable({...group, isEncrypted: true}), false);
+		assert.equal(isActivityPubGroupFederatable({...group, isRemote: true}), false);
+		assert.equal(isActivityPubGroupFederatable({...group, type: GroupType.PersonalChat}), false);
+		assert.equal(isActivityPubPostFederatable(group, {...post, isDeleted: true}), false);
+		assert.equal(isActivityPubPostFederatable(group, {...post, isEncrypted: true}), false);
+		assert.equal(isActivityPubPostFederatable(group, {...post, publishedAt: 'Invalid date'}), false);
+		assert.throws(() => buildActivityPubGroupActor(getConfig(), {...group, isPublic: false}), /activitypub_group_not_federatable/);
+		assert.throws(() => buildActivityPubPostNote(getConfig(), group, {...post, status: PostStatus.Draft}), /activitypub_post_not_federatable/);
+	});
+});
+
+function getConfig() {
+	return {
+		enabled: true,
+		publicUrl: 'https://social.example',
+		domain: 'example.com'
+	};
+}
+
+function getGroup() {
+	return {
+		id: 3,
+		name: 'test-channel',
+		title: 'Test Channel',
+		description: 'A public test channel',
+		homePage: 'https://social.example/groups/test-channel',
+		type: GroupType.Channel,
+		view: GroupView.TelegramLike,
+		theme: 'default',
+		isPublic: true,
+		isOpen: true,
+		isRemote: false,
+		isReplyForbidden: false,
+		creatorId: 1,
+		avatarImage: {
+			mimeType: ContentMimeType.ImagePng,
+			url: 'https://social.example/ipfs/avatar'
+		},
+		coverImage: {
+			mimeType: 'image/jpeg',
+			url: 'https://social.example/ipfs/cover'
+		},
+		storageUpdatedAt: new Date('2026-06-01T00:00:00Z'),
+		staticStorageUpdatedAt: new Date('2026-06-01T00:00:00Z')
+	} as any;
+}
+
+function getPublishedPost() {
+	return {
+		id: 11,
+		status: PostStatus.Published,
+		groupId: 3,
+		userId: 1,
+		localId: 7,
+		publishedAt: new Date('2026-06-01T12:00:00Z'),
+		isDeleted: false,
+		isEncrypted: false,
+		createdAt: new Date('2026-06-01T11:00:00Z'),
+		updatedAt: new Date('2026-06-01T12:00:00Z')
+	} as any;
+}
+
+function getContents() {
+	return [
+		{
+			id: 101,
+			type: 'text',
+			text: 'Hello <fediverse>\nfrom GeeSome',
+			storageId: 'text-storage',
+			mimeType: ContentMimeType.Text,
+			url: 'https://social.example/ipfs/text-storage'
+		},
+		{
+			id: 102,
+			type: 'image',
+			storageId: 'image-storage',
+			mimeType: ContentMimeType.ImagePng,
+			url: 'https://social.example/ipfs/image-storage'
+		}
+	] as any[];
+}


### PR DESCRIPTION
## Summary
- Add ActivityStreams serializers for GeeSome group actors, published post Notes/Create activities, and outbox collections.
- Keep serializers behind public/non-encrypted/published safety gates; private, encrypted, remote, deleted, draft, invalid-date, and personal-chat data are rejected or filtered.
- Update ActivityPub TODO/research notes so the next slice is route wiring rather than payload shape.

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/activityPubHelpers.test.ts test/activityPubSerializers.test.ts --exit -t 10000`
- `git diff --check`

Not run: `npm run test:docker` (focused serializer-only slice).
