### PR TITLE
Export ATProto facets from rich text

### DIFF
--- a/app/richText.ts
+++ b/app/richText.ts
@@ -49,6 +49,31 @@ export type RichTextDocument = {
 	source?: any;
 };
 
+export type RichTextAtProtoFacetFeature = {
+	$type: 'app.bsky.richtext.facet#link';
+	uri: string;
+} | {
+	$type: 'app.bsky.richtext.facet#mention';
+	did: string;
+} | {
+	$type: 'app.bsky.richtext.facet#tag';
+	tag: string;
+};
+
+export type RichTextAtProtoFacet = {
+	$type: 'app.bsky.richtext.facet';
+	index: {
+		byteStart: number;
+		byteEnd: number;
+	};
+	features: RichTextAtProtoFacetFeature[];
+};
+
+export type RichTextAtProtoText = {
+	text: string;
+	facets: RichTextAtProtoFacet[];
+};
+
 export function createRichTextDocument(blocks: RichTextBlock[], options: any = {}): RichTextDocument {
 	const document: RichTextDocument = {
 		type: RICH_TEXT_DOCUMENT_TYPE,
@@ -89,6 +114,14 @@ export function richTextToSafeHtml(document: RichTextDocument): string {
 		return '';
 	}
 	return sanitizeHtml(document.blocks.map(block => richTextBlockToHtml(block)).join(''));
+}
+
+export function richTextToAtProtoTextWithFacets(document: RichTextDocument): RichTextAtProtoText {
+	if (!isRichTextDocument(document)) {
+		return getEmptyAtProtoText();
+	}
+	const blockTexts = document.blocks.map(block => richTextBlockToAtProtoText(block));
+	return joinAtProtoTextParts(blockTexts, '\n');
 }
 
 export function isRichTextDocument(value: any): value is RichTextDocument {
@@ -538,6 +571,162 @@ function validateRichTextMark(mark: any, path: string, errors: string[]) {
 	}
 }
 
+function richTextBlockToAtProtoText(block: RichTextBlock): RichTextAtProtoText {
+	if (block.type === 'paragraph' || block.type === 'blockquote' || block.type === 'listItem') {
+		return inlineNodesToAtProtoText(block.children || []);
+	}
+	if (block.type === 'codeBlock') {
+		return {
+			text: String(block.text || ''),
+			facets: []
+		};
+	}
+	if (block.type === 'list') {
+		const itemTexts = (block.items || []).map(item => richTextBlockToAtProtoText({...item, type: 'listItem'}));
+		return joinAtProtoTextParts(itemTexts, '\n');
+	}
+	if (block.type === 'lineBreak') {
+		return {
+			text: '\n',
+			facets: []
+		};
+	}
+	if (block.type === 'attachment') {
+		return {
+			text: block.alt || block.title || '',
+			facets: []
+		};
+	}
+	return getEmptyAtProtoText();
+}
+
+function inlineNodesToAtProtoText(nodes: RichTextInlineNode[]): RichTextAtProtoText {
+	const result = getEmptyAtProtoText();
+	(nodes || []).forEach((node) => {
+		appendInlineNodeToAtProtoText(result, node);
+	});
+	return result;
+}
+
+function appendInlineNodeToAtProtoText(result: RichTextAtProtoText, node: RichTextInlineNode) {
+	const text = String(node?.text || '');
+	if (!text) {
+		return;
+	}
+	const byteStart = getUtf8ByteLength(result.text);
+	result.text += text;
+	const byteEnd = getUtf8ByteLength(result.text);
+	const features = getAtProtoFacetFeatures(node, normalizeMarks(node.marks || []));
+	if (features.length === 0) {
+		return;
+	}
+	result.facets.push({
+		$type: 'app.bsky.richtext.facet',
+		index: {
+			byteStart,
+			byteEnd
+		},
+		features
+	});
+}
+
+function getAtProtoFacetFeatures(node: RichTextInlineNode, marks: RichTextMark[]): RichTextAtProtoFacetFeature[] {
+	return marks
+		.map(mark => getAtProtoFacetFeature(node, mark))
+		.filter(Boolean) as RichTextAtProtoFacetFeature[];
+}
+
+function getAtProtoFacetFeature(node: RichTextInlineNode, mark: RichTextMark): RichTextAtProtoFacetFeature | null {
+	if (mark.type === 'link') {
+		return getAtProtoLinkFacetFeature(mark);
+	}
+	if (mark.type === 'mention') {
+		return getAtProtoMentionFacetFeature(mark);
+	}
+	if (mark.type === 'hashtag') {
+		return getAtProtoTagFacetFeature(node, mark);
+	}
+	return null;
+}
+
+function getAtProtoLinkFacetFeature(mark: RichTextMark): RichTextAtProtoFacetFeature | null {
+	const uri = sanitizeAbsoluteHref(mark.href);
+	if (!uri) {
+		return null;
+	}
+	return {
+		$type: 'app.bsky.richtext.facet#link',
+		uri
+	};
+}
+
+function getAtProtoMentionFacetFeature(mark: RichTextMark): RichTextAtProtoFacetFeature | null {
+	if (!isAtProtoDid(mark.id)) {
+		return null;
+	}
+	return {
+		$type: 'app.bsky.richtext.facet#mention',
+		did: mark.id
+	};
+}
+
+function getAtProtoTagFacetFeature(node: RichTextInlineNode, mark: RichTextMark): RichTextAtProtoFacetFeature | null {
+	const tag = getAtProtoTagName(mark.name || node.text);
+	if (!tag) {
+		return null;
+	}
+	return {
+		$type: 'app.bsky.richtext.facet#tag',
+		tag
+	};
+}
+
+function joinAtProtoTextParts(parts: RichTextAtProtoText[], separator: string): RichTextAtProtoText {
+	const result = getEmptyAtProtoText();
+	(parts || []).filter(part => part.text.length > 0).forEach((part) => {
+		if (result.text.length > 0) {
+			result.text += separator;
+		}
+		const byteOffset = getUtf8ByteLength(result.text);
+		result.text += part.text;
+		result.facets.push(...part.facets.map(facet => shiftAtProtoFacet(facet, byteOffset)));
+	});
+	return result;
+}
+
+function shiftAtProtoFacet(facet: RichTextAtProtoFacet, byteOffset: number): RichTextAtProtoFacet {
+	return {
+		...facet,
+		index: {
+			byteStart: facet.index.byteStart + byteOffset,
+			byteEnd: facet.index.byteEnd + byteOffset
+		}
+	};
+}
+
+function getAtProtoTagName(value: any): string {
+	const tag = String(value || '').trim().replace(/^#/, '');
+	if (!tag || tag.length > 640 || /\s/.test(tag)) {
+		return '';
+	}
+	return tag;
+}
+
+function isAtProtoDid(value: any): value is string {
+	return typeof value === 'string' && /^did:[a-z0-9]+:[A-Za-z0-9._:%-]+$/.test(value);
+}
+
+function getUtf8ByteLength(value: string): number {
+	return Buffer.byteLength(value, 'utf8');
+}
+
+function getEmptyAtProtoText(): RichTextAtProtoText {
+	return {
+		text: '',
+		facets: []
+	};
+}
+
 export default {
 	RICH_TEXT_DOCUMENT_TYPE,
 	RICH_TEXT_MIME_TYPE,
@@ -546,6 +735,7 @@ export default {
 	htmlToRichText,
 	richTextToPlainText,
 	richTextToSafeHtml,
+	richTextToAtProtoTextWithFacets,
 	isRichTextDocument,
 	assertRichTextDocument,
 	validateRichTextDocument

--- a/docs/activitypub-research.md
+++ b/docs/activitypub-research.md
@@ -72,7 +72,7 @@ Do not allow arbitrary raw HTML nodes, inline styles, arbitrary classes, iframes
 Adapter policy:
 
 - ActivityPub and Matrix: render from canonical rich text to conservative sanitized HTML, with plain text fallbacks where the target protocol expects them.
-- Bluesky/ATProto: render plain text plus facets for links, mentions, and tags.
+- Bluesky/ATProto: render plain text plus facets for links, mentions, and tags. Status: `richTextToAtProtoTextWithFacets` exports deterministic UTF-8 byte-indexed link, DID mention, and tag facets from canonical rich text; account-level Bluesky import/cross-post wiring remains future work.
 - Farcaster: render plain text plus mention positions and embeds.
 - Nostr-like protocols: render plaintext plus protocol tags.
 - Inbound ActivityPub/Matrix HTML: sanitize, normalize, and parse into canonical rich text before it can become a native editable GeeSome post. The original remote object may be stored for audit/debug, but it must not be rendered directly.

--- a/docs/rich-text-content-format.md
+++ b/docs/rich-text-content-format.md
@@ -1,6 +1,6 @@
 # GeeSome Rich Text Content Format
 
-Status: design note with the first helper slice implemented in `app/richText.ts` and ActivityPub local post serialization wired to render canonical rich-text payloads. Native post storage, editor integration, and broader protocol wiring remain future work.
+Status: design note with the first helper slice implemented in `app/richText.ts`, ActivityPub local post serialization wired to render canonical rich-text payloads, and ATProto-compatible plain text/facet export helpers covered by tests. Native post storage, editor integration, and broader protocol wiring remain future work.
 
 ## Decision
 
@@ -207,7 +207,7 @@ Adapters should be pure functions from canonical rich text to target representat
 | --- | --- |
 | ActivityPub | Sanitized HTML `content`, plain text summary/fallback when useful, ActivityStreams `tag` objects for mentions/hashtags, `attachment` objects for media. |
 | Matrix | Plain `body` plus `formatted_body` with `format: org.matrix.custom.html`; HTML from the same conservative renderer. |
-| ATProto/Bluesky | Plain `text` plus facets for links, mentions, and tags. Unsupported marks become plain text. |
+| ATProto/Bluesky | Plain `text` plus facets for links, mentions, and tags. Unsupported marks become plain text. Status: `richTextToAtProtoTextWithFacets` exports deterministic UTF-8 byte-indexed link, DID mention, and tag facets. |
 | Farcaster | Plain text plus mentions, mention positions, and embeds. Unsupported marks become plain text. |
 | Nostr-like notes | Plain text plus protocol tags for links, mentions, and hashtags where supported. |
 | Static site | Sanitized HTML generated from canonical rich text, plus escaped title/meta/plain snippets. |
@@ -266,6 +266,7 @@ Recommended first code PR:
 3. Add `htmlToRichText` for the current allowed HTML subset. Status: implemented in `app/richText.ts`.
 4. Add fixtures that prove unsafe HTML cannot survive the round trip. Status: implemented in `test/richText.test.ts`.
 5. Wire only one low-risk render path to the helpers before replacing broader post storage. Status: ActivityPub local post `content` serialization renders canonical rich-text payloads and falls back to escaped legacy text for invalid payloads.
+6. Add deterministic plain-text facet export for ATProto-style protocols. Status: implemented as `richTextToAtProtoTextWithFacets` with UTF-8 byte-offset fixtures in `test/richText.test.ts`.
 
 Do not change the storage format for all posts in the first implementation PR.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -372,13 +372,13 @@ First deliverable:
 - Add tests with deterministic JSON-LD payloads and signature fixtures.
 - Reuse the shared deterministic ActivityPub helper contract from `geesome-libs` [#121](https://github.com/galtproject/geesome-libs/issues/121) for actor, WebFinger, Note/Create, digest, and request-signature fixtures.
 - Before remote object moderation can create visible posts, add HTML render-path tests that prove untrusted ActivityPub/local post HTML is sanitized or escaped consistently in API/webview/static-site/admin preview surfaces. Static-site generated output and backend admin remote-object preview output now have focused helper/render tests; frontend/admin UI adoption and ActivityPub remote-content ingestion into visible posts remain.
-- Add a rich-text content-format design note with schema versioning, IPLD/DAG-CBOR storage shape, allowed blocks/marks, attachment references, migrations, sanitization boundaries, and ActivityPub/Matrix/ATProto/Farcaster/Nostr export adapters before implementing native remote-post ingestion or cross-network publishing. Status: documented in [rich-text-content-format.md](./rich-text-content-format.md); implementation remains a follow-up.
+- Add a rich-text content-format design note with schema versioning, IPLD/DAG-CBOR storage shape, allowed blocks/marks, attachment references, migrations, sanitization boundaries, and ActivityPub/Matrix/ATProto/Farcaster/Nostr export adapters before implementing native remote-post ingestion or cross-network publishing. Status: documented in [rich-text-content-format.md](./rich-text-content-format.md); helper implementation now covers canonical validation, unsafe HTML import, sanitized HTML rendering, ActivityPub local-post rendering, and ATProto-compatible UTF-8 byte-indexed text facets. Native post storage, editor integration, and direct protocol wiring remain follow-up.
 
 Verification:
 
 - New module tests for actor serialization, WebFinger, and outbox payloads.
 - Existing `test/group.test.ts` for post compatibility.
-- Rich-text adapter tests that import unsafe ActivityPub/Matrix-style HTML into the canonical model, render sanitized ActivityPub/Matrix HTML, and export deterministic plain text plus facets/tags for ATProto/Farcaster/Nostr-style protocols.
+- Rich-text adapter tests that import unsafe ActivityPub/Matrix-style HTML into the canonical model, render sanitized ActivityPub/Matrix HTML, and export deterministic plain text plus facets/tags for ATProto/Farcaster/Nostr-style protocols. Status: unsafe HTML import, sanitized HTML rendering, ActivityPub local-post rendering, and ATProto-compatible link/DID-mention/tag facet export with UTF-8 byte offsets are covered; Farcaster/Nostr-specific exporters remain future work.
 - Later integration smoke against a local ActivityPub test server.
 - Later Bluesky data-exchange smoke with the protocol boundary explicit: ActivityPub interop should use a bridge such as Bridgy Fed, while direct Bluesky/ATProto import or cross-post testing should use a seeded test `socNetAccount` database row for the Bluesky account and verify ownership, credential handling, idempotency, and moderation/signature boundaries.
 

--- a/test/richText.test.ts
+++ b/test/richText.test.ts
@@ -7,6 +7,7 @@ import {
 	createRichTextDocument,
 	htmlToRichText,
 	isRichTextDocument,
+	richTextToAtProtoTextWithFacets,
 	richTextToPlainText,
 	richTextToSafeHtml,
 	validateRichTextDocument
@@ -190,5 +191,83 @@ describe('richText helpers', () => {
 			}
 		]);
 		assert.equal(richTextToSafeHtml(document).includes('/relative'), false);
+	});
+
+	it('exports ATProto-compatible text facets with UTF-8 byte offsets', () => {
+		const document = createRichTextDocument([
+			{
+				type: 'paragraph',
+				children: [
+					{text: 'Hi 🌍 '},
+					{text: 'site', marks: [{type: 'link', href: 'https://example.com/post'}]},
+					{text: ' '},
+					{text: '@alice', marks: [{type: 'mention', id: 'did:plc:alice123'}]},
+					{text: ' '},
+					{text: '#тег', marks: [{type: 'hashtag', name: 'тег'}]},
+					{text: ' plain', marks: [{type: 'mention', id: 'alice'}]}
+				]
+			},
+			{
+				type: 'codeBlock',
+				text: 'x < y'
+			}
+		]);
+		const exported = richTextToAtProtoTextWithFacets(document);
+
+		assert.equal(exported.text, 'Hi 🌍 site @alice #тег plain\nx < y');
+		assert.deepEqual(exported.facets, [
+			{
+				$type: 'app.bsky.richtext.facet',
+				index: {
+					byteStart: 8,
+					byteEnd: 12
+				},
+				features: [{
+					$type: 'app.bsky.richtext.facet#link',
+					uri: 'https://example.com/post'
+				}]
+			},
+			{
+				$type: 'app.bsky.richtext.facet',
+				index: {
+					byteStart: 13,
+					byteEnd: 19
+				},
+				features: [{
+					$type: 'app.bsky.richtext.facet#mention',
+					did: 'did:plc:alice123'
+				}]
+			},
+			{
+				$type: 'app.bsky.richtext.facet',
+				index: {
+					byteStart: 20,
+					byteEnd: 27
+				},
+				features: [{
+					$type: 'app.bsky.richtext.facet#tag',
+					tag: 'тег'
+				}]
+			}
+		]);
+	});
+
+	it('drops unsupported ATProto facets while preserving text', () => {
+		const document = createRichTextDocument([{
+			type: 'paragraph',
+			children: [
+				{text: 'bad link', marks: [{type: 'link', href: 'javascript:alert(1)'}]},
+				{text: ' '},
+				{text: '#too long', marks: [{type: 'hashtag'}]}
+			]
+		}]);
+		const exported = richTextToAtProtoTextWithFacets(document);
+
+		assert.equal(exported.text, 'bad link #too long');
+		assert.deepEqual(exported.facets, []);
+		assert.deepEqual(richTextToAtProtoTextWithFacets({} as any), {
+			text: '',
+			facets: []
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Add `richTextToAtProtoTextWithFacets` for ATProto/Bluesky-style plain-text export from canonical rich text.
- Emit deterministic UTF-8 byte-indexed facets for safe links, DID-backed mentions, and hashtags.
- Preserve unsupported marks as plain text instead of creating misleading protocol facets.
- Update rich-text and ActivityPub TODO docs with the new adapter-helper status.

## Validation
- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/richText.test.ts`
- `git diff --check -- app/richText.ts test/richText.test.ts docs/rich-text-content-format.md docs/todo.md docs/activitypub-research.md`