### PR TITLE
Consume simplified social migration UI

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -366,7 +366,7 @@ Current state:
 
 - The backend and frontend expose source feeds, account connection, cross-posting, review/import, migration, reconciliation, and rich media/relation policy controls.
 - Several screens expose powerful policy and troubleshooting inputs that are useful for edge cases but can distract from the common path.
-- Status: planned. This should become the next user-facing UI polish pass before treating the ActivityPub/Bluesky phase as complete.
+- Status: in progress. The social migration screen now keeps source, target, preview, import actions, progress, and results in the primary flow; source tuning, ownership proof, media/relation policy, moderation filters, and relation repair are grouped behind task-named disclosures. Unverified ownership remains a visible blocker with a direct repair action. Remaining UI slices are ActivityPub/Bluesky source readers, account connection diagnostics, and cross-post policy controls.
 
 Implementation context:
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@geesome/ui": "https://github.com/galtproject/geesome-ui#1738bb8",
+    "@geesome/ui": "https://github.com/galtproject/geesome-ui#75ed341",
     "@revoinc/async-busboy": "^2.0.3",
     "apidoc": "^1.2.0",
     "apidoc-plugin-ts": "git+https://github.com/MicrowaveDev/apidoc-plugin-ts.git#afc63f1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,9 +1236,9 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@geesome/ui@https://github.com/galtproject/geesome-ui#1738bb8":
+"@geesome/ui@https://github.com/galtproject/geesome-ui#75ed341":
   version "0.1.0"
-  resolved "https://github.com/galtproject/geesome-ui#1738bb80830c174b22ceb1fc46214754e4b86d19"
+  resolved "https://github.com/galtproject/geesome-ui#75ed3418da749279b7d5a6662c0824f77152e731"
 
 "@helia/bitswap@^3.2.3":
   version "3.2.3"


### PR DESCRIPTION
## Summary

- pin `@geesome/ui` to merged geesome-ui PR #29
- record the completed social-migration progressive-disclosure slice in the deterministic ActivityPub/Bluesky UI plan
- leave source readers, account diagnostics, and cross-post controls identified as the remaining UI simplification work

## Verification

- `npm run todo:sections`
- `npm run todo:context -- activitypub-bluesky-simplified-user-ui`
- `npm run test:frontend-dist-publish`
- `git diff --check`