### PR TITLE
Render canonical rich text in static-site metadata

### DIFF
--- a/app/modules/staticSiteGenerator/helpers.ts
+++ b/app/modules/staticSiteGenerator/helpers.ts
@@ -12,6 +12,7 @@ import { join } from 'path';
 import {load as cheerioLoad} from 'cheerio';
 import {readdirSync, rmdirSync, unlinkSync, statSync} from 'fs';
 import {sanitizeHtml} from '../../htmlSafety.js';
+import {isRichTextDocument, richTextToSafeHtml} from '../../richText.js';
 const {trim} = _;
 
 const isDir = path => {
@@ -219,6 +220,12 @@ function sanitizeStaticSiteContents(contents = []) {
 }
 
 function sanitizeStaticSiteContent(content) {
+    if (content?.type === 'text' && isRichTextDocument(content.json)) {
+        return {
+            ...content,
+            text: richTextToSafeHtml(content.json)
+        };
+    }
     if (content?.type !== 'text' || typeof content.text !== 'string') {
         return content;
     }

--- a/docs/rich-text-content-format.md
+++ b/docs/rich-text-content-format.md
@@ -1,6 +1,6 @@
 # GeeSome Rich Text Content Format
 
-Status: design note with the first helper slice implemented in `app/richText.ts`, ActivityPub local post serialization wired to render canonical rich-text payloads plus ActivityStreams mention/hashtag tags, Matrix message-content export covered by tests, ATProto-compatible plain text/facet export helpers covered by tests, Farcaster cast export covered by tests, Nostr-like text-note export covered by tests, remote ActivityPub object previews exposing canonical rich-text content projections for review, group content projection exposing canonical rich-text stored payloads as body text plus validated JSON, and backend post create/update input accepting canonical rich-text body data. Editor integration, native write UI, and broader protocol wiring remain future work.
+Status: design note with the first helper slice implemented in `app/richText.ts`, ActivityPub local post serialization wired to render canonical rich-text payloads plus ActivityStreams mention/hashtag tags, Matrix message-content export covered by tests, ATProto-compatible plain text/facet export helpers covered by tests, Farcaster cast export covered by tests, Nostr-like text-note export covered by tests, remote ActivityPub object previews exposing canonical rich-text content projections for review, group content projection exposing canonical rich-text stored payloads as body text plus validated JSON, backend post create/update input accepting canonical rich-text body data, and static-site post metadata rendering canonical rich-text content through the safe HTML renderer. Editor integration, native write UI, and broader protocol wiring remain future work.
 
 ## Decision
 
@@ -210,7 +210,7 @@ Adapters should be pure functions from canonical rich text to target representat
 | ATProto/Bluesky | Plain `text` plus facets for links, mentions, and tags. Unsupported marks become plain text. Status: `richTextToAtProtoTextWithFacets` exports deterministic UTF-8 byte-indexed link, DID mention, and tag facets. |
 | Farcaster | Plain text plus mentions, byte-based mention positions, and embeds. Unsupported marks become plain text. Status: `richTextToFarcasterCast` exports CastAdd-style `text`, `embeds`, empty `embedsDeprecated`, `mentions`, and `mentionsPositions`, removes valid FID mention display text from the cast body, preserves invalid mentions as plain text, and bounds safe link embeds to Farcaster's two-embed shape. |
 | Nostr-like notes | Plain text plus protocol tags for links, mentions, and hashtags where supported. Status: `richTextToNostrTextNote` exports plain content plus `r`, `p`, and `t` tags for safe links, 64-hex pubkey mentions, and hashtags. |
-| Static site | Sanitized HTML generated from canonical rich text, plus escaped title/meta/plain snippets. |
+| Static site | Sanitized HTML generated from canonical rich text, plus escaped title/meta/plain snippets. Status: static-site content sanitization prefers validated canonical rich-text JSON and renders it through `richTextToSafeHtml`, with legacy text HTML still sanitized as a fallback. |
 | Search/snippets | Plain text only, no HTML. |
 
 Every adapter should have fixtures for unsafe input, nested marks, links, mentions, hashtags, attachments, empty docs, and unsupported features.
@@ -273,6 +273,7 @@ Recommended first code PR:
 10. Add Farcaster cast export. Status: implemented as `richTextToFarcasterCast` with text, safe URL embeds, FID mentions, and byte-position fixtures.
 11. Add shared stored-content projection helpers so canonical rich-text content rows can be read as plain body text plus validated JSON by post APIs and protocol serializers. Status: implemented in `app/modules/group/contentProjectionHelpers.ts` and wired into `group.prepareContentData`.
 12. Add backend native write input so post create/update can receive a validated `contentRichText` document and save it as a normal `ContentView.Contents` row. Status: implemented in `app/modules/group/postContentInputHelpers.ts` and wired into `group.createPost` / `group.updatePost`.
+13. Render canonical rich-text post content through the generated static-site safe HTML path instead of downgrading it to plain text first. Status: implemented in `app/modules/staticSiteGenerator/helpers.ts`.
 
 Do not change the storage format for all posts in the first implementation PR.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -491,7 +491,7 @@ Goal: move from helper-level canonical rich-text adapters toward native post sto
 
 Current state:
 
-- The design note and helpers cover canonical validation, unsafe HTML import, sanitized HTML rendering, ActivityPub/Matrix HTML output, ATProto facets, Farcaster casts, Nostr-like tags, stored canonical rich-text post-content projection as plain body text plus validated JSON, and backend create/update post input for native canonical rich-text bodies.
+- The design note and helpers cover canonical validation, unsafe HTML import, sanitized HTML rendering, ActivityPub/Matrix HTML output, ATProto facets, Farcaster casts, Nostr-like tags, stored canonical rich-text post-content projection as plain body text plus validated JSON, backend create/update post input for native canonical rich-text bodies, and static-site rendering from canonical rich text through the safe HTML renderer.
 - Editor/native write UI, richer post component rendering, and broader direct protocol wiring remain follow-up.
 
 Implementation context:

--- a/test/staticSiteGeneratorHelpers.test.ts
+++ b/test/staticSiteGeneratorHelpers.test.ts
@@ -1,7 +1,8 @@
 import assert from 'assert';
+import {createRichTextDocument} from '../app/richText.js';
 import ssgHelpers from '../app/modules/staticSiteGenerator/helpers.js';
 
-const {getTitleAndDescription, sanitizeStaticSiteHtml} = ssgHelpers;
+const {getPostTitleAndDescription, getTitleAndDescription, sanitizeStaticSiteContents, sanitizeStaticSiteHtml} = ssgHelpers;
 
 describe('staticSiteGenerator helpers', () => {
 	it('sanitizes unsafe post html while preserving safe formatting and links', () => {
@@ -45,5 +46,57 @@ describe('staticSiteGenerator helpers', () => {
 		assert.equal(description.includes('<script'), false);
 		assert.equal(description.includes('javascript:'), false);
 		assert.match(description, /<a[^>]+href="ipns:\/\/example-key\/path"[^>]*>safe ipns<\/a>/);
+	});
+
+	it('renders canonical rich-text contents through the safe static-site html renderer', () => {
+		const richText = createRichTextDocument([{
+			type: 'paragraph',
+			children: [
+				{text: 'Rich '},
+				{text: 'title', marks: [{type: 'strong'}]},
+				{text: ' link', marks: [{type: 'link', href: 'https://example.com/post'}]},
+				{text: ' bad', marks: [{type: 'link', href: 'javascript:alert(1)'} as any]}
+			]
+		}]);
+		const [content] = sanitizeStaticSiteContents([{
+			type: 'text',
+			view: 'contents',
+			text: '<script>alert(1)</script>',
+			json: richText
+		}]);
+
+		assert.equal(content.text.includes('<script'), false);
+		assert.equal(content.text.includes('javascript:'), false);
+		assert.match(content.text, /<strong>title<\/strong>/);
+		assert.match(content.text, /<a[^>]+href="https:\/\/example\.com\/post"[^>]*> link<\/a>/);
+
+		const meta = getPostTitleAndDescription({}, [content], {
+			titleLength: 200,
+			descriptionLength: 200
+		});
+
+		assert.equal(meta.pageTitle, 'Rich title link bad');
+		assert.match(meta.itemTitle, /Rich/);
+		assert.match(meta.itemTitle, /title/);
+		assert.equal(meta.itemTitle.includes('<script'), false);
+		assert.equal(meta.itemDescription.includes('javascript:'), false);
+	});
+
+	it('falls back to sanitizing legacy text html when rich-text json is absent or invalid', () => {
+		const contents = sanitizeStaticSiteContents([
+			{
+				type: 'text',
+				view: 'contents',
+				text: '<p onclick="x()">Legacy <em>html</em></p><script>x()</script>',
+				json: {type: 'bad'}
+			},
+			{
+				type: 'image',
+				text: '<script>x()</script>'
+			}
+		]);
+
+		assert.equal(contents[0].text, '<p>Legacy <em>html</em></p>');
+		assert.equal(contents[1].text, '<script>x()</script>');
 	});
 });


### PR DESCRIPTION
## Summary
- render validated canonical rich-text post content through `richTextToSafeHtml` in static-site content sanitization
- keep legacy text/html sanitization as the fallback for non-rich-text content
- update the rich-text TODO/design note and add static-site helper coverage

## Validation
- GROUP_DERIVED_STATE_ASYNC=0 node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha test/staticSiteGeneratorHelpers.test.ts test/richText.test.ts
- node --import tsx --experimental-global-customevent -e "await import('./app/modules/staticSiteGenerator/helpers.ts');"
- git diff --check