### PR TITLE
Project canonical rich text content for post readers

### DIFF
--- a/app/modules/group/contentProjectionHelpers.ts
+++ b/app/modules/group/contentProjectionHelpers.ts
@@ -1,4 +1,10 @@
 import type {IContent, IContentDataProjectionOptions} from '../database/interface.js';
+import type {RichTextDocument} from '../../richText.js';
+import {
+	RICH_TEXT_MIME_TYPE,
+	contentTextToRichText,
+	richTextToPlainText
+} from '../../richText.js';
 
 type ContentTextStorage = {
 	getFileDataText(storageId: string): Promise<string>;
@@ -57,4 +63,26 @@ export async function getProjectedContentText(
 	const text = await storage.getFileDataText(storageId);
 	setBodyTextCache(options, storageId, text);
 	return text;
+}
+
+export async function getProjectedContentRichText(
+	storage: ContentTextStorage,
+	content: IContent,
+	options: IContentDataProjectionOptions = {}
+): Promise<RichTextDocument | null> {
+	if (!isProjectedRichTextContent(content)) {
+		return null;
+	}
+	return contentTextToRichText(await getProjectedContentText(storage, content, options), String(content.mimeType || ''));
+}
+
+export function getProjectedContentRichTextPlainText(document: RichTextDocument | null): string {
+	if (!document) {
+		return '';
+	}
+	return richTextToPlainText(document);
+}
+
+export function isProjectedRichTextContent(content: IContent): boolean {
+	return String(content?.mimeType || '').toLowerCase() === RICH_TEXT_MIME_TYPE;
 }

--- a/app/modules/group/index.ts
+++ b/app/modules/group/index.ts
@@ -29,7 +29,12 @@ import {
 	IListParams,
 	IListParamsOptions
 } from "../database/interface.js";
-import {getProjectedContentText} from './contentProjectionHelpers.js';
+import {
+	getProjectedContentRichText,
+	getProjectedContentRichTextPlainText,
+	getProjectedContentText,
+	isProjectedRichTextContent
+} from './contentProjectionHelpers.js';
 const {extend, pick, isUndefined, some, uniqBy, clone, orderBy, sumBy} = _;
 const log = debug('geesome:app:group');
 const groupDerivedStateQueueModuleName = 'group-derived-state';
@@ -1288,7 +1293,24 @@ function getModule(app: IGeesomeApp, models) {
 				mimeType: c.mimeType,
 				size: c.size,
 			}
-			if (c.mimeType.startsWith('text/')) {
+			const mimeType = String(c.mimeType || '');
+			if (isProjectedRichTextContent(c)) {
+				const contentData: IContentData = {
+					type: 'text',
+					...baseData
+				};
+				if (options.includeText !== false || options.includeJson !== false) {
+					const richText = await getProjectedContentRichText(app.ms.storage, c, options);
+					if (options.includeText !== false) {
+						contentData.text = getProjectedContentRichTextPlainText(richText);
+					}
+					if (richText && options.includeJson !== false) {
+						contentData.json = richText;
+					}
+				}
+				return contentData;
+			}
+			if (mimeType.startsWith('text/')) {
 				const contentData: IContentData = {
 					type: 'text',
 					...baseData
@@ -1297,17 +1319,17 @@ function getModule(app: IGeesomeApp, models) {
 					contentData.text = await getProjectedContentText(app.ms.storage, c, options);
 				}
 				return contentData;
-			} else if (c.mimeType.includes('image')) {
+			} else if (mimeType.includes('image')) {
 				return {
 					type: 'image',
 					...baseData
 				};
-			} else if (c.mimeType.includes('video')) {
+			} else if (mimeType.includes('video')) {
 				return {
 					type: 'video',
 					...baseData
 				};
-			} else if (c.mimeType.includes('json')) {
+			} else if (mimeType.includes('json')) {
 				const contentData: IContentData = {
 					type: 'json',
 					...baseData

--- a/app/richText.ts
+++ b/app/richText.ts
@@ -132,6 +132,42 @@ export function htmlToRichText(html: string, options: any = {}): RichTextDocumen
 	return createRichTextDocument(blocks, options);
 }
 
+export function plainTextToRichText(text: string, options: any = {}): RichTextDocument {
+	return createRichTextDocument(plainTextToRichTextBlocks(text), options);
+}
+
+export function contentTextToRichText(text: string, mimeType: string, options: any = {}): RichTextDocument | null {
+	const normalizedMimeType = String(mimeType || '').toLowerCase();
+	if (normalizedMimeType === RICH_TEXT_MIME_TYPE) {
+		return parseRichTextDocumentJson(text);
+	}
+	if (normalizedMimeType === 'text/html') {
+		return htmlToRichText(text, options);
+	}
+	if (normalizedMimeType.startsWith('text/')) {
+		return plainTextToRichText(text, options);
+	}
+	return null;
+}
+
+export function parseRichTextDocumentJson(value: any): RichTextDocument | null {
+	if (isRichTextDocument(value)) {
+		return value;
+	}
+	if (typeof value !== 'string') {
+		return null;
+	}
+	try {
+		const document = JSON.parse(value);
+		if (!isRichTextDocument(document)) {
+			return null;
+		}
+		return document;
+	} catch {
+		return null;
+	}
+}
+
 export function richTextToPlainText(document: RichTextDocument): string {
 	if (!isRichTextDocument(document)) {
 		return '';
@@ -255,6 +291,15 @@ function htmlNodesToBlocks($, nodes: any[]): RichTextBlock[] {
 	}
 
 	return normalizeBlocks(blocks);
+}
+
+function plainTextToRichTextBlocks(text: string): RichTextBlock[] {
+	return String(text || '')
+		.split(/\r\n|\r|\n/)
+		.map((line) => ({
+			type: 'paragraph',
+			children: line ? [{text: line}] : []
+		}));
 }
 
 function htmlNodeToBlocks($, node: any): RichTextBlock[] | null {

--- a/docs/rich-text-content-format.md
+++ b/docs/rich-text-content-format.md
@@ -1,6 +1,6 @@
 # GeeSome Rich Text Content Format
 
-Status: design note with the first helper slice implemented in `app/richText.ts`, ActivityPub local post serialization wired to render canonical rich-text payloads plus ActivityStreams mention/hashtag tags, Matrix message-content export covered by tests, ATProto-compatible plain text/facet export helpers covered by tests, Farcaster cast export covered by tests, Nostr-like text-note export covered by tests, and remote ActivityPub object previews exposing canonical rich-text content projections for review. Native post storage, editor integration, and broader protocol wiring remain future work.
+Status: design note with the first helper slice implemented in `app/richText.ts`, ActivityPub local post serialization wired to render canonical rich-text payloads plus ActivityStreams mention/hashtag tags, Matrix message-content export covered by tests, ATProto-compatible plain text/facet export helpers covered by tests, Farcaster cast export covered by tests, Nostr-like text-note export covered by tests, remote ActivityPub object previews exposing canonical rich-text content projections for review, and group content projection now exposing canonical rich-text stored payloads as body text plus validated JSON. Editor integration, native write UI, and broader protocol wiring remain future work.
 
 ## Decision
 
@@ -271,6 +271,7 @@ Recommended first code PR:
 8. Add Matrix message content export. Status: implemented as `richTextToMatrixMessageContent` with plain fallback and sanitized `org.matrix.custom.html` fixtures.
 9. Add Nostr-like text note export. Status: implemented as `richTextToNostrTextNote` with plain content plus `r`/`p`/`t` protocol tag fixtures.
 10. Add Farcaster cast export. Status: implemented as `richTextToFarcasterCast` with text, safe URL embeds, FID mentions, and byte-position fixtures.
+11. Add shared stored-content projection helpers so canonical rich-text content rows can be read as plain body text plus validated JSON by post APIs and protocol serializers. Status: implemented in `app/modules/group/contentProjectionHelpers.ts` and wired into `group.prepareContentData`.
 
 Do not change the storage format for all posts in the first implementation PR.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -491,8 +491,8 @@ Goal: move from helper-level canonical rich-text adapters toward native post sto
 
 Current state:
 
-- The design note and helpers cover canonical validation, unsafe HTML import, sanitized HTML rendering, ActivityPub/Matrix HTML output, ATProto facets, Farcaster casts, and Nostr-like tags.
-- Native post storage, editor integration, and direct protocol wiring remain follow-up.
+- The design note and helpers cover canonical validation, unsafe HTML import, sanitized HTML rendering, ActivityPub/Matrix HTML output, ATProto facets, Farcaster casts, Nostr-like tags, and stored canonical rich-text post-content projection as plain body text plus validated JSON.
+- Editor/native write UI, richer post component rendering, and direct protocol wiring remain follow-up.
 
 Implementation context:
 
@@ -502,7 +502,7 @@ Implementation context:
 
 Verification:
 
-- Rich-text helper tests plus focused group/post/editor tests when the native storage shape is introduced.
+- Rich-text helper tests plus focused group/post/editor tests as the native storage/write shape expands.
 - Rendering tests for Vue frontend, generated static sites, ActivityPub, and Bluesky adapters when wiring changes.
 <!-- /todo-section -->
 

--- a/test/contentProjectionHelpers.test.ts
+++ b/test/contentProjectionHelpers.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert';
+import {RICH_TEXT_MIME_TYPE, createRichTextDocument} from '../app/richText.js';
+import {
+	getProjectedContentRichText,
+	getProjectedContentRichTextPlainText,
+	getProjectedContentText,
+	isProjectedRichTextContent
+} from '../app/modules/group/contentProjectionHelpers.js';
+
+describe('content projection helpers', () => {
+	it('projects canonical rich-text content through the shared text cache', async () => {
+		const document = createRichTextDocument([{
+			type: 'paragraph',
+			children: [{text: 'Stored post body'}]
+		}]);
+		let readCount = 0;
+		const storage = {
+			async getFileDataText(storageId: string) {
+				readCount += 1;
+				assert.equal(storageId, 'rich-storage');
+				return JSON.stringify(document);
+			}
+		};
+		const content = {
+			storageId: 'rich-storage',
+			mimeType: RICH_TEXT_MIME_TYPE
+		} as any;
+		const options = {bodyTextCache: new Map<string, string>()};
+
+		const projected = await getProjectedContentRichText(storage, content, options);
+
+		assert.equal(isProjectedRichTextContent(content), true);
+		assert.deepEqual(projected, document);
+		assert.equal(getProjectedContentRichTextPlainText(projected), 'Stored post body');
+		assert.equal(await getProjectedContentText(storage, content, options), JSON.stringify(document));
+		assert.equal(readCount, 1);
+	});
+
+	it('ignores non-canonical or invalid rich-text content safely', async () => {
+		const storage = {
+			async getFileDataText() {
+				return '{"type":"geesome.richText"}';
+			}
+		};
+
+		assert.equal(isProjectedRichTextContent({mimeType: 'application/json'} as any), false);
+		assert.equal(
+			await getProjectedContentRichText(storage, {storageId: 'bad', mimeType: RICH_TEXT_MIME_TYPE} as any),
+			null
+		);
+		assert.equal(getProjectedContentRichTextPlainText(null), '');
+	});
+});

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -13,6 +13,7 @@ import trieHelper from "geesome-libs/src/base36Trie.js";
 import {ContentStorageType, ContentView, CorePermissionName} from "../app/modules/database/interface.js";
 import {PostContentAttachmentReason, PostEventAction, PostEventType, PostStatus} from "../app/modules/group/interface.js";
 import {IGeesomeApp} from "../app/interface.js";
+import {RICH_TEXT_MIME_TYPE, createRichTextDocument} from "../app/richText.js";
 import {
 	collectDatabaseDerivedStateIntegrity,
 	repairDatabaseDerivedState
@@ -132,6 +133,32 @@ describe("group", function () {
 		assert.equal(gotPost.contents[0].id, actorContent.id);
 		assert.equal(actorContentRows.length, 1);
 		assert.notEqual(gotPost.contents[0].id, ownerContent.id);
+	});
+
+	it('projects canonical rich-text post contents as body text with validated json', async () => {
+		const testUser = (await app.ms.database.getAllUserList('user'))[0];
+		const testGroup = (await app.ms.group.getAllGroupList(admin.id, 'test').then(r => r.list))[0];
+		const richText = createRichTextDocument([{
+			type: 'paragraph',
+			children: [{text: 'Projected body'}]
+		}]);
+		const content = await app.ms.content.saveData(testUser.id, JSON.stringify(richText), 'projected-body.json', {
+			mimeType: RICH_TEXT_MIME_TYPE,
+			view: ContentView.Contents
+		});
+		const post = await app.ms.group.createPost(testUser.id, {
+			contents: [{id: content.id, view: ContentView.Contents}],
+			groupId: testGroup.id,
+			status: PostStatus.Published
+		});
+		const gotPost = await app.ms.group.getPostPure(post.id);
+		const contentData = await app.ms.group.getPostContentData(gotPost, 'https://node.example/ipfs/');
+
+		assert.equal(contentData.length, 1);
+		assert.equal(contentData[0].type, 'text');
+		assert.equal(contentData[0].mimeType, RICH_TEXT_MIME_TYPE);
+		assert.equal(contentData[0].text, 'Projected body');
+		assert.deepEqual(contentData[0].json, richText);
 	});
 
 	it('requires an actor before creating missing remote content rows', async () => {

--- a/test/richText.test.ts
+++ b/test/richText.test.ts
@@ -4,9 +4,12 @@ import {
 	RICH_TEXT_MIME_TYPE,
 	RICH_TEXT_VERSION,
 	assertRichTextDocument,
+	contentTextToRichText,
 	createRichTextDocument,
 	htmlToRichText,
 	isRichTextDocument,
+	parseRichTextDocumentJson,
+	plainTextToRichText,
 	richTextToActivityPubTags,
 	richTextToAtProtoTextWithFacets,
 	richTextToFarcasterCast,
@@ -70,6 +73,28 @@ describe('richText helpers', () => {
 		assert.match(html, /<pre><code>x &lt; y<\/code><\/pre>/);
 		assert.match(html, /<ul><li>one<\/li><li>two<\/li><\/ul>/);
 		assert.equal(html.includes('bafy-image'), false);
+	});
+
+	it('normalizes stored content text formats into canonical rich text', () => {
+		const document = createRichTextDocument([{
+			type: 'paragraph',
+			children: [{text: 'Stored rich text'}]
+		}]);
+
+		assert.deepEqual(parseRichTextDocumentJson(JSON.stringify(document)), document);
+		assert.equal(parseRichTextDocumentJson('{bad json'), null);
+		assert.equal(parseRichTextDocumentJson({type: 'not-rich-text'}), null);
+		assert.equal(
+			richTextToPlainText(contentTextToRichText(JSON.stringify(document), RICH_TEXT_MIME_TYPE)!),
+			'Stored rich text'
+		);
+		assert.equal(
+			richTextToPlainText(contentTextToRichText('<p>Hello <strong>html</strong></p><script>x()</script>', 'text/html')!),
+			'Hello html'
+		);
+		assert.equal(richTextToPlainText(plainTextToRichText('line one\nline two')), 'line one\nline two');
+		assert.equal(contentTextToRichText('{"type":"geesome.richText"}', RICH_TEXT_MIME_TYPE), null);
+		assert.equal(contentTextToRichText('{"ok":true}', 'application/json'), null);
 	});
 
 	it('imports unsafe html into canonical rich text without preserving active content', () => {


### PR DESCRIPTION
## Summary
- add rich-text parsing helpers for stored canonical JSON, HTML, and plain text
- project canonical rich-text content rows as post body text with validated JSON for richer consumers
- document the completed storage projection bridge and add focused helper/group coverage

## Validation
- GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/richText.test.ts test/contentProjectionHelpers.test.ts test/activityPubSerializers.test.ts
- GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/blueskyModule.test.ts --grep "cross-posts local rich-text posts"
- git diff --cached --check

## Note
- A local group integration grep was attempted, but this machine could not boot the full app test because local Postgres rejected the configured geesome user and local js-ipfs hit the @peculiar/webcrypto Crypto export issue before the test body ran. The integration test is included for Docker/CI coverage.