### PR TITLE
Fix static site list recency and gateway hook cache

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -491,16 +491,14 @@ function getModule(config, appPass) {
     }
 
     async callHook(callFromModule, name, args) {
-      const supportHookListExist = !!this.msSupportHookList[name];
-      const modulesList = this.msSupportHookList[name] || this.config.modules;
-      if (!supportHookListExist) {
+      if (!this.msSupportHookList[name]) {
         this.msSupportHookList[name] = [];
       }
-      return pIteration.mapSeries(modulesList, (moduleName: string) => {
+      return pIteration.mapSeries(this.config.modules, (moduleName: string) => {
         if (!this.ms[moduleName] || !this.ms[moduleName][name]) {
           return;
         }
-        if (!supportHookListExist) {
+        if (!this.msSupportHookList[name].includes(moduleName)) {
           this.msSupportHookList[name].push(moduleName);
         }
         if (moduleName === callFromModule) {

--- a/app/modules/staticSiteGenerator/index.ts
+++ b/app/modules/staticSiteGenerator/index.ts
@@ -21,7 +21,7 @@ const generatedGroupPostsLimit = 9999;
 const generatedGroupPostBatchLimit = 100;
 const generatedOutputCacheLimit = helpers.parsePositiveInteger(process.env.GENERATED_OUTPUT_CACHE_LIMIT, 500);
 const staticSiteListParams: IListParamsOptions = {
-    sortBy: 'createdAt',
+    sortBy: 'updatedAt',
     allowedSortBy: ['createdAt', 'updatedAt', 'id', 'name', 'entityType', 'entityId'],
     maxLimit: 100
 };

--- a/test/staticSiteGenerator.test.ts
+++ b/test/staticSiteGenerator.test.ts
@@ -146,6 +146,44 @@ describe("staticSiteGenerator", function () {
 		assert.equal(await app.callHookCheckAllowed('content', 'isStorageIdAllowed', [directoryStorageId]), true);
 	});
 
+	it('should list recently refreshed static sites first by default', async () => {
+		const StaticSite = app.ms.database.sequelize.model('staticSite') as any;
+		const refreshedSite = await (staticSiteGenerator as any).createDbStaticSite({
+			userId: testUser.id,
+			entityType: 'content-list',
+			entityId: 'refreshed-list',
+			name: 'refreshed_site',
+			title: 'Refreshed site',
+			storageId: 'refreshed-storage'
+		});
+		const newerCreatedSite = await (staticSiteGenerator as any).createDbStaticSite({
+			userId: testUser.id,
+			entityType: 'content-list',
+			entityId: 'newer-created-list',
+			name: 'newer_created_site',
+			title: 'Newer created site',
+			storageId: 'newer-created-storage'
+		});
+
+		await StaticSite.update({
+			createdAt: new Date('2026-07-01T10:00:00.000Z'),
+			updatedAt: new Date('2026-07-08T10:00:00.000Z')
+		}, {where: {id: refreshedSite.id}, silent: true});
+		await StaticSite.update({
+			createdAt: new Date('2026-07-07T10:00:00.000Z'),
+			updatedAt: new Date('2026-07-07T10:00:00.000Z')
+		}, {where: {id: newerCreatedSite.id}, silent: true});
+
+		const response = await staticSiteGenerator.getStaticSiteResponse(testUser.id, 'content-list', {limit: 10});
+		assert.deepEqual(response.list.map(site => site.storageId), [
+			'refreshed-storage',
+			'newer-created-storage'
+		]);
+
+		(app as any).msSupportHookList.isStorageIdAllowed = [];
+		assert.equal(await app.callHookCheckAllowed('content', 'isStorageIdAllowed', ['refreshed-storage']), true);
+	});
+
 	it('should use group avatar as generated site favicon', async () => {
 		const pngImagePath = await resourcesHelper.prepare('input-image.png');
 		const avatarContent = await app.ms.content.saveData(testUser.id, fs.createReadStream(pngImagePath), 'input-image.png', {


### PR DESCRIPTION
## Summary
- Fixes the gateway authorization hook cache so early `/ipfs/*` requests during startup cannot permanently hide later-loaded hook responders like `staticSiteGenerator`.
- Changes static-site list defaults to `updatedAt DESC`, so refreshed generated pages appear before older outputs.
- Adds a regression covering both refreshed ordering and stale empty hook-cache recovery.

Closes #1233

## Verification
- Focused Docker regression passed on this branch.
- Full `npm run test:docker` was attempted; it completed 406 passing / 11 pending but failed with 9 timeouts in broad app/storage/image-heavy tests, consistent with IPFS/object storage timeouts rather than assertion failures in this patch.
