### PR TITLE
Add ActivityPub HTML rendering safety gate

### DIFF
--- a/docs/activitypub-research.md
+++ b/docs/activitypub-research.md
@@ -293,6 +293,8 @@ Remote `Create(Note)` replies and mentions are currently stored only as `Activit
 - `sourcePostId`: remote object URL
 - `replyToId`: mapped local post if `inReplyTo` matches a known ActivityPub object
 
+Before any remote ActivityPub object becomes a visible GeeSome/webview post, review the existing post rendering path because post bodies are HTML. Store the remote raw object for audit, but render only sanitized/escaped content with an explicit allowlist for tags, attributes, links, media embeds, and IPFS/IPNS URLs. The safety pass should cover local text posts, remote ActivityStreams `content`, static-site/webview rendering, and admin remote-object previews, with regression fixtures for `<script>`, event handlers, `javascript:` URLs, iframe/object/embed tags, CSS injection, malformed HTML, and oversized markup.
+
 Attachments can be represented first as remote URLs in `propertiesJson`; importing them into GeeSome/IPFS content should be a later, explicit backup feature.
 
 ## Implementation Options
@@ -365,6 +367,7 @@ Recommendation: create a short Fedify spike before implementation. If Node 22 is
 ### Slice 4: Remote Replies And Moderation
 
 - Process remote `Create(Note)` replies/mentions. Status: signed replies to known local objects and mentions of known local group actors are stored idempotently as `ActivityPubObject` rows and exposed through an AdminRead remote-object list; moderation and GeeSome post creation remain future work.
+- Define and test the HTML rendering/sanitization boundary before turning cached remote objects into visible GeeSome posts. This must cover webview/static-site post rendering, admin review previews, ActivityStreams `content`, local text posts, allowed HTML/media/link policy, and XSS fixtures.
 - Add moderation controls.
 - Handle remote `Update(Note)`. Status: signed shared-inbox `Update(Note)` mutates cached remote object rows from the same actor; updating visible GeeSome posts from remote objects remains future moderation work.
 - Handle remote `Delete`. Status: signed shared-inbox `Delete` tombstones cached remote object rows from the same actor; deleting visible GeeSome posts from remote objects remains future moderation work.

--- a/docs/activitypub-research.md
+++ b/docs/activitypub-research.md
@@ -382,6 +382,7 @@ Recommendation: create a short Fedify spike before implementation. If Node 22 is
 - Route tests for ActivityPub content negotiation and `application/activity+json`. Status: focused unit coverage now checks the public WebFinger, actor, outbox, post-object, group inbox, and shared-inbox route registrations and response content types.
 - Fedify testing utilities if Fedify is adopted.
 - Manual/local federation tests with `fedify lookup`, `fedify inbox`, ActivityPub.Academy, and one Mastodon-compatible server.
+- Bluesky compatibility smoke must be explicit about protocol boundaries. Bluesky uses AT Protocol, so ActivityPub exchange should be tested through a bridge such as Bridgy Fed: local GeeSome group post delivery should appear on the bridged Bluesky side, and a Bluesky reply/mention should come back as a signed ActivityPub inbox/shared-inbox activity that GeeSome stores as a remote object. Separately, test any direct Bluesky/ATProto data exchange through the socNet account path with a test `socNetAccount` database row (`socNet` set to the final Bluesky module name, test account identity, and non-production app password/OAuth credentials), verifying credential ownership, import/cross-post semantics, idempotency, and that the direct ATProto path does not bypass ActivityPub signature/moderation gates.
 
 ## Sources
 
@@ -393,3 +394,5 @@ Recommendation: create a short Fedify spike before implementation. If Node 22 is
 - Mastodon WebFinger documentation: https://docs.joinmastodon.org/spec/webfinger/
 - Mastodon security/signature documentation: https://docs.joinmastodon.org/spec/security/
 - Fedify documentation: https://fedify.dev/
+- Bluesky AT Protocol documentation: https://docs.bsky.app/docs/advanced-guides/atproto
+- Bridgy Fed bridge documentation: https://fed.brid.gy/docs

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -366,6 +366,7 @@ Verification:
 - New module tests for actor serialization, WebFinger, and outbox payloads.
 - Existing `test/group.test.ts` for post compatibility.
 - Later integration smoke against a local ActivityPub test server.
+- Later Bluesky data-exchange smoke with the protocol boundary explicit: ActivityPub interop should use a bridge such as Bridgy Fed, while direct Bluesky/ATProto import or cross-post testing should use a seeded test `socNetAccount` database row for the Bluesky account and verify ownership, credential handling, idempotency, and moderation/signature boundaries.
 
 ### 11. Database Scalability For Large Groups
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -337,6 +337,7 @@ Scope:
 - Represent published group posts as ActivityPub `Create` activities with `Note`/attachment objects and stable GeeSome/IPFS links. Read-only serializers now cover Note/Create and outbox collection payloads, and public route wiring dereferences actor, outbox, and Note object URLs.
 - Verify HTTP signatures for inbound activities and sign outbound activities. Raw JSON request bytes are now available to route callbacks for digest/signature checks; outbound RSA-SHA256 signing helpers, stable local actor keys, and inbound signature/Digest/Date verification exist. Actual inbox activity acceptance still waits for remote actor cache/follow state.
 - Store inbound/outbound follow state and minimal remote actor metadata. Remote actor key/inbox metadata is now cached for signature verification and outbound follow requests, signed inbound `Follow` activities are persisted idempotently for group inboxes, signed embedded `Undo(Follow)` cancels stored inbound follows, accepted follows enqueue outbound `Accept(Follow)` delivery rows, admin-triggered outbound follows enqueue signed `Follow` delivery rows, signed remote `Accept`/`Reject` responses update outbound follow state, published local posts enqueue outbound `Create(Note)` delivery rows, and the opt-in delivery worker can claim/sign/send/retry queued rows.
+- Before cached remote ActivityPub objects become visible posts, audit how posts render in webviews/static sites because post text is HTML. Define the sanitization/escaping and allowlist policy for local text posts, ActivityStreams `content`, admin review previews, links/media embeds, IPFS/IPNS URLs, and dangerous markup such as scripts, event handlers, `javascript:` URLs, iframes, CSS injection, malformed HTML, and oversized markup.
 - Keep moderation, deletes/updates, rich media federation, and full timeline syncing for later slices.
 - Decide whether to adopt Fedify or keep a minimal custom module. The repo now targets Node 22, so the earlier Node-floor concern is gone; the remaining decision is dependency weight, integration shape, and whether Fedify's helpers fit GeeSome's IPFS/IPNS-first identity model.
 
@@ -358,6 +359,7 @@ First deliverable:
 - Implement read-only actor/outbox/WebFinger for one local group.
 - Add tests with deterministic JSON-LD payloads and signature fixtures.
 - Reuse the shared deterministic ActivityPub helper contract from `geesome-libs` [#121](https://github.com/galtproject/geesome-libs/issues/121) for actor, WebFinger, Note/Create, digest, and request-signature fixtures.
+- Before remote object moderation can create visible posts, add HTML render-path tests that prove untrusted ActivityPub/local post HTML is sanitized or escaped consistently in API/webview/static-site/admin preview surfaces.
 
 Verification:
 


### PR DESCRIPTION
## Summary
- add an explicit ActivityPub plan gate before cached remote objects can become visible GeeSome posts
- document that post bodies render as HTML and need a sanitizer/escaping policy for webview, static-site, API, and admin preview surfaces
- call out XSS regression fixtures such as scripts, event handlers, `javascript:` URLs, iframe/embed tags, CSS injection, malformed HTML, and oversized markup

## Validation
- `git diff --check origin/dev...HEAD`

Doc-only follow-up to keep the ActivityPub backlog honest before remote post creation work starts.
