### PR TITLE
Render rich text content in ActivityPub posts

### DIFF
--- a/app/modules/activityPub/serializers.ts
+++ b/app/modules/activityPub/serializers.ts
@@ -1,6 +1,7 @@
 import type {IContentData} from '../database/interface.js';
 import {GroupType, PostStatus} from '../group/interface.js';
 import type {IGroup, IPost} from '../group/interface.js';
+import {RICH_TEXT_MIME_TYPE, isRichTextDocument, richTextToSafeHtml} from '../../richText.js';
 import {
 	activityPubContext,
 	activityPubPublicCollection,
@@ -244,7 +245,22 @@ function getActivityPubPostContent(contents: IContentData[]): string {
 	if (!textContent) {
 		return '';
 	}
+	if (textContent.mimeType === RICH_TEXT_MIME_TYPE) {
+		return getActivityPubRichTextContent(textContent.text);
+	}
 	return escapeActivityPubHtml(textContent.text);
+}
+
+function getActivityPubRichTextContent(value: string): string {
+	try {
+		const document = JSON.parse(value);
+		if (!isRichTextDocument(document)) {
+			return escapeActivityPubHtml(value);
+		}
+		return richTextToSafeHtml(document);
+	} catch {
+		return escapeActivityPubHtml(value);
+	}
 }
 
 function escapeActivityPubHtml(value: string): string {

--- a/docs/rich-text-content-format.md
+++ b/docs/rich-text-content-format.md
@@ -1,6 +1,6 @@
 # GeeSome Rich Text Content Format
 
-Status: design note with the first helper slice implemented in `app/richText.ts`. Native post storage, editor integration, and protocol wiring remain future work.
+Status: design note with the first helper slice implemented in `app/richText.ts` and ActivityPub local post serialization wired to render canonical rich-text payloads. Native post storage, editor integration, and broader protocol wiring remain future work.
 
 ## Decision
 
@@ -265,7 +265,7 @@ Recommended first code PR:
 2. Add `richTextToPlainText` and `richTextToSafeHtml`. Status: implemented in `app/richText.ts`.
 3. Add `htmlToRichText` for the current allowed HTML subset. Status: implemented in `app/richText.ts`.
 4. Add fixtures that prove unsafe HTML cannot survive the round trip. Status: implemented in `test/richText.test.ts`.
-5. Wire only one low-risk render path to the helpers before replacing broader post storage.
+5. Wire only one low-risk render path to the helpers before replacing broader post storage. Status: ActivityPub local post `content` serialization renders canonical rich-text payloads and falls back to escaped legacy text for invalid payloads.
 
 Do not change the storage format for all posts in the first implementation PR.
 

--- a/test/activityPubSerializers.test.ts
+++ b/test/activityPubSerializers.test.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import {RICH_TEXT_MIME_TYPE, createRichTextDocument} from '../app/richText.js';
 import {ContentMimeType} from '../app/modules/database/interface.js';
 import {GroupType, GroupView, PostStatus} from '../app/modules/group/interface.js';
 import {
@@ -83,6 +84,38 @@ describe('activityPub serializers', () => {
 		assert.equal(activity.type, 'Create');
 		assert.equal(activity.actor, 'https://social.example/ap/groups/test-channel');
 		assert.deepEqual(activity.object, note);
+	});
+
+	it('renders canonical rich-text post content safely', () => {
+		const document = createRichTextDocument([{
+			type: 'paragraph',
+			children: [
+				{text: 'Hello '},
+				{text: 'fediverse', marks: [{type: 'strong'}]},
+				{text: ' link', marks: [{type: 'link', href: 'https://example.com/post'}]},
+				{text: ' unsafe', marks: [{type: 'link', href: 'javascript:alert(1)'}]}
+			]
+		}]);
+		const contents = [{
+			...getContents()[0],
+			text: JSON.stringify(document),
+			mimeType: RICH_TEXT_MIME_TYPE
+		}];
+		const note = buildActivityPubPostNote(getConfig(), getGroup(), getPublishedPost(), {contents});
+
+		assert.equal(note.content, '<p>Hello <strong>fediverse</strong><a href="https://example.com/post"> link</a> unsafe</p>');
+		assert.equal(note.content.includes('javascript:'), false);
+	});
+
+	it('escapes invalid rich-text payloads instead of throwing from ActivityPub serializers', () => {
+		const contents = [{
+			...getContents()[0],
+			text: '{"bad": "<script>alert(1)</script>"}',
+			mimeType: RICH_TEXT_MIME_TYPE
+		}];
+		const note = buildActivityPubPostNote(getConfig(), getGroup(), getPublishedPost(), {contents});
+
+		assert.equal(note.content, '{&quot;bad&quot;: &quot;&lt;script&gt;alert(1)&lt;/script&gt;&quot;}');
 	});
 
 	it('builds an outbox collection and filters non-federatable posts', () => {


### PR DESCRIPTION
## Summary
- Render canonical rich-text post contents in ActivityPub Note `content` when the text content uses `application/vnd.geesome.rich-text+json`.
- Keep legacy plain-text escaping unchanged.
- Fall back to escaped raw text when a rich-text payload is malformed or invalid, so outbox serialization does not throw on bad saved content.
- Mark the rich-text design note with this first render-boundary implementation.

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/activityPubSerializers.test.ts test/richText.test.ts`
- `git diff --check -- app/modules/activityPub/serializers.ts test/activityPubSerializers.test.ts docs/rich-text-content-format.md`