### PR TITLE
Accept canonical rich text post bodies

### DIFF
--- a/app/modules/group/api.ts
+++ b/app/modules/group/api.ts
@@ -171,7 +171,7 @@ export default (app: IGeesomeApp, groupModule: IGeesomeGroupModule) => {
 
     /**
      * @api {post} /v1/user/group/create-post Create Group post
-     * @apiDescription Create post by content ids and group id.
+     * @apiDescription Create post by content references and/or canonical rich-text body data.
      * @apiName UserGroupCreatePost
      * @apiGroup UserGroup
      *
@@ -187,7 +187,7 @@ export default (app: IGeesomeApp, groupModule: IGeesomeGroupModule) => {
      *   curl -X POST http://localhost:2052/v1/user/group/create-post \
      *     -H "Authorization: Bearer geesome-api-key" \
      *     -H "Content-Type: application/json" \
-     *     -d '{"groupId":1,"contentIds":[10],"type":"post"}'
+     *     -d '{"groupId":1,"contentRichText":{"type":"geesome.richText","version":1,"blocks":[{"type":"paragraph","children":[{"text":"Hello"}]}]},"contents":[{"id":10,"view":"attachment"}],"type":"post"}'
      */
     app.ms.api.onAuthorizedPost('user/group/create-post', async (req, res) => {
         res.send(await groupModule.createPost(req.user.id, req.body), 200);

--- a/app/modules/group/index.ts
+++ b/app/modules/group/index.ts
@@ -35,6 +35,7 @@ import {
 	getProjectedContentText,
 	isProjectedRichTextContent
 } from './contentProjectionHelpers.js';
+import {getPostInputContents, stripPostContentInputFields} from './postContentInputHelpers.js';
 const {extend, pick, isUndefined, some, uniqBy, clone, orderBy, sumBy} = _;
 const log = debug('geesome:app:group');
 const groupDerivedStateQueueModuleName = 'group-derived-state';
@@ -1103,8 +1104,9 @@ function getModule(app: IGeesomeApp, models) {
 			postData.groupId = await this.checkGroupId(postData.groupId);
 			log('checkGroupId');
 
-			const contents = await this.getContentsForPost(userId, postData.contents);
-			delete postData.contents;
+			const postInputContents = await getPostInputContents(app, userId, postData);
+			stripPostContentInputFields(postData);
+			const contents = await this.getContentsForPost(userId, postInputContents);
 			const size = sumBy(contents || [], contentSize);
 
 			const [user, group] = await Promise.all([
@@ -1413,8 +1415,9 @@ function getModule(app: IGeesomeApp, models) {
 			}
 			delete postData.groupId;
 
-			const contentsData = await this.getContentsForPost(userId, postData.contents);
-			delete postData.contents;
+			const postInputContents = await getPostInputContents(app, userId, postData);
+			stripPostContentInputFields(postData);
+			const contentsData = await this.getContentsForPost(userId, postInputContents);
 
 			// B4: drafts/deleted rows are DB-only. Only run post manifest/static rebuild when
 			// the merged row is actively published. Rows that leave the public lifecycle still

--- a/app/modules/group/interface.ts
+++ b/app/modules/group/interface.ts
@@ -5,6 +5,7 @@ import {
 	IUser
 } from "../database/interface.js";
 import {IUserListResponse} from "../../interface.js";
+import type {RichTextDocument} from "../../richText.js";
 
 export default interface IGeesomeGroupModule {
 
@@ -418,6 +419,9 @@ export interface IPostInput {
 	groupId: number;
 	contentIds?: number[];
 	contentsIds?: number[];
+	contents?: IContent[];
+	contentRichText?: RichTextDocument;
+	contentRichTextFileName?: string;
 	view?: string;
 	type?: string;
 	size?: string;
@@ -432,6 +436,9 @@ export interface IPostInput {
 export interface IPostUpdateInput {
 	contentIds?: number[];
 	contentsIds?: number[];
+	contents?: IContent[];
+	contentRichText?: RichTextDocument;
+	contentRichTextFileName?: string;
 	view?: string;
 	type?: string;
 	size?: string;

--- a/app/modules/group/postContentInputHelpers.ts
+++ b/app/modules/group/postContentInputHelpers.ts
@@ -1,0 +1,53 @@
+import type {IGeesomeApp} from '../../interface.js';
+import type {IContent} from '../database/interface.js';
+import {ContentView} from '../database/interface.js';
+import type {RichTextDocument} from '../../richText.js';
+import {RICH_TEXT_MIME_TYPE, assertRichTextDocument} from '../../richText.js';
+
+export type PostContentRichTextInput = {
+	contentRichText?: RichTextDocument | null;
+	contentRichTextFileName?: string;
+	contents?: IContent[];
+};
+
+export async function getPostInputContents(app: IGeesomeApp, userId: number, postData: PostContentRichTextInput): Promise<IContent[] | null> {
+	if (!hasContentRichTextInput(postData)) {
+		return postData.contents || null;
+	}
+	const richTextContent = await createPostRichTextContent(app, userId, postData);
+	return [richTextContent, ...(postData.contents || [])];
+}
+
+export function stripPostContentInputFields(postData: PostContentRichTextInput): void {
+	delete postData.contents;
+	delete postData.contentRichText;
+	delete postData.contentRichTextFileName;
+}
+
+function hasContentRichTextInput(postData: PostContentRichTextInput): boolean {
+	return postData.contentRichText !== undefined && postData.contentRichText !== null;
+}
+
+async function createPostRichTextContent(app: IGeesomeApp, userId: number, postData: PostContentRichTextInput): Promise<IContent> {
+	const contentRichText = postData.contentRichText;
+	assertRichTextDocument(contentRichText);
+	return app.ms.content.saveData(
+		userId,
+		JSON.stringify(contentRichText),
+		getPostRichTextContentFileName(postData),
+		{
+			mimeType: RICH_TEXT_MIME_TYPE,
+			view: ContentView.Contents,
+			properties: {
+				source: 'group:contentRichText'
+			}
+		}
+	);
+}
+
+function getPostRichTextContentFileName(postData: PostContentRichTextInput): string {
+	if (typeof postData.contentRichTextFileName === 'string' && postData.contentRichTextFileName.trim()) {
+		return postData.contentRichTextFileName.trim();
+	}
+	return 'post-rich-text.json';
+}

--- a/docs/rich-text-content-format.md
+++ b/docs/rich-text-content-format.md
@@ -1,6 +1,6 @@
 # GeeSome Rich Text Content Format
 
-Status: design note with the first helper slice implemented in `app/richText.ts`, ActivityPub local post serialization wired to render canonical rich-text payloads plus ActivityStreams mention/hashtag tags, Matrix message-content export covered by tests, ATProto-compatible plain text/facet export helpers covered by tests, Farcaster cast export covered by tests, Nostr-like text-note export covered by tests, remote ActivityPub object previews exposing canonical rich-text content projections for review, and group content projection now exposing canonical rich-text stored payloads as body text plus validated JSON. Editor integration, native write UI, and broader protocol wiring remain future work.
+Status: design note with the first helper slice implemented in `app/richText.ts`, ActivityPub local post serialization wired to render canonical rich-text payloads plus ActivityStreams mention/hashtag tags, Matrix message-content export covered by tests, ATProto-compatible plain text/facet export helpers covered by tests, Farcaster cast export covered by tests, Nostr-like text-note export covered by tests, remote ActivityPub object previews exposing canonical rich-text content projections for review, group content projection exposing canonical rich-text stored payloads as body text plus validated JSON, and backend post create/update input accepting canonical rich-text body data. Editor integration, native write UI, and broader protocol wiring remain future work.
 
 ## Decision
 
@@ -272,6 +272,7 @@ Recommended first code PR:
 9. Add Nostr-like text note export. Status: implemented as `richTextToNostrTextNote` with plain content plus `r`/`p`/`t` protocol tag fixtures.
 10. Add Farcaster cast export. Status: implemented as `richTextToFarcasterCast` with text, safe URL embeds, FID mentions, and byte-position fixtures.
 11. Add shared stored-content projection helpers so canonical rich-text content rows can be read as plain body text plus validated JSON by post APIs and protocol serializers. Status: implemented in `app/modules/group/contentProjectionHelpers.ts` and wired into `group.prepareContentData`.
+12. Add backend native write input so post create/update can receive a validated `contentRichText` document and save it as a normal `ContentView.Contents` row. Status: implemented in `app/modules/group/postContentInputHelpers.ts` and wired into `group.createPost` / `group.updatePost`.
 
 Do not change the storage format for all posts in the first implementation PR.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -491,8 +491,8 @@ Goal: move from helper-level canonical rich-text adapters toward native post sto
 
 Current state:
 
-- The design note and helpers cover canonical validation, unsafe HTML import, sanitized HTML rendering, ActivityPub/Matrix HTML output, ATProto facets, Farcaster casts, Nostr-like tags, and stored canonical rich-text post-content projection as plain body text plus validated JSON.
-- Editor/native write UI, richer post component rendering, and direct protocol wiring remain follow-up.
+- The design note and helpers cover canonical validation, unsafe HTML import, sanitized HTML rendering, ActivityPub/Matrix HTML output, ATProto facets, Farcaster casts, Nostr-like tags, stored canonical rich-text post-content projection as plain body text plus validated JSON, and backend create/update post input for native canonical rich-text bodies.
+- Editor/native write UI, richer post component rendering, and broader direct protocol wiring remain follow-up.
 
 Implementation context:
 

--- a/test/postContentInputHelpers.test.ts
+++ b/test/postContentInputHelpers.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert';
+import {ContentView} from '../app/modules/database/interface.js';
+import {getPostInputContents, stripPostContentInputFields} from '../app/modules/group/postContentInputHelpers.js';
+import {RICH_TEXT_MIME_TYPE, createRichTextDocument} from '../app/richText.js';
+
+describe('post content input helpers', () => {
+	it('saves canonical rich-text post bodies as ordinary contents refs', async () => {
+		const calls: any[] = [];
+		const app = {
+			ms: {
+				content: {
+					async saveData(userId, data, fileName, options) {
+						calls.push({userId, data, fileName, options});
+						return {
+							id: 11,
+							view: options.view,
+							mimeType: options.mimeType
+						};
+					}
+				}
+			}
+		};
+		const richText = createRichTextDocument([{
+			type: 'paragraph',
+			children: [{text: 'Native body'}]
+		}]);
+		const attachmentRef = {id: 22, view: ContentView.Attachment} as any;
+		const postData = {
+			contentRichText: richText,
+			contentRichTextFileName: 'body.json',
+			contents: [attachmentRef]
+		};
+
+		const contents = await getPostInputContents(app as any, 7, postData);
+
+		assert.deepEqual(contents, [{
+			id: 11,
+			view: ContentView.Contents,
+			mimeType: RICH_TEXT_MIME_TYPE
+		}, attachmentRef]);
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0].userId, 7);
+		assert.equal(calls[0].data, JSON.stringify(richText));
+		assert.equal(calls[0].fileName, 'body.json');
+		assert.equal(calls[0].options.mimeType, RICH_TEXT_MIME_TYPE);
+		assert.equal(calls[0].options.view, ContentView.Contents);
+		assert.equal(calls[0].options.properties.source, 'group:contentRichText');
+	});
+
+	it('preserves legacy content refs when rich text is absent', async () => {
+		const contentsRef = [{id: 33, view: ContentView.Contents}] as any;
+		const app = {
+			ms: {
+				content: {
+					async saveData() {
+						throw new Error('unexpected_save');
+					}
+				}
+			}
+		};
+
+		assert.equal(await getPostInputContents(app as any, 7, {contents: contentsRef}), contentsRef);
+		assert.equal(await getPostInputContents(app as any, 7, {}), null);
+	});
+
+	it('rejects invalid rich-text body data before saving content', async () => {
+		const app = {
+			ms: {
+				content: {
+					async saveData() {
+						throw new Error('unexpected_save');
+					}
+				}
+			}
+		};
+
+		await assert.rejects(
+			() => getPostInputContents(app as any, 7, {contentRichText: {type: 'bad'} as any}),
+			/rich_text_document_invalid/
+		);
+	});
+
+	it('strips API-only post body input fields before persistence', () => {
+		const postData = {
+			contentRichText: createRichTextDocument([]),
+			contentRichTextFileName: 'body.json',
+			contents: [{id: 44}],
+			type: 'post'
+		};
+
+		stripPostContentInputFields(postData as any);
+
+		assert.deepEqual(postData, {type: 'post'});
+	});
+});


### PR DESCRIPTION
## Summary
- add a group post input helper that saves validated `contentRichText` as a normal `ContentView.Contents` content row
- wire `contentRichText` into post create/update while preserving the existing `contents` reference flow
- update group API docs, input interfaces, and the rich-text TODO/design note

## Validation
- GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/postContentInputHelpers.test.ts test/richText.test.ts test/contentProjectionHelpers.test.ts test/activityPubSerializers.test.ts
- GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/blueskyModule.test.ts --grep "cross-posts local rich-text posts"
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/group/index.ts'); await import('./app/modules/group/postContentInputHelpers.ts');"
- npm run generate-docs
- npm run security:route-inventory
- git diff --check