### PR TITLE
Consume simplified social source readers

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -366,7 +366,7 @@ Current state:
 
 - The backend and frontend expose source feeds, account connection, cross-posting, review/import, migration, reconciliation, and rich media/relation policy controls.
 - Several screens expose powerful policy and troubleshooting inputs that are useful for edge cases but can distract from the common path.
-- Status: in progress. The social migration screen now keeps source, target, preview, import actions, progress, and results in the primary flow; source tuning, ownership proof, media/relation policy, moderation filters, and relation repair are grouped behind task-named disclosures. Unverified ownership remains a visible blocker with a direct repair action. Remaining UI slices are ActivityPub/Bluesky source readers, account connection diagnostics, and cross-post policy controls.
+- Status: in progress. The social migration screen now keeps source, target, preview, import actions, progress, and results in the primary flow; source tuning, ownership proof, media/relation policy, moderation filters, and relation repair are grouped behind task-named disclosures. Unverified ownership remains a visible blocker with a direct repair action. ActivityPub and native Bluesky source readers now lead with subscribe, feed refresh/read state, reviews, and visible errors; source defaults, import policy, synchronization, pause/resume, and removal are grouped behind task-named disclosures. Remaining UI slices are Bluesky account connection diagnostics and cross-post policy controls.
 
 Implementation context:
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@geesome/ui": "https://github.com/galtproject/geesome-ui#75ed341",
+    "@geesome/ui": "https://github.com/galtproject/geesome-ui#4296618",
     "@revoinc/async-busboy": "^2.0.3",
     "apidoc": "^1.2.0",
     "apidoc-plugin-ts": "git+https://github.com/MicrowaveDev/apidoc-plugin-ts.git#afc63f1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,9 +1236,9 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@geesome/ui@https://github.com/galtproject/geesome-ui#75ed341":
+"@geesome/ui@https://github.com/galtproject/geesome-ui#4296618":
   version "0.1.0"
-  resolved "https://github.com/galtproject/geesome-ui#75ed3418da749279b7d5a6662c0824f77152e731"
+  resolved "https://github.com/galtproject/geesome-ui#4296618e9d2a8a8b20ce6e898d8a2028f6844fbf"
 
 "@helia/bitswap@^3.2.3":
   version "3.2.3"


### PR DESCRIPTION
## Summary

- pin `@geesome/ui` to merged geesome-ui PR #30
- record the completed ActivityPub and Bluesky feed-first source-reader slice
- narrow the remaining simplified UI work to account connection diagnostics and cross-post policy controls

## Verification

- `npm run todo:context -- activitypub-bluesky-simplified-user-ui`
- `npm run test:frontend-dist-publish`
- `git diff --check`