### PR TITLE
Add ActivityPub actor signing keys

### DIFF
--- a/app/modules/activityPub/index.ts
+++ b/app/modules/activityPub/index.ts
@@ -2,9 +2,10 @@ import {IGeesomeApp} from '../../interface.js';
 import type {IContentData, IListParams} from '../database/interface.js';
 import type {IGroup, IPost} from '../group/interface.js';
 import {PostStatus} from '../group/interface.js';
-import IGeesomeActivityPubModule, {IResolvedActivityPubConfig} from './interface.js';
+import IGeesomeActivityPubModule, {IActivityPubSignRequestOptions, IResolvedActivityPubConfig} from './interface.js';
 import {
 	buildActivityPubGroupWebFingerResponse,
+	getActivityPubGroupActorUrls,
 	getActivityPubGroupPreferredUsername,
 	isActivityPubEnabled,
 	normalizeActivityPubPostLocalId,
@@ -17,15 +18,17 @@ import {
 	isActivityPubGroupFederatable,
 	isActivityPubPostFederatable
 } from './serializers.js';
+import {generateActivityPubRsaKeyPair, signActivityPubRequestWithKey} from './signatureHelpers.js';
 
-export default async (app: IGeesomeApp) => {
-	app.checkModules(['api', 'group']);
-	const module = getModule(app);
+export default async (app: IGeesomeApp, options: any = {}) => {
+	app.checkModules(['api', 'group', 'database']);
+	const models = options.models || await (await import('./models.js')).default(app.ms.database.sequelize);
+	const module = getModule(app, models);
 	(await import('./api.js')).default(app, module);
 	return module;
 }
 
-function getModule(app: IGeesomeApp): IGeesomeActivityPubModule {
+function getModule(app: IGeesomeApp, models): IGeesomeActivityPubModule {
 	class ActivityPubModule implements IGeesomeActivityPubModule {
 		isEnabled(): boolean {
 			return isActivityPubEnabled(app.config.activityPubConfig);
@@ -45,9 +48,10 @@ function getModule(app: IGeesomeApp): IGeesomeActivityPubModule {
 		async getGroupActor(groupName: string) {
 			const config = getResolvedActivityPubConfig(app);
 			const group = await getFederatableGroup(app, groupName);
+			const actorRecord = await getOrCreateGroupActorRecord(app, models, config, group);
 			const actorGroup = await getGroupWithProjectedImages(app, group, config);
 
-			return buildActivityPubGroupActor(config, actorGroup);
+			return buildActivityPubGroupActor(config, actorGroup, {publicKeyPem: actorRecord.publicKeyPem});
 		}
 
 		async getGroupOutbox(groupName: string, listParams: IListParams = {}) {
@@ -73,45 +77,26 @@ function getModule(app: IGeesomeApp): IGeesomeActivityPubModule {
 
 			return buildActivityPubPostNote(config, group, post, {contents});
 		}
+
+		async getGroupActorKey(groupName: string) {
+			const config = getResolvedActivityPubConfig(app);
+			const group = await getFederatableGroup(app, groupName);
+			const actorRecord = await getOrCreateGroupActorRecord(app, models, config, group);
+
+			return getActorKeyFromRecord(app, actorRecord);
+		}
+
+		async signGroupRequest(groupName: string, options: IActivityPubSignRequestOptions) {
+			const actorKey = await this.getGroupActorKey(groupName);
+			return signActivityPubRequestWithKey(actorKey, options);
+		}
+
+		async flushDatabase() {
+			await models.ActivityPubActor.destroy({where: {}});
+		}
 	}
 
 	return new ActivityPubModule();
-}
-
-function parseWebFingerResource(resource: string) {
-	const rawResource = String(resource || '').trim();
-	const match = rawResource.match(/^acct:([^@]+)@([^@]+)$/);
-	if (!match) {
-		throwActivityPubNotFound();
-	}
-
-	return {
-		preferredUsername: match[1],
-		domain: match[2].toLowerCase()
-	};
-}
-
-function getPreferredUsernameForRoute(groupName: string): string {
-	try {
-		return getActivityPubGroupPreferredUsername(groupName);
-	} catch (e) {
-		throwActivityPubNotFound();
-	}
-}
-
-function getPostLocalIdForRoute(localId: number | string): string {
-	try {
-		return normalizeActivityPubPostLocalId(localId);
-	} catch (e) {
-		throwActivityPubNotFound();
-	}
-}
-
-function getResolvedActivityPubConfig(app: IGeesomeApp): IResolvedActivityPubConfig {
-	if (!isActivityPubEnabled(app.config.activityPubConfig)) {
-		throwActivityPubNotFound();
-	}
-	return resolveActivityPubConfig(app.config.activityPubConfig);
 }
 
 async function getFederatableGroup(app: IGeesomeApp, groupName: string): Promise<IGroup> {
@@ -186,8 +171,139 @@ async function getContentDataWithUrl(app: IGeesomeApp, content, config: IResolve
 	});
 }
 
+async function getOrCreateGroupActorRecord(app: IGeesomeApp, models, config: IResolvedActivityPubConfig, group: IGroup) {
+	const actorData = getGroupActorRecordData(config, group);
+	const existingActor = await getGroupActorRecord(models, group);
+	if (existingActor) {
+		return syncEnabledGroupActorRecord(existingActor, actorData);
+	}
+
+	const keyPair = generateActivityPubRsaKeyPair();
+	const privateKeyPemEncrypted = await app.encryptTextWithAppPass(keyPair.privateKeyPem);
+	try {
+		return await models.ActivityPubActor.create({
+			...actorData,
+			publicKeyPem: keyPair.publicKeyPem,
+			privateKeyPemEncrypted,
+			isEnabled: true
+		});
+	} catch (e) {
+		if (!isActivityPubActorUniqueError(e)) {
+			throw e;
+		}
+		const createdActor = await getGroupActorRecord(models, group);
+		if (!createdActor) {
+			throw e;
+		}
+		return syncEnabledGroupActorRecord(createdActor, actorData);
+	}
+}
+
+async function getActorKeyFromRecord(app: IGeesomeApp, actorRecord) {
+	return {
+		keyId: getActorKeyId(actorRecord),
+		actorUrl: actorRecord.actorUrl,
+		publicKeyPem: actorRecord.publicKeyPem,
+		privateKeyPem: await app.decryptTextWithAppPass(actorRecord.privateKeyPemEncrypted)
+	};
+}
+
+async function getGroupActorRecord(models, group: IGroup) {
+	return models.ActivityPubActor.findOne({
+		where: {
+			entityType: 'group',
+			entityId: group.id
+		}
+	});
+}
+
+async function syncEnabledGroupActorRecord(actorRecord, actorData) {
+	if (actorRecord.isEnabled === false) {
+		throwActivityPubNotFound();
+	}
+	return syncGroupActorRecord(actorRecord, actorData);
+}
+
+async function syncGroupActorRecord(actorRecord, actorData) {
+	const updateData = getChangedActorData(actorRecord, actorData);
+	if (!Object.keys(updateData).length) {
+		return actorRecord;
+	}
+	await actorRecord.update(updateData);
+	return actorRecord;
+}
+
+function getGroupActorRecordData(config: IResolvedActivityPubConfig, group: IGroup) {
+	const urls = getActivityPubGroupActorUrls(config, group);
+	return {
+		entityType: 'group',
+		entityId: group.id,
+		preferredUsername: getActivityPubGroupPreferredUsername(group),
+		actorUrl: urls.actorUrl,
+		inboxUrl: urls.inboxUrl,
+		outboxUrl: urls.outboxUrl,
+		followersUrl: urls.followersUrl,
+		followingUrl: urls.followingUrl
+	};
+}
+
+function getChangedActorData(actorRecord, actorData) {
+	const updateData = {};
+	Object.keys(actorData).forEach((key) => {
+		if (actorRecord[key] === actorData[key]) {
+			return;
+		}
+		updateData[key] = actorData[key];
+	});
+	return updateData;
+}
+
+function parseWebFingerResource(resource: string) {
+	const rawResource = String(resource || '').trim();
+	const match = rawResource.match(/^acct:([^@]+)@([^@]+)$/);
+	if (!match) {
+		throwActivityPubNotFound();
+	}
+
+	return {
+		preferredUsername: match[1],
+		domain: match[2].toLowerCase()
+	};
+}
+
+function getPreferredUsernameForRoute(groupName: string): string {
+	try {
+		return getActivityPubGroupPreferredUsername(groupName);
+	} catch (e) {
+		throwActivityPubNotFound();
+	}
+}
+
+function getPostLocalIdForRoute(localId: number | string): string {
+	try {
+		return normalizeActivityPubPostLocalId(localId);
+	} catch (e) {
+		throwActivityPubNotFound();
+	}
+}
+
+function getResolvedActivityPubConfig(app: IGeesomeApp): IResolvedActivityPubConfig {
+	if (!isActivityPubEnabled(app.config.activityPubConfig)) {
+		throwActivityPubNotFound();
+	}
+	return resolveActivityPubConfig(app.config.activityPubConfig);
+}
+
 function getContentBaseUrl(config: IResolvedActivityPubConfig): string {
 	return `${config.publicUrl}/ipfs/`;
+}
+
+function isActivityPubActorUniqueError(error): boolean {
+	return error?.name === 'SequelizeUniqueConstraintError';
+}
+
+function getActorKeyId(actorRecord): string {
+	return `${actorRecord.actorUrl}#main-key`;
 }
 
 function throwActivityPubNotFound(): never {

--- a/app/modules/activityPub/interface.ts
+++ b/app/modules/activityPub/interface.ts
@@ -48,6 +48,34 @@ export interface IActivityPubOutboxOptions {
 	contentsByPostId?: Map<number, IContentData[]>;
 }
 
+export interface IActivityPubActorKey {
+	keyId: string;
+	actorUrl: string;
+	publicKeyPem: string;
+	privateKeyPem: string;
+}
+
+export interface IActivityPubGeneratedKeyPair {
+	publicKeyPem: string;
+	privateKeyPem: string;
+}
+
+export interface IActivityPubSignRequestOptions {
+	method: string;
+	url: string;
+	body?: string | Buffer;
+	date?: Date | string;
+	headers?: Record<string, string | number>;
+	signedHeaders?: string[];
+}
+
+export interface IActivityPubSignedRequest {
+	headers: Record<string, string>;
+	signature: string;
+	signingString: string;
+	signedHeaders: string[];
+}
+
 export type IActivityPubActorObject = Record<string, any>;
 
 export type IActivityPubNoteObject = Record<string, any>;
@@ -66,4 +94,10 @@ export default interface IGeesomeActivityPubModule {
 	getGroupOutbox(groupName: string, listParams?: IListParams): Promise<IActivityPubOutboxCollection>;
 
 	getGroupPostNote(groupName: string, localId: number | string): Promise<IActivityPubNoteObject>;
+
+	getGroupActorKey(groupName: string): Promise<IActivityPubActorKey>;
+
+	signGroupRequest(groupName: string, options: IActivityPubSignRequestOptions): Promise<IActivityPubSignedRequest>;
+
+	flushDatabase(): Promise<void>;
 }

--- a/app/modules/activityPub/models.ts
+++ b/app/modules/activityPub/models.ts
@@ -1,0 +1,60 @@
+import {DataTypes, Sequelize} from 'sequelize';
+
+export default async function (sequelize: Sequelize) {
+	const ActivityPubActor = sequelize.define('activityPubActor', {
+		entityType: {
+			type: DataTypes.STRING(50),
+			allowNull: false
+		},
+		entityId: {
+			type: DataTypes.INTEGER,
+			allowNull: false
+		},
+		preferredUsername: {
+			type: DataTypes.STRING(100),
+			allowNull: false
+		},
+		actorUrl: {
+			type: DataTypes.STRING(500),
+			allowNull: false
+		},
+		inboxUrl: {
+			type: DataTypes.STRING(500),
+			allowNull: false
+		},
+		outboxUrl: {
+			type: DataTypes.STRING(500),
+			allowNull: false
+		},
+		followersUrl: {
+			type: DataTypes.STRING(500),
+			allowNull: false
+		},
+		followingUrl: {
+			type: DataTypes.STRING(500),
+			allowNull: false
+		},
+		publicKeyPem: {
+			type: DataTypes.TEXT,
+			allowNull: false
+		},
+		privateKeyPemEncrypted: {
+			type: DataTypes.TEXT,
+			allowNull: false
+		},
+		isEnabled: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: true
+		}
+	} as any, {
+		indexes: [
+			{name: 'activity_pub_actors_entity_unique', fields: ['entityType', 'entityId'], unique: true},
+			{name: 'activity_pub_actors_actor_url_unique', fields: ['actorUrl'], unique: true},
+			{name: 'activity_pub_actors_username_idx', fields: ['preferredUsername']}
+		]
+	} as any);
+
+	return {
+		ActivityPubActor: await ActivityPubActor.sync({})
+	};
+}

--- a/app/modules/activityPub/signatureHelpers.ts
+++ b/app/modules/activityPub/signatureHelpers.ts
@@ -1,0 +1,133 @@
+import crypto from 'node:crypto';
+import type {
+	IActivityPubActorKey,
+	IActivityPubGeneratedKeyPair,
+	IActivityPubSignedRequest,
+	IActivityPubSignRequestOptions
+} from './interface.js';
+
+export function generateActivityPubRsaKeyPair(): IActivityPubGeneratedKeyPair {
+	const {publicKey, privateKey} = crypto.generateKeyPairSync('rsa', {
+		modulusLength: 2048,
+		publicKeyEncoding: {
+			type: 'spki',
+			format: 'pem'
+		},
+		privateKeyEncoding: {
+			type: 'pkcs8',
+			format: 'pem'
+		}
+	});
+
+	return {
+		publicKeyPem: publicKey,
+		privateKeyPem: privateKey
+	};
+}
+
+export function signActivityPubRequestWithKey(actorKey: IActivityPubActorKey, options: IActivityPubSignRequestOptions): IActivityPubSignedRequest {
+	const url = new URL(options.url);
+	const headers = getActivityPubSignatureHeaders(options, url);
+	const signedHeaders = getActivityPubSignedHeaders(options, headers);
+	const signingString = getActivityPubSigningString(options.method, url, headers, signedHeaders);
+	const signature = crypto
+		.createSign('RSA-SHA256')
+		.update(signingString)
+		.end()
+		.sign(actorKey.privateKeyPem, 'base64');
+
+	headers.Signature = [
+		`keyId="${actorKey.keyId}"`,
+		'algorithm="rsa-sha256"',
+		`headers="${signedHeaders.join(' ')}"`,
+		`signature="${signature}"`
+	].join(',');
+
+	return {
+		headers,
+		signature,
+		signingString,
+		signedHeaders
+	};
+}
+
+export function getActivityPubDigestHeader(body: string | Buffer): string {
+	const buffer = Buffer.isBuffer(body) ? body : Buffer.from(String(body));
+	const digest = crypto.createHash('sha256').update(buffer).digest('base64');
+
+	return `SHA-256=${digest}`;
+}
+
+function getActivityPubSignatureHeaders(options: IActivityPubSignRequestOptions, url: URL): Record<string, string> {
+	const headers = normalizeHeaders(options.headers);
+	headers.Host = headers.Host || url.host;
+	headers.Date = headers.Date || getActivityPubSignatureDate(options.date);
+	if (options.body !== undefined && options.body !== null) {
+		headers.Digest = headers.Digest || getActivityPubDigestHeader(options.body);
+	}
+	return headers;
+}
+
+function getActivityPubSignedHeaders(options: IActivityPubSignRequestOptions, headers: Record<string, string>): string[] {
+	if (options.signedHeaders?.length) {
+		return options.signedHeaders;
+	}
+	if (headers.Digest) {
+		return ['(request-target)', 'host', 'date', 'digest'];
+	}
+	return ['(request-target)', 'host', 'date'];
+}
+
+function getActivityPubSigningString(method: string, url: URL, headers: Record<string, string>, signedHeaders: string[]): string {
+	return signedHeaders.map((name) => {
+		if (name === '(request-target)') {
+			return `(request-target): ${String(method || 'GET').toLowerCase()} ${getRequestTarget(url)}`;
+		}
+		return `${name.toLowerCase()}: ${getHeaderValue(headers, name)}`;
+	}).join('\n');
+}
+
+function normalizeHeaders(headers: IActivityPubSignRequestOptions['headers'] = {}): Record<string, string> {
+	const result = {};
+	Object.keys(headers || {}).forEach((name) => {
+		result[normalizeHeaderName(name)] = String(headers[name]);
+	});
+	return result;
+}
+
+function normalizeHeaderName(name: string): string {
+	return String(name)
+		.split('-')
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+		.join('-');
+}
+
+function getHeaderValue(headers: Record<string, string>, name: string): string {
+	const headerName = normalizeHeaderName(name);
+	if (headers[headerName] === undefined) {
+		throw new Error(`activitypub_signature_header_missing:${name}`);
+	}
+	return headers[headerName];
+}
+
+function getActivityPubSignatureDate(value?: Date | string): string {
+	const date = getActivityPubSignatureDateValue(value);
+	if (Number.isNaN(date.getTime())) {
+		throw new Error('activitypub_signature_date_invalid');
+	}
+	return date.toUTCString();
+}
+
+function getRequestTarget(url: URL): string {
+	return `${url.pathname}${url.search}`;
+}
+
+function getActivityPubSignatureDateValue(value?: Date | string): Date {
+	if (!value) {
+		return new Date();
+	}
+	if (value instanceof Date) {
+		return value;
+	}
+	return new Date(value);
+}

--- a/check/databaseSyncModels.ts
+++ b/check/databaseSyncModels.ts
@@ -72,6 +72,13 @@ const moduleModelSyncers = [
     },
   },
   {
+    name: 'activityPub',
+    sync: async (sequelize: Sequelize, models: any) => {
+      Object.assign(models, await (await import('../app/modules/activityPub/models.js')).default(sequelize));
+      return models;
+    },
+  },
+  {
     name: 'foreignAccounts',
     sync: async (sequelize: Sequelize, models: any) => {
       Object.assign(models, await (await import('../app/modules/foreignAccounts/models.js')).default(sequelize));

--- a/docs/activitypub-research.md
+++ b/docs/activitypub-research.md
@@ -100,7 +100,7 @@ Suggested WebFinger:
 
 Implementation status: the first config/helper slice added explicit `activityPubConfig.enabled`, `activityPubConfig.publicUrl`, and `activityPubConfig.domain` values, sourced from `ACTIVITYPUB_ENABLED`, `ACTIVITYPUB_PUBLIC_URL`, and `ACTIVITYPUB_DOMAIN`. The helper layer normalizes the public URL, derives the domain from it when needed, and builds group actor, inbox/outbox/followers/following, shared-inbox, post-object, WebFinger resource, WebFinger URL, and WebFinger response data. It requires the group name to pass GeeSome username validation before producing an `acct:` handle.
 
-Read-only route status: group actor, Note, Create, and outbox collection payload builders exist behind safety gates that reject private, encrypted, remote, deleted, draft, and personal-chat data. The dedicated `activityPub` module now exposes disabled-by-default public WebFinger, actor, outbox, and post-object routes with protocol content types. The next implementation slices should add stable actor key storage, HTTP signature verification/signing, follow state, and delivery queues before accepting inbound activities.
+Read-only route and key status: group actor, Note, Create, and outbox collection payload builders exist behind safety gates that reject private, encrypted, remote, deleted, draft, and personal-chat data. The dedicated `activityPub` module now exposes disabled-by-default public WebFinger, actor, outbox, and post-object routes with protocol content types. Local group actors now get model-sync-created `ActivityPubActor` records with encrypted RSA private keys, public keys are embedded in actor documents, and reusable outbound RSA-SHA256 HTTP-signature helpers exist. The next implementation slices should add inbound HTTP signature verification, follow state, and delivery queues before accepting inbound activities.
 
 ## Post Mapping
 
@@ -244,7 +244,7 @@ Do not derive canonical actor IDs from `PORT`, internal Docker hostnames, or for
 
 Use ActivityPub-specific models instead of adding many nullable columns to `Group` and `Post`:
 
-- `ActivityPubActor`: local actor binding, `entityType`, `entityId`, `preferredUsername`, `actorUrl`, `inboxUrl`, `outboxUrl`, `followersUrl`, `privateKeyPemEncrypted`, `publicKeyPem`, `isEnabled`.
+- `ActivityPubActor`: local actor binding, `entityType`, `entityId`, `preferredUsername`, `actorUrl`, `inboxUrl`, `outboxUrl`, `followersUrl`, `followingUrl`, `privateKeyPemEncrypted`, `publicKeyPem`, `isEnabled`. Status: local group actor rows and signing keys exist.
 - `ActivityPubRemoteActor`: remote `actorUrl`, `preferredUsername`, `domain`, `inboxUrl`, `sharedInboxUrl`, `publicKeyPem`, `lastFetchedAt`, `rawJson`.
 - `ActivityPubFollow`: local actor id, remote actor id, direction, state, remote activity id, accepted/rejected timestamps.
 - `ActivityPubObject`: local post id or remote object URL, activity id, object id, type, raw JSON, visibility, delivery state.
@@ -330,7 +330,7 @@ Recommendation: create a short Fedify spike before implementation. If Node 22 is
 
 - Decide whether the ActivityPub actor is `Group`, `Service`, or compatibility `Person`.
 - Decide whether runtime can move to Node 22 for Fedify.
-- Define database records for actor keypairs, remote actors, follows, and delivery attempts.
+- Define database records for actor keypairs, remote actors, follows, and delivery attempts. Status: local actor keypair records exist; remote actor, follow, object, and delivery records remain future work.
 - Document exact public URL shape. Status: group actor and post-object URL helpers now pin the `/ap/groups/{groupName}` and `/ap/groups/{groupName}/posts/{localId}` shapes, plus WebFinger `acct:{groupName}@{domain}` resources. The remaining design decision is whether later route/signature implementation uses Fedify or the minimal custom module.
 
 ### Slice 1: Discovery And Read-Only Federation

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -325,7 +325,7 @@ Goal: make GeeSome groups/posts visible and interoperable through ActivityPub wi
 
 This is an important protocol-facing feature, not only a generic integration. The first delivery should define a minimal compatible ActivityPub surface before implementing broad Mastodon-style behavior.
 
-Status: first API prerequisite, public identity helper, read-only serializer, and read-only route slices landed. The API module now supports unversioned JSON `POST` handlers, accepts `application/*+json` payloads, and exposes captured raw JSON bytes for signed/protocol-style posts such as future ActivityPub inbox/shared-inbox routes. ActivityPub config now has explicit `enabled`, `publicUrl`, and `domain` fields sourced from `ACTIVITYPUB_*` env vars, deterministic helpers build group actor, inbox/outbox/followers/following, shared-inbox, post-object, and WebFinger URLs, serializers build group actor, Note/Create, and outbox collection payloads behind public/non-encrypted/published safety gates, and the dedicated `activityPub` module exposes disabled-by-default public WebFinger, actor, outbox, and post-object routes. Next slices should add actor key storage/signatures, inbound inbox verification, follow state, and delivery queues before accepting broad federation activities.
+Status: first API prerequisite, public identity helper, read-only serializer, read-only route, and actor-key/signature slices landed. The API module now supports unversioned JSON `POST` handlers, accepts `application/*+json` payloads, and exposes captured raw JSON bytes for signed/protocol-style posts such as future ActivityPub inbox/shared-inbox routes. ActivityPub config now has explicit `enabled`, `publicUrl`, and `domain` fields sourced from `ACTIVITYPUB_*` env vars, deterministic helpers build group actor, inbox/outbox/followers/following, shared-inbox, post-object, and WebFinger URLs, serializers build group actor, Note/Create, and outbox collection payloads behind public/non-encrypted/published safety gates, the dedicated `activityPub` module exposes disabled-by-default public WebFinger, actor, outbox, and post-object routes, and local group actors now get model-sync-created `ActivityPubActor` records with encrypted RSA private keys, public keys in actor documents, and reusable outbound HTTP-signature helpers. Next slices should add inbound inbox verification, follow state, and delivery queues before accepting broad federation activities.
 
 Research note: [activitypub-research.md](./activitypub-research.md).
 
@@ -335,7 +335,7 @@ Scope:
 - Expose WebFinger discovery for local actors. The dedicated ActivityPub module now serves public `/.well-known/webfinger` for federatable local group actors.
 - Add actor, outbox, inbox, followers, and following endpoints. Read-only actor, outbox, and post-object routes are exposed; inbox, followers, following, and remote delivery are still future slices.
 - Represent published group posts as ActivityPub `Create` activities with `Note`/attachment objects and stable GeeSome/IPFS links. Read-only serializers now cover Note/Create and outbox collection payloads, and public route wiring dereferences actor, outbox, and Note object URLs.
-- Verify HTTP signatures for inbound activities and sign outbound activities. Raw JSON request bytes are now available to route callbacks for future digest/signature checks.
+- Verify HTTP signatures for inbound activities and sign outbound activities. Raw JSON request bytes are now available to route callbacks for future digest/signature checks; outbound RSA-SHA256 signing helpers and stable local actor keys exist, while inbound verification is still future work.
 - Store inbound follows/accepts and minimal remote actor metadata.
 - Keep moderation, deletes/updates, rich media federation, and full timeline syncing for later slices.
 - Decide whether to adopt Fedify or keep a minimal custom module. The repo now targets Node 22, so the earlier Node-floor concern is gone; the remaining decision is dependency weight, integration shape, and whether Fedify's helpers fit GeeSome's IPFS/IPNS-first identity model.
@@ -346,7 +346,7 @@ Likely modules:
 - `app/modules/group` for local group/post mapping.
 - `app/modules/content` for attachment URLs and media metadata.
 - `app/modules/api` for unversioned POST/raw body support.
-- ActivityPub-specific Sequelize models for actor, remote actor, follow, object, and delivery records.
+- ActivityPub-specific Sequelize models for actor, remote actor, follow, object, and delivery records. The first model-sync `ActivityPubActor` table now stores local group actor URLs and encrypted signing keys; remote actors, follows, objects, and delivery rows are still future slices.
 
 Do not reuse `remoteGroup` as the ActivityPub remote actor store; it is GeeSome/IPFS-manifest oriented, while ActivityPub uses HTTPS actor IDs and signed HTTP.
 

--- a/test/activityPubModule.test.ts
+++ b/test/activityPubModule.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import crypto from 'node:crypto';
 import activityPubModule from '../app/modules/activityPub/index.js';
 import registerActivityPubApi from '../app/modules/activityPub/api.js';
 import {ContentMimeType} from '../app/modules/database/interface.js';
@@ -23,6 +24,9 @@ describe('activityPub module', () => {
 
 		const actor = await module.getGroupActor('test-channel');
 		assert.equal(actor.id, 'https://social.example/ap/groups/test-channel');
+		assert.equal(actor.publicKey.id, 'https://social.example/ap/groups/test-channel#main-key');
+		assert.equal(actor.publicKey.owner, 'https://social.example/ap/groups/test-channel');
+		assert.match(actor.publicKey.publicKeyPem, /^-----BEGIN PUBLIC KEY-----/);
 		assert.deepEqual(actor.icon, {
 			type: 'Image',
 			mediaType: ContentMimeType.ImagePng,
@@ -44,12 +48,53 @@ describe('activityPub module', () => {
 		assert.equal(note.attachment[0].url, 'https://social.example/ipfs/image-storage');
 	});
 
+	it('keeps a stable encrypted actor key and signs outbound requests', async () => {
+		const {module, models} = await createActivityPubHarness();
+
+		const firstActor = await module.getGroupActor('test-channel');
+		const secondActor = await module.getGroupActor('test-channel');
+		assert.equal(firstActor.publicKey.publicKeyPem, secondActor.publicKey.publicKeyPem);
+		assert.equal(models.ActivityPubActor.rows.length, 1);
+		assert.notEqual(models.ActivityPubActor.rows[0].privateKeyPemEncrypted, (await module.getGroupActorKey('test-channel')).privateKeyPem);
+		assert.match(models.ActivityPubActor.rows[0].privateKeyPemEncrypted, /^encrypted:/);
+
+		const body = JSON.stringify({type: 'Follow'});
+		const signedRequest = await module.signGroupRequest('test-channel', {
+			method: 'POST',
+			url: 'https://remote.example/inbox?x=1',
+			body,
+			date: new Date('2026-06-01T12:00:00Z')
+		});
+		const signature = parseSignatureHeader(signedRequest.headers.Signature);
+		const verified = crypto
+			.createVerify('RSA-SHA256')
+			.update(signedRequest.signingString)
+			.end()
+			.verify(firstActor.publicKey.publicKeyPem, signature.signature, 'base64');
+
+		assert.equal(verified, true);
+		assert.equal(signature.keyId, 'https://social.example/ap/groups/test-channel#main-key');
+		assert.deepEqual(signedRequest.signedHeaders, ['(request-target)', 'host', 'date', 'digest']);
+		assert.equal(signedRequest.headers.Host, 'remote.example');
+		assert.equal(signedRequest.headers.Date, 'Mon, 01 Jun 2026 12:00:00 GMT');
+		assert.match(signedRequest.headers.Digest, /^SHA-256=/);
+		await assert.rejects(() => module.signGroupRequest('test-channel', {
+			method: 'GET',
+			url: 'https://remote.example/inbox',
+			date: 'invalid-date'
+		}), /activitypub_signature_date_invalid/);
+	});
+
 	it('returns not found for disabled, mismatched, private, and invalid resources', async () => {
 		const {module} = await createActivityPubHarness();
 
 		await assert.rejects(() => module.getWebFingerResponse('acct:test-channel@other.example'), hasNotFoundCode);
 		await assert.rejects(() => module.getGroupActor('private-channel'), hasNotFoundCode);
 		await assert.rejects(() => module.getGroupPostNote('test-channel', 0), hasNotFoundCode);
+
+		const disabledActor = await createActivityPubHarness();
+		disabledActor.models.ActivityPubActor.rows.push(getActivityPubActorRow({isEnabled: false}));
+		await assert.rejects(() => disabledActor.module.getGroupActor('test-channel'), hasNotFoundCode);
 
 		const disabled = await createActivityPubHarness({
 			config: {
@@ -97,6 +142,7 @@ describe('activityPub API', () => {
 
 async function createActivityPubHarness(overrides: any = {}) {
 	const routes = {};
+	const models = getModelsStub();
 	const calls: any = {
 		getGroupByParams: [],
 		getGroupPosts: []
@@ -112,10 +158,13 @@ async function createActivityPubHarness(overrides: any = {}) {
 			}
 		},
 		checkModules(modules) {
-			assert.deepEqual(modules, ['api', 'group']);
+			assert.deepEqual(modules, ['api', 'group', 'database']);
 		},
+		encryptTextWithAppPass: async (value) => `encrypted:${Buffer.from(value).toString('base64')}`,
+		decryptTextWithAppPass: async (value) => Buffer.from(value.replace(/^encrypted:/, ''), 'base64').toString(),
 		ms: {
 			api: getApiStub(routes),
+			database: {},
 			group: {
 				async getGroupByParams(params) {
 					calls.getGroupByParams.push(params);
@@ -155,9 +204,10 @@ async function createActivityPubHarness(overrides: any = {}) {
 	};
 
 	return {
-		module: await activityPubModule(app as any),
+		module: await activityPubModule(app as any, {models}),
 		routes,
-		calls
+		calls,
+		models
 	};
 }
 
@@ -192,6 +242,67 @@ async function callRoute(routes, key: string, req: any) {
 
 function hasNotFoundCode(error) {
 	return error?.code === 404 && error?.message === 'activitypub_resource_not_found';
+}
+
+function getModelsStub() {
+	const rows: any[] = [];
+	return {
+		ActivityPubActor: {
+			rows,
+			async findOne({where}) {
+				return rows.find((row) => {
+					return Object.keys(where).every((key) => row[key] === where[key]);
+				}) || null;
+			},
+			async create(data) {
+				const row = {
+					...data,
+					id: rows.length + 1,
+					async update(updateData) {
+						Object.assign(this, updateData);
+						return this;
+					}
+				};
+				rows.push(row);
+				return row;
+			},
+			async destroy() {
+				rows.length = 0;
+			}
+		}
+	};
+}
+
+function getActivityPubActorRow(overrides: any = {}) {
+	return {
+		id: 1,
+		entityType: 'group',
+		entityId: 3,
+		preferredUsername: 'test-channel',
+		actorUrl: 'https://social.example/ap/groups/test-channel',
+		inboxUrl: 'https://social.example/ap/groups/test-channel/inbox',
+		outboxUrl: 'https://social.example/ap/groups/test-channel/outbox',
+		followersUrl: 'https://social.example/ap/groups/test-channel/followers',
+		followingUrl: 'https://social.example/ap/groups/test-channel/following',
+		publicKeyPem: 'public-key',
+		privateKeyPemEncrypted: 'encrypted:private-key',
+		isEnabled: true,
+		async update(updateData) {
+			Object.assign(this, updateData);
+			return this;
+		},
+		...overrides
+	};
+}
+
+function parseSignatureHeader(value: string) {
+	return value.split(',').reduce((result, item) => {
+		const separatorIndex = item.indexOf('=');
+		const rawKey = item.slice(0, separatorIndex);
+		const rawValue = item.slice(separatorIndex + 1);
+		result[rawKey] = rawValue.replace(/^"|"$/g, '');
+		return result;
+	}, {});
 }
 
 function getGroup() {


### PR DESCRIPTION
## Summary
- Add model-sync `ActivityPubActor` records for local group actors, including stable actor URLs, public keys, and encrypted RSA private keys.
- Embed public keys in read-only actor documents and expose module helpers for retrieving actor keys and signing outbound ActivityPub HTTP requests.
- Wire the new model into `database:sync-models` and update ActivityPub TODO/research notes so the next slices start at inbound verification/follows/delivery.

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/activityPubHelpers.test.ts test/activityPubSerializers.test.ts test/activityPubModule.test.ts --exit -t 10000`
- `node --import tsx -e "await import('./app/modules/activityPub/models.ts'); await import('./app/modules/activityPub/signatureHelpers.ts'); console.log('activityPub model/signature imports ok')"`
- `git diff --check`

Blocked:
- `npm run database:sync-models` could not complete locally because Postgres rejected the configured `geesome` user password (`28P01`).

Not run:
- `npm run test:docker` (focused ActivityPub actor-key slice).
