### PR TITLE
Make static site search indexing opt-in

### DIFF
--- a/app/modules/content/api.ts
+++ b/app/modules/content/api.ts
@@ -345,7 +345,7 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
      * @apiName IpfsContent
      * @apiGroup ContentData
      *
-     * @apiDescription Unversioned IPFS gateway-compatible content stream.
+     * @apiDescription Unversioned IPFS gateway-compatible content stream. Generated static-site roots include `X-Robots-Tag: noindex, nofollow` unless the static-site render options explicitly set `allowSearchIndexing` to boolean `true`.
      * @apiUse StorageErrors
     */
     app.ms.api.onUnversionGet('/ipfs/*', async (req, res) => {
@@ -360,7 +360,7 @@ export default (app: IGeesomeApp, contentModule: IGeesomeContentModule) => {
      * @apiName IpfsContentHead
      * @apiGroup ContentData
      *
-     * @apiDescription Unversioned IPFS gateway-compatible HEAD request.
+     * @apiDescription Unversioned IPFS gateway-compatible HEAD request. Generated static-site roots include `X-Robots-Tag: noindex, nofollow` unless the static-site render options explicitly set `allowSearchIndexing` to boolean `true`.
      * @apiUse StorageErrors
      */
     app.ms.api.onUnversionHead('/ipfs/*', async (req, res) => {

--- a/app/modules/content/index.ts
+++ b/app/modules/content/index.ts
@@ -180,6 +180,36 @@ function getModule(app: IGeesomeApp) {
 		return app.callHookCheckAllowed('content', 'isStorageIdAllowed', [storageId]);
 	}
 
+	async function getStorageResponseHeadersForApi(storageId) {
+		if (!storageId) {
+			return {};
+		}
+		if (typeof app.callHook !== 'function') {
+			return {};
+		}
+		return mergeStorageResponseHeaders(await app.callHook('content', 'getStorageResponseHeaders', [storageId]));
+	}
+
+	function mergeStorageResponseHeaders(responseList = []) {
+		const headers = {};
+		if (!isArray(responseList)) {
+			return headers;
+		}
+		responseList.forEach((responseHeaders) => {
+			if (!responseHeaders || !isObject(responseHeaders) || isArray(responseHeaders)) {
+				return;
+			}
+			Object.keys(responseHeaders).forEach((name) => {
+				const value = responseHeaders[name];
+				if (isUndefined(value) || value === null) {
+					return;
+				}
+				headers[name] = value;
+			});
+		});
+		return headers;
+	}
+
 	function isPublishedAppStorageId(storageId) {
 		return storageId && (storageId === app.docsStorageId || storageId === app.frontendStorageId);
 	}
@@ -1241,12 +1271,14 @@ function getModule(app: IGeesomeApp) {
 				const storagePathMetadata = await this.getSharedStorageMetadataForPath(dataPath);
 				const {storageId} = storagePathMetadata;
 				let content = storagePathMetadata.content;
+				let storageResponseHeaders = {};
 				helpers.logDebug(log, () => ['content', helpers.toLogValue(content)]);
 				if (!content) {
 					const storageIdAllowed = await isStorageIdAllowedForApi(storageId);
 					if (!storageIdAllowed) {
 						return res.send(423);
 					}
+					storageResponseHeaders = await getStorageResponseHeadersForApi(storageId);
 				}
 
 				dataPath = this.prepareContentStoragePathResponse(res, dataPath, content);
@@ -1258,7 +1290,7 @@ function getModule(app: IGeesomeApp) {
 				if (fileStat.cid) {
 					content = await app.ms.database.getSharedStorageMetadataByStorageId(ipfsHelper.cidToIpfsHash(fileStat.cid), {includePreviews: true});
 				}
-				const headers = await this.getIpfsHashHeadersObj(content, dataPath, fileStat.size, false);
+				const headers = await this.getIpfsHashHeadersObj(content, dataPath, fileStat.size, false, storageResponseHeaders);
 				log('headers', headers);
 				res.writeHead(200, headers);
 				return this.getFileStream(dataPath).then((stream) => {
@@ -1269,11 +1301,13 @@ function getModule(app: IGeesomeApp) {
 			const storagePathMetadata = await this.getSharedStorageMetadataForPath(dataPath);
 			const {storageId} = storagePathMetadata;
 			const content = storagePathMetadata.content;
+			let storageResponseHeaders = {};
 			if (!content) {
 				const storageIdAllowed = await isStorageIdAllowedForApi(storageId);
 				if (!storageIdAllowed) {
 					return res.send(423);
 				}
+				storageResponseHeaders = await getStorageResponseHeadersForApi(storageId);
 			}
 
 			const contentStoragePath = dataPath;
@@ -1322,6 +1356,7 @@ function getModule(app: IGeesomeApp) {
 					// 'Cache-Control': 'no-cache, no-store, must-revalidate',
 					// 'Pragma': 'no-cache',
 					// 'Expires': 0,
+					...storageResponseHeaders,
 					'Cross-Origin-Resource-Policy': 'cross-origin',
 					'Content-Type': mimeType,
 					'Accept-Ranges': 'bytes',
@@ -1338,12 +1373,14 @@ function getModule(app: IGeesomeApp) {
 			const storagePathMetadata = await this.getSharedStorageMetadataForPath(dataPath);
 			const {storageId} = storagePathMetadata;
 			let content = storagePathMetadata.content;
+			let storageResponseHeaders = {};
 			if (!content) {
 				const storageIdAllowed = await isStorageIdAllowedForApi(storageId);
 				if (!storageIdAllowed) {
 					res.writeHead(423, {'Cross-Origin-Resource-Policy': 'cross-origin'});
 					return res.stream.end();
 				}
+				storageResponseHeaders = await getStorageResponseHeadersForApi(storageId);
 			}
 
 			dataPath = this.prepareContentStoragePathResponse(res, dataPath, content);
@@ -1355,12 +1392,12 @@ function getModule(app: IGeesomeApp) {
 			if (fileStat.cid) {
 				content = await app.ms.database.getSharedStorageMetadataByStorageId(ipfsHelper.cidToIpfsHash(fileStat.cid), {includePreviews: true});
 			}
-			const headersObj = await this.getIpfsHashHeadersObj(content, dataPath, fileStat.size, this.isContentPreviewStoragePath(content, dataPath));
+			const headersObj = await this.getIpfsHashHeadersObj(content, dataPath, fileStat.size, this.isContentPreviewStoragePath(content, dataPath), storageResponseHeaders);
 			res.writeHead(200, headersObj);
 			res.stream.end();
 		}
 
-		async getIpfsHashHeadersObj(content, dataPath, dataSize?, preview?) {
+		async getIpfsHashHeadersObj(content, dataPath, dataSize?, preview?, extraHeaders = {}) {
 			if (!dataSize && dataSize !== 0) {
 				dataSize = await this.getFileSize(dataPath, content);
 			}
@@ -1374,6 +1411,7 @@ function getModule(app: IGeesomeApp) {
 			}
 			return {
 				...contentData,
+				...extraHeaders,
 				'Accept-Ranges': 'bytes',
 				'Cross-Origin-Resource-Policy': 'cross-origin',
 				'cache-control': 'public, max-age=29030400, immutable',

--- a/app/modules/staticSiteGenerator/index.ts
+++ b/app/modules/staticSiteGenerator/index.ts
@@ -20,6 +20,7 @@ const customStylesCssMaxLength = 128 * 1024;
 const generatedGroupPostsLimit = 9999;
 const generatedGroupPostBatchLimit = 100;
 const generatedOutputCacheLimit = helpers.parsePositiveInteger(process.env.GENERATED_OUTPUT_CACHE_LIMIT, 500);
+const staticSiteNoIndexHeaderValue = 'noindex, nofollow';
 const staticSiteListParams: IListParamsOptions = {
     sortBy: 'updatedAt',
     allowedSortBy: ['createdAt', 'updatedAt', 'id', 'name', 'entityType', 'entityId'],
@@ -92,6 +93,7 @@ function normalizeStaticSiteOptions(options: any = {}) {
     normalized.post = normalized.post || {};
     normalized.postList = normalized.postList || {};
     normalized.site = normalized.site || {};
+    normalized.allowSearchIndexing = normalized.allowSearchIndexing === true;
 
     validateStaticSiteName(normalized.name);
     validateStaticSiteName(normalized.site.name);
@@ -122,6 +124,28 @@ function normalizeStaticSiteHtmlOption(html, errorMessage) {
         throw new Error(errorMessage);
     }
     return sanitizeStaticSiteHtml(html);
+}
+
+function parseStoredStaticSiteOptions(staticSite) {
+    if (!staticSite?.options) {
+        return {};
+    }
+    try {
+        return JSON.parse(staticSite.options);
+    } catch (e) {
+        return {};
+    }
+}
+
+function isStaticSiteSearchIndexingAllowed(staticSite) {
+    return parseStoredStaticSiteOptions(staticSite).allowSearchIndexing === true;
+}
+
+function getStaticSiteRobotsHeaders(options) {
+    if (options.allowSearchIndexing === true) {
+        return [];
+    }
+    return [['meta', {name: 'robots', content: staticSiteNoIndexHeaderValue}]];
 }
 
 function prepareStaticSiteUpdateData(updateData) {
@@ -280,8 +304,19 @@ export async function getModule(app: IGeesomeApp, models) {
             return this.getStaticSiteByStorageId(storageId).then(site => !!site);
         }
 
-        async getStaticSiteByStorageId(storageId: string): Promise<boolean> {
+        async getStaticSiteByStorageId(storageId: string): Promise<IStaticSite> {
             return models.StaticSite.findOne({where: {storageId}});
+        }
+
+        async getStorageResponseHeaders(storageId: string): Promise<Record<string, string>> {
+            const staticSite = await this.getStaticSiteByStorageId(storageId);
+            if (!staticSite) {
+                return {};
+            }
+            if (isStaticSiteSearchIndexingAllowed(staticSite)) {
+                return {};
+            }
+            return {'X-Robots-Tag': staticSiteNoIndexHeaderValue};
         }
 
         async getDefaultOptionsByGroupId(userId: number, groupId: number) {
@@ -667,7 +702,8 @@ export async function getModule(app: IGeesomeApp, models) {
             const postImages = type === 'post' && p ? p.contents.filter(c => c.type === 'image') : [];
             const imageUrl = postImages.length ? postImages[0].url : options.site.avatarUrl;
 
-            const headers = getOgHeaders(options.site.title, options.lang, pageTitle, pageDescription, imageUrl);
+            const headers = getOgHeaders(options.site.title, options.lang, pageTitle, pageDescription, imageUrl)
+                .concat(getStaticSiteRobotsHeaders(options));
             const htmlContent = await renderPage(path || '/', headers);
             const {id: storageId} = await app.ms.storage.saveFile(htmlContent);
             if (type !== 'simple') {

--- a/app/modules/staticSiteGenerator/interface.ts
+++ b/app/modules/staticSiteGenerator/interface.ts
@@ -7,6 +7,7 @@ export interface IStaticSiteRenderArgs {
 	entityIds?: any[];
 }
 export interface IStaticSiteOptions {
+	allowSearchIndexing?: boolean;
 	baseStorageUri?;
 	lang;
 	dateFormat;
@@ -40,7 +41,9 @@ export default interface IGeesomeStaticSiteGeneratorModule {
 
 	isStorageIdAllowed(storageId: string): Promise<boolean>;
 
-	getStaticSiteByStorageId(storageId: string): Promise<boolean>;
+	getStaticSiteByStorageId(storageId: string): Promise<IStaticSite>;
+
+	getStorageResponseHeaders(storageId: string): Promise<Record<string, string>>;
 }
 
 export interface IStaticSite {

--- a/test/contentHeaders.test.ts
+++ b/test/contentHeaders.test.ts
@@ -154,6 +154,56 @@ describe("content headers", function () {
 		assert.equal(statRequested, false);
 	});
 
+	it("adds storage hook response headers to allowed unknown HEAD paths", async () => {
+		const writes: any = {};
+		const hookCalls: any[] = [];
+		const content = await contentModule({
+			checkModules: () => null,
+			callHookCheckAllowed: async () => true,
+			callHook: async (callFromModule, name, args) => {
+				hookCalls.push({callFromModule, name, args});
+				return [{"X-Robots-Tag": "noindex, nofollow"}];
+			},
+			ms: {
+				api: getApiStub(),
+				database: {
+					getSharedStorageMetadataByStorageId: async () => null
+				},
+				storage: {
+					getFileStat: async () => ({size: 5})
+				}
+			}
+		} as unknown as IGeesomeApp);
+
+		await content.getContentHead({} as any, {
+			setHeader: (name, value) => {
+				writes.headers = writes.headers || {};
+				writes.headers[name] = value;
+			},
+			writeHead: (status, responseHeaders) => {
+				writes.status = status;
+				writes.headers = {
+					...writes.headers,
+					...responseHeaders
+				};
+			},
+			stream: {
+				end: () => {
+					writes.ended = true;
+				}
+			}
+		} as any, "site-root");
+
+		assert.equal(writes.status, 200);
+		assert.equal(writes.headers["X-Robots-Tag"], "noindex, nofollow");
+		assert.deepEqual(hookCalls, [{
+			callFromModule: "content",
+			name: "getStorageResponseHeaders",
+			args: ["site-root"]
+		}]);
+		assert.equal(writes.ended, true);
+	});
+
 	it("keeps preview MIME headers on HEAD preview storage paths", async () => {
 		const headers = {};
 		const contentSize = 3;
@@ -507,12 +557,17 @@ describe("content headers", function () {
 		const finished = new Promise((resolve) => responseStream.on("finish", resolve));
 		const writes: any = {};
 		const sends: any[] = [];
+		const hookCalls: any[] = [];
 		let statPath = "";
 		let streamPath = "";
 		responseStream.resume();
 		const content = await contentModule({
 			checkModules: () => null,
 			callHookCheckAllowed: async () => true,
+			callHook: async (callFromModule, name, args) => {
+				hookCalls.push({callFromModule, name, args});
+				return [{"X-Robots-Tag": "noindex, nofollow"}];
+			},
 			ms: {
 				api: getApiStub(),
 				database: {
@@ -553,8 +608,14 @@ describe("content headers", function () {
 		assert.equal(writes.status, 200);
 		assert.equal(writes.headers["Content-Type"], "text/html");
 		assert.equal(writes.headers["Content-Length"], 21620);
+		assert.equal(writes.headers["X-Robots-Tag"], "noindex, nofollow");
 		assert.equal(statPath, "site-root/index.html");
 		assert.equal(streamPath, "site-root/index.html");
+		assert.deepEqual(hookCalls, [{
+			callFromModule: "content",
+			name: "getStorageResponseHeaders",
+			args: ["site-root"]
+		}]);
 		assert.deepEqual(sends, []);
 	});
 
@@ -820,6 +881,9 @@ describe("content headers", function () {
 		const content = await contentModule({
 			checkModules: () => null,
 			callHookCheckAllowed: async () => true,
+			callHook: async () => {
+				return [{"X-Robots-Tag": "noindex, nofollow"}];
+			},
 			ms: {
 				api: getApiStub(),
 				database: {
@@ -863,6 +927,7 @@ describe("content headers", function () {
 		assert.equal(writes.headers["Content-Type"], "text/html");
 		assert.equal(writes.headers["Content-Range"], "bytes 0-1/5");
 		assert.equal(writes.headers["Content-Length"], 2);
+		assert.equal(writes.headers["X-Robots-Tag"], "noindex, nofollow");
 		assert.equal(statPath, "site-root/index.html");
 		assert.equal(streamPath, "site-root/index.html");
 		assert.deepEqual(streamOptions, {offset: 0, length: 2});

--- a/test/staticSiteGenerator.test.ts
+++ b/test/staticSiteGenerator.test.ts
@@ -184,6 +184,44 @@ describe("staticSiteGenerator", function () {
 		assert.equal(await app.callHookCheckAllowed('content', 'isStorageIdAllowed', ['refreshed-storage']), true);
 	});
 
+	it('should make static site search indexing opt-in', async () => {
+		await (staticSiteGenerator as any).createDbStaticSite({
+			userId: testUser.id,
+			entityType: 'content-list',
+			entityId: 'private-list',
+			name: 'private_site',
+			title: 'Private site',
+			storageId: 'private-storage'
+		});
+		await (staticSiteGenerator as any).createDbStaticSite({
+			userId: testUser.id,
+			entityType: 'content-list',
+			entityId: 'string-true-list',
+			name: 'string_true_site',
+			title: 'String true site',
+			storageId: 'string-true-storage',
+			options: JSON.stringify({allowSearchIndexing: 'true'})
+		});
+		await (staticSiteGenerator as any).createDbStaticSite({
+			userId: testUser.id,
+			entityType: 'content-list',
+			entityId: 'public-list',
+			name: 'public_site',
+			title: 'Public site',
+			storageId: 'public-storage',
+			options: JSON.stringify({allowSearchIndexing: true})
+		});
+
+		assert.deepEqual(await staticSiteGenerator.getStorageResponseHeaders('private-storage'), {
+			'X-Robots-Tag': 'noindex, nofollow'
+		});
+		assert.deepEqual(await staticSiteGenerator.getStorageResponseHeaders('string-true-storage'), {
+			'X-Robots-Tag': 'noindex, nofollow'
+		});
+		assert.deepEqual(await staticSiteGenerator.getStorageResponseHeaders('public-storage'), {});
+		assert.deepEqual(await staticSiteGenerator.getStorageResponseHeaders('missing-storage'), {});
+	});
+
 	it('should use group avatar as generated site favicon', async () => {
 		const pngImagePath = await resourcesHelper.prepare('input-image.png');
 		const avatarContent = await app.ms.content.saveData(testUser.id, fs.createReadStream(pngImagePath), 'input-image.png', {
@@ -289,10 +327,37 @@ describe("staticSiteGenerator", function () {
 		assert.equal(storedOptions.post.titleLength, 5);
 		assert.equal(storedOptions.post.descriptionLength, 400);
 		assert.equal(storedOptions.postList.postsPerPage, 1);
+		assert.equal(storedOptions.allowSearchIndexing, false);
 		assert.equal(storedOptions.stylesCss, stylesCss);
 
+		const indexHtmlContent = await app.ms.storage.getFileData(`${directoryStorageId}/index.html`).then(b => b.toString('utf8'));
+		assert.equal(indexHtmlContent.includes('<meta name="robots" content="noindex, nofollow"/>'), true);
 		const styleCssContent = await app.ms.storage.getFileData(`${directoryStorageId}/style.css`).then(b => b.toString('utf8'));
 		assert.equal(styleCssContent.includes('.static-site-settings-marker'), true);
+	});
+
+	it('should omit robots meta when static site search indexing is explicitly allowed', async () => {
+		const directoryStorageId = await staticSiteGenerator.generateGroupSite(testUser.id, {entityType: 'group', entityId: testGroup.id}, {
+			baseStorageUri: 'http://localhost:2052/ipfs/',
+			allowSearchIndexing: true,
+			postList: {
+				postsPerPage: 5,
+			},
+			site: {
+				title: 'PublicSite',
+				name: 'public_site',
+				description: 'Public About',
+				username: 'myusername',
+				base: '/'
+			}
+		});
+
+		const indexHtmlContent = await app.ms.storage.getFileData(`${directoryStorageId}/index.html`).then(b => b.toString('utf8'));
+		const staticSiteInfo = await staticSiteGenerator.getStaticSiteInfo(testUser.id, {entityType: 'group', entityId: testGroup.id});
+		const storedOptions = JSON.parse(staticSiteInfo.options);
+		assert.equal(indexHtmlContent.includes('name="robots"'), false);
+		assert.equal(storedOptions.allowSearchIndexing, true);
+		assert.deepEqual(await staticSiteGenerator.getStorageResponseHeaders(directoryStorageId), {});
 	});
 
 	it('should sanitize generated post html before render', async () => {


### PR DESCRIPTION
## Summary

- Hotfix generated static-site search indexing to be opt-in through `allowSearchIndexing: true`.
- Mark default/private static sites with robots metadata in generated HTML and `X-Robots-Tag` on gateway responses.

## Source of truth

- User request: generated static sites must not be available in search engines unless a parameter explicitly opts them in; the default must be false.
- Tracking issue: Closes #1236.
- Dev PR: #1237.

## Scope

- Adds `allowSearchIndexing` to static-site render options and normalizes it to `false` unless the value is boolean `true`.
- Adds robots `noindex, nofollow` metadata to generated HTML unless indexing is explicitly allowed.
- Adds `X-Robots-Tag: noindex, nofollow` to GeeSome `/ipfs/*` GET, HEAD, and range responses for existing generated static-site storage roots unless their stored options explicitly allow indexing.
- Updates API docs/comments. The dev-only static-site module overview doc is not present on `master` and was intentionally left out of this hotfix.

## Verification

- `GROUP_DERIVED_STATE_ASYNC=0 GATEWAY_PORT=2083 PORT=7772 SSG_RUNTIME=1 DATA_DIR=test-data node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/contentHeaders.test.ts --exit -t 60000`
- Docker-backed focused static-site generator run for `search indexing opt-in|normalize static site settings|omit robots meta`: 3 passing.
- `npm run generate-docs`
- `npm run security:route-inventory`
