### PR TITLE
Add opt-in runtime CPU attribution

### DIFF
--- a/DEBUG.md
+++ b/DEBUG.md
@@ -21,6 +21,7 @@ GeeSome Node keeps logs quiet by default. Enable extra output with the variables
 | `geesome*` | All node module traces (deployment default) |
 | `geesome:app` | App lifecycle / module startup only |
 | `geesome:memory` | Memory profiler snapshots (see below) |
+| `geesome:runtime` | Opt-in CPU, event-loop, memory, and bounded request snapshots |
 | `geesome:database:sql` | SQL query traces (pair with `GEESOME_LOG_SQL=1`) |
 
 ## Log flags
@@ -49,3 +50,14 @@ Each line looks like:
 `rssMb` is the process resident memory — the number to size RAM by; `systemFreeMb` shows host headroom. The JSONL file can be handed to an agent to analyze and propose hardware requirements.
 
 Besides the periodic snapshots, the node also emits **labeled** snapshots around video transcoding (`"label":"video:transcode:before"` / `"video:transcode:after"`). ffmpeg runs as a child process, so its cost shows up as a drop in `systemFreeMb` (and a bump in `externalMb` for native buffers) between the two labels rather than in `rssMb`.
+
+## Runtime profiling (for CPU incidents)
+
+Set `GEESOME_RUNTIME_PROFILE=1` or `GEESOME_RUNTIME_LOG_FILE` to add process CPU,
+event-loop utilization/delay, system load, and bounded API/gateway request counters
+to periodic snapshots. The exact `DEBUG=geesome:runtime` namespace also enables
+runtime profiling. A broad `DEBUG=geesome*` does not enable the event-loop monitor
+or request tracking, so existing deployments keep their legacy memory-only cost.
+
+See [Runtime performance diagnostics](./docs/runtime-performance-diagnostics.md)
+for fields, privacy boundaries, and incident interpretation.

--- a/README.MD
+++ b/README.MD
@@ -288,7 +288,7 @@ geesomeClient.init().then(async () => {
 - Auto-backup social networks channels(Telegram)
 
 ## TODO:
-- Stabilize content serving, upload limits, client-disconnect stream cleanup, and high-CPU paths reported in open operational issues.
+- Stabilize content serving, upload limits, client-disconnect stream cleanup, and high-CPU paths reported in open operational issues. Opt-in runtime diagnostics now correlate process CPU/event-loop pressure with bounded API/gateway request counters for the next production incident.
 - Finish the existing Pinata/pinning path with manual and auto pin flows exposed cleanly in API/UI.
 - API key permissions and expiration are enforced; keep extending scoped service-token tests as new integrations land.
 - Run a focused security review of API authorization and encryption boundaries before expanding integrations and production E2EE.

--- a/app/memoryProfiler.ts
+++ b/app/memoryProfiler.ts
@@ -1,78 +1,320 @@
-import os from "os";
-import fs from "fs";
-import path from "path";
-import debug from "debug";
-import helpers from "./helpers.js";
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import {monitorEventLoopDelay, performance} from 'node:perf_hooks';
+import debug from 'debug';
+import helpers from './helpers.js';
 
 const memoryLog = debug('geesome:memory');
+const runtimeLog = debug('geesome:runtime');
+const defaultProfilerIntervalSec = 60;
+const eventLoopDelayResolutionMs = 20;
 
 let filePath: string | undefined;
+let profilerEnabled = false;
+let runtimeProfilerEnabled = false;
+let profilerTimer: NodeJS.Timeout | null = null;
+let eventLoopDelayHistogram: ReturnType<typeof monitorEventLoopDelay> | null = null;
+let previousCpuUsage = process.cpuUsage();
+let previousCpuTimestamp = process.hrtime.bigint();
+let previousEventLoopUtilization = performance.eventLoopUtilization();
+const requestStatsByService = new Map<string, RequestStats>();
 
-function toMb(bytes: number) {
-  return Math.round((bytes / 1024 / 1024) * 10) / 10;
+type RequestStats = {
+	started: number;
+	completed: number;
+	aborted: number;
+	inFlight: number;
+	totalDurationMs: number;
+	methods: Record<string, number>;
+	statusClasses: Record<string, number>;
+};
+
+export function recordMemorySnapshot(label?: string, extra?: any) {
+	if (!isProfilingEnabled()) {
+		return null;
+	}
+	const snapshot = takeMemorySnapshot(label, extra);
+	writeSnapshot(snapshot, false);
+	return snapshot;
 }
 
-function isProfilingEnabled() {
-  return memoryLog.enabled || !!filePath;
+export function recordRuntimeSnapshot(label?: string) {
+	if (!runtimeProfilerEnabled) {
+		return null;
+	}
+	const snapshot = {
+		...takeMemorySnapshot(label),
+		...takeCpuSnapshot(),
+		eventLoop: takeEventLoopSnapshot(),
+		requests: takeRequestStatsSnapshot()
+	};
+	writeSnapshot(snapshot, true);
+	return snapshot;
+}
+
+export function trackRuntimeHttpRequest(serviceName: string, req: any, res: any): void {
+	if (!runtimeProfilerEnabled) {
+		return;
+	}
+	const stats = getRequestStats(serviceName);
+	const startedAt = performance.now();
+	const method = normalizeRequestMethod(req?.method);
+	stats.started += 1;
+	stats.inFlight += 1;
+	stats.methods[method] = (stats.methods[method] || 0) + 1;
+
+	let settled = false;
+	const settle = (aborted: boolean) => {
+		if (settled) {
+			return;
+		}
+		settled = true;
+		stats.inFlight = Math.max(0, stats.inFlight - 1);
+		stats.totalDurationMs += performance.now() - startedAt;
+		if (aborted) {
+			stats.aborted += 1;
+			return;
+		}
+		stats.completed += 1;
+		const statusClass = getStatusClass(res?.statusCode);
+		stats.statusClasses[statusClass] = (stats.statusClasses[statusClass] || 0) + 1;
+	};
+
+	res.once('finish', () => settle(false));
+	res.once('close', () => settle(!res.writableEnded));
+}
+
+export function startMemoryProfiler() {
+	if (profilerTimer) {
+		return profilerTimer;
+	}
+	filePath = getRuntimeLogFilePath();
+	runtimeProfilerEnabled = shouldEnableRuntimeProfiler();
+	profilerEnabled = isProfilingEnabled() || runtimeProfilerEnabled;
+	if (!profilerEnabled) {
+		return null;
+	}
+	prepareLogDirectory();
+	if (runtimeProfilerEnabled) {
+		resetRuntimeBaselines();
+		eventLoopDelayHistogram = monitorEventLoopDelay({resolution: eventLoopDelayResolutionMs});
+		eventLoopDelayHistogram.enable();
+	}
+	recordPeriodicSnapshot();
+	profilerTimer = setInterval(recordPeriodicSnapshot, getProfilerIntervalMs());
+	profilerTimer.unref();
+	return profilerTimer;
+}
+
+export function stopMemoryProfiler(): void {
+	if (profilerTimer) {
+		clearInterval(profilerTimer);
+	}
+	profilerTimer = null;
+	eventLoopDelayHistogram?.disable();
+	eventLoopDelayHistogram = null;
+	profilerEnabled = false;
+	runtimeProfilerEnabled = false;
+	filePath = undefined;
+	requestStatsByService.clear();
 }
 
 function takeMemorySnapshot(label?: string, extra?: any) {
-  const mem = process.memoryUsage();
-  return {
-    time: new Date().toISOString(),
-    ...(label ? {label} : {}),
-    rssMb: toMb(mem.rss),
-    heapUsedMb: toMb(mem.heapUsed),
-    heapTotalMb: toMb(mem.heapTotal),
-    externalMb: toMb(mem.external),
-    arrayBuffersMb: toMb(mem.arrayBuffers),
-    systemTotalMb: toMb(os.totalmem()),
-    systemFreeMb: toMb(os.freemem()),
-    uptimeSec: Math.round(process.uptime()),
-    ...(extra || {}),
-  };
+	const memory = process.memoryUsage();
+	return {
+		time: new Date().toISOString(),
+		...(label ? {label} : {}),
+		rssMb: toMb(memory.rss),
+		heapUsedMb: toMb(memory.heapUsed),
+		heapTotalMb: toMb(memory.heapTotal),
+		externalMb: toMb(memory.external),
+		arrayBuffersMb: toMb(memory.arrayBuffers),
+		systemTotalMb: toMb(os.totalmem()),
+		systemFreeMb: toMb(os.freemem()),
+		uptimeSec: Math.round(process.uptime()),
+		...(extra || {})
+	};
 }
 
-function writeSnapshot(snapshot: any) {
-  helpers.logDebug(memoryLog, () => ['snapshot', snapshot]);
-  if (filePath) {
-    fs.appendFile(filePath, JSON.stringify(snapshot) + '\n', (e) => {
-      if (e) {
-        console.error('memory_log_file_write_error', e.message);
-      }
-    });
-  }
+function recordPeriodicSnapshot(): void {
+	if (runtimeProfilerEnabled) {
+		recordRuntimeSnapshot();
+		return;
+	}
+	recordMemorySnapshot();
 }
 
-// Record a one-off labeled snapshot around an event of interest (e.g. video
-// transcoding). No-op unless profiling is enabled. Native/child-process memory
-// (ffmpeg) shows up in externalMb/systemFreeMb rather than rss.
-export function recordMemorySnapshot(label?: string, extra?: any) {
-  if (!isProfilingEnabled()) {
-    return;
-  }
-  writeSnapshot(takeMemorySnapshot(label, extra));
+function takeCpuSnapshot() {
+	const currentTimestamp = process.hrtime.bigint();
+	const elapsedMicros = Number(currentTimestamp - previousCpuTimestamp) / 1000;
+	const cpuUsage = process.cpuUsage(previousCpuUsage);
+	const usedMicros = cpuUsage.user + cpuUsage.system;
+	previousCpuUsage = process.cpuUsage();
+	previousCpuTimestamp = currentTimestamp;
+	return {
+		processCpuPercent: roundNumber(elapsedMicros > 0 ? usedMicros / elapsedMicros * 100 : 0),
+		processUserCpuMs: roundNumber(cpuUsage.user / 1000),
+		processSystemCpuMs: roundNumber(cpuUsage.system / 1000),
+		systemLoadAverage: os.loadavg().map(roundNumber),
+		logicalCpuCount: os.cpus().length
+	};
 }
 
-// Periodically profile process and system memory so real-world footprint can be
-// measured to size hardware requirements. Writes one JSON object per line to
-// GEESOME_MEMORY_LOG_FILE (if set) and/or emits on the geesome:memory debug
-// namespace. Interval in seconds via GEESOME_MEMORY_LOGS_INTERVAL (default 60).
-export function startMemoryProfiler() {
-  filePath = process.env.GEESOME_MEMORY_LOG_FILE || undefined;
-  if (!isProfilingEnabled()) {
-    return;
-  }
-  if (filePath) {
-    try {
-      fs.mkdirSync(path.dirname(filePath), {recursive: true});
-    } catch (e) {
-      console.error('memory_log_file_dir_error', e.message);
-    }
-  }
-  const intervalSec = Number.parseInt(process.env.GEESOME_MEMORY_LOGS_INTERVAL || '', 10);
-  const intervalMs = (Number.isFinite(intervalSec) && intervalSec > 0 ? intervalSec : 60) * 1000;
-  recordMemorySnapshot();
-  const timer = setInterval(() => recordMemorySnapshot(), intervalMs);
-  timer.unref();
+function takeEventLoopSnapshot() {
+	const utilization = performance.eventLoopUtilization(previousEventLoopUtilization);
+	previousEventLoopUtilization = performance.eventLoopUtilization();
+	const result = {
+		utilization: roundNumber(utilization.utilization),
+		activeMs: roundNumber(utilization.active),
+		idleMs: roundNumber(utilization.idle),
+		delayMeanMs: nanosecondsToMilliseconds(eventLoopDelayHistogram?.mean),
+		delayP95Ms: nanosecondsToMilliseconds(eventLoopDelayHistogram?.percentile(95)),
+		delayMaxMs: nanosecondsToMilliseconds(eventLoopDelayHistogram?.max)
+	};
+	eventLoopDelayHistogram?.reset();
+	return result;
+}
+
+function takeRequestStatsSnapshot() {
+	const result = {};
+	requestStatsByService.forEach((stats, serviceName) => {
+		result[serviceName] = {
+			started: stats.started,
+			completed: stats.completed,
+			aborted: stats.aborted,
+			inFlight: stats.inFlight,
+			averageDurationMs: roundNumber(
+				stats.completed + stats.aborted > 0
+					? stats.totalDurationMs / (stats.completed + stats.aborted)
+					: 0
+			),
+			methods: {...stats.methods},
+			statusClasses: {...stats.statusClasses}
+		};
+		resetRequestStatsInterval(stats);
+	});
+	return result;
+}
+
+function getRequestStats(serviceName: string): RequestStats {
+	const normalizedServiceName = String(serviceName || 'unknown');
+	let stats = requestStatsByService.get(normalizedServiceName);
+	if (!stats) {
+		stats = createRequestStats();
+		requestStatsByService.set(normalizedServiceName, stats);
+	}
+	return stats;
+}
+
+function createRequestStats(): RequestStats {
+	return {
+		started: 0,
+		completed: 0,
+		aborted: 0,
+		inFlight: 0,
+		totalDurationMs: 0,
+		methods: {},
+		statusClasses: {}
+	};
+}
+
+function resetRequestStatsInterval(stats: RequestStats): void {
+	stats.started = 0;
+	stats.completed = 0;
+	stats.aborted = 0;
+	stats.totalDurationMs = 0;
+	stats.methods = {};
+	stats.statusClasses = {};
+}
+
+function resetRuntimeBaselines(): void {
+	previousCpuUsage = process.cpuUsage();
+	previousCpuTimestamp = process.hrtime.bigint();
+	previousEventLoopUtilization = performance.eventLoopUtilization();
+}
+
+function writeSnapshot(snapshot: any, isRuntimeSnapshot: boolean): void {
+	helpers.logDebug(memoryLog, () => ['snapshot', snapshot]);
+	if (isRuntimeSnapshot) {
+		helpers.logDebug(runtimeLog, () => ['snapshot', snapshot]);
+	}
+	if (!filePath) {
+		return;
+	}
+	fs.appendFile(filePath, `${JSON.stringify(snapshot)}\n`, (e) => {
+		if (e) {
+			console.error('runtime_log_file_write_error', e.message);
+		}
+	});
+}
+
+function prepareLogDirectory(): void {
+	if (!filePath) {
+		return;
+	}
+	try {
+		fs.mkdirSync(path.dirname(filePath), {recursive: true});
+	} catch (e) {
+		console.error('runtime_log_file_dir_error', e.message);
+	}
+}
+
+function getRuntimeLogFilePath(): string | undefined {
+	return process.env.GEESOME_RUNTIME_LOG_FILE || process.env.GEESOME_MEMORY_LOG_FILE || undefined;
+}
+
+function getProfilerIntervalMs(): number {
+	const rawInterval = process.env.GEESOME_RUNTIME_LOG_INTERVAL_SEC
+		|| process.env.GEESOME_MEMORY_LOGS_INTERVAL
+		|| '';
+	const intervalSec = Number.parseInt(rawInterval, 10);
+	return (Number.isFinite(intervalSec) && intervalSec > 0 ? intervalSec : defaultProfilerIntervalSec) * 1000;
+}
+
+function isProfilingEnabled(): boolean {
+	return memoryLog.enabled || !!filePath;
+}
+
+function shouldEnableRuntimeProfiler(): boolean {
+	return helpers.parseBoolean(process.env.GEESOME_RUNTIME_PROFILE, false)
+		|| !!process.env.GEESOME_RUNTIME_LOG_FILE
+		|| isDebugNamespaceExplicitlyEnabled('geesome:runtime');
+}
+
+function isDebugNamespaceExplicitlyEnabled(namespace: string): boolean {
+	return String(process.env.DEBUG || '')
+		.split(/[\s,]+/)
+		.some(pattern => pattern === namespace);
+}
+
+function normalizeRequestMethod(method): string {
+	const normalizedMethod = String(method || 'UNKNOWN').toUpperCase();
+	if (!/^[A-Z]+$/.test(normalizedMethod)) {
+		return 'UNKNOWN';
+	}
+	return normalizedMethod;
+}
+
+function getStatusClass(statusCode): string {
+	const parsedStatusCode = Number(statusCode);
+	if (!Number.isInteger(parsedStatusCode) || parsedStatusCode < 100 || parsedStatusCode > 599) {
+		return 'unknown';
+	}
+	return `${Math.floor(parsedStatusCode / 100)}xx`;
+}
+
+function nanosecondsToMilliseconds(value): number {
+	if (!Number.isFinite(value) || value < 0) {
+		return 0;
+	}
+	return roundNumber(value / 1e6);
+}
+
+function toMb(bytes: number): number {
+	return roundNumber(bytes / 1024 / 1024);
+}
+
+function roundNumber(value: number): number {
+	return Math.round(value * 10) / 10;
 }

--- a/app/modules/api/index.ts
+++ b/app/modules/api/index.ts
@@ -5,6 +5,7 @@ import bodyParser from 'body-parser';
 import bearerToken from 'express-bearer-token';
 import {IGeesomeApp} from "../../interface.js";
 import helpers from "../../helpers.js";
+import {trackRuntimeHttpRequest} from '../../memoryProfiler.js';
 import {buildOpenApiFromApiDoc, getApiDocData} from "../../apiDocSpec.js";
 import {IUser} from "../database/interface.js";
 import IGeesomeApiModule, {
@@ -47,6 +48,10 @@ async function getModule(app: IGeesomeApp, version, port) {
 	if (helpers.isAccessLogEnabled()) {
 		service.use(morgan('combined'));
 	}
+	service.use((req, res, next) => {
+		trackRuntimeHttpRequest('api', req, res);
+		next();
+	});
 
 	service.use(async (req, res, next) => {
 		setHeaders(res);

--- a/app/modules/gateway/index.ts
+++ b/app/modules/gateway/index.ts
@@ -5,6 +5,7 @@ import bearerToken from 'express-bearer-token';
 import IGeesomeGatewayModule from "./interface.js";
 import {IGeesomeApp} from "../../interface.js";
 import appHelpers from "../../helpers.js";
+import {trackRuntimeHttpRequest} from '../../memoryProfiler.js';
 import gatewayHelpers from "./helpers.js";
 
 export default async (app: IGeesomeApp, options: {registerApi?: boolean, port?: number | string} = {}) => {
@@ -27,6 +28,10 @@ async function getModule(app: IGeesomeApp, port) {
 	if (appHelpers.isAccessLogEnabled()) {
 		service.use(morgan('combined'));
 	}
+	service.use((req, res, next) => {
+		trackRuntimeHttpRequest('gateway', req, res);
+		next();
+	});
 
 	service.use(async (req, res, next) => {
 		setHeaders(res);

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ can be used for the generated API page, this portal, and module docs.
 ## Focused References
 
 - [Debugging and logs](../DEBUG.md)
+- [Runtime performance diagnostics](./runtime-performance-diagnostics.md)
 - [Code style](./code-style.md)
 - [Security review](./security-review.md)
 - [Security route inventory](./security-route-inventory.md)

--- a/docs/runtime-performance-diagnostics.md
+++ b/docs/runtime-performance-diagnostics.md
@@ -1,0 +1,53 @@
+# Runtime Performance Diagnostics
+
+GeeSome's runtime profiler is disabled by default. Enable it during a CPU or
+memory incident to write bounded JSON Lines snapshots without enabling access
+logs or serializing request bodies.
+
+```sh
+GEESOME_RUNTIME_LOG_FILE=/var/log/geesome/runtime.jsonl \
+GEESOME_RUNTIME_LOG_INTERVAL_SEC=60 \
+  npm run start
+```
+
+`GEESOME_RUNTIME_PROFILE=1` enables the same profiler without requiring a file;
+use it with the exact `DEBUG=geesome:runtime` namespace when debug output is the
+desired destination. A broad `DEBUG=geesome*` does not enable event-loop or
+request tracking, because that wildcard is common in existing deployments.
+
+The legacy `GEESOME_MEMORY_LOG_FILE` and `GEESOME_MEMORY_LOGS_INTERVAL`
+variables remain supported for memory-only snapshots. The legacy
+`DEBUG=geesome:memory` behavior also remains memory-only.
+
+Each interval records:
+
+- process CPU percentage relative to one logical core, plus user/system CPU time;
+- event-loop utilization and mean, p95, and maximum delay;
+- RSS, heap, external, array-buffer, system-free, and system-total memory;
+- system load average and logical CPU count;
+- API and gateway requests started/completed/aborted, current in-flight count,
+  average duration, HTTP method counts, and status classes.
+
+No request paths, query values, headers, bodies, user IDs, or response payloads
+are recorded. Interval counters reset after each snapshot; `inFlight` remains a
+current gauge.
+
+## Reading A CPU Incident
+
+- High process CPU plus high event-loop utilization points toward JavaScript work
+  in the GeeSome process. Capture a Node CPU profile during the same workload.
+- High process CPU with low event-loop utilization points more toward native
+  modules, garbage collection, or work outside ordinary JavaScript callbacks.
+- High event-loop delay with a request spike points toward synchronous or
+  CPU-heavy request handling. Compare API and gateway counts before selecting a
+  route-specific reproducer.
+- Low GeeSome process CPU while system load stays high means another process is
+  the primary suspect. Check Kubo/IPFS, PostgreSQL, nginx, media converters, and
+  other services with process-level tools.
+- Rising aborted requests can indicate client disconnects, reverse-proxy timeout,
+  or an overloaded response path.
+
+The profiler attributes the first boundary only. It intentionally does not add
+high-cardinality per-route labels or always-on tracing. Once a recurring boundary
+is known, add a focused benchmark or job/route timer and keep it behind the same
+opt-in diagnostics policy.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -123,7 +123,7 @@ Verification:
 
 ### 3. Content Serving Stabilization
 
-Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback. [#846](https://github.com/galtproject/geesome-node/issues/846) extends the same header behavior to gateway HEAD requests so published folder/IPFS-style paths can return storage headers. [#848](https://github.com/galtproject/geesome-node/issues/848) hardens byte-range handling so malformed or unsatisfiable ranges return `416` before storage streams are opened. [#850](https://github.com/galtproject/geesome-node/issues/850) returns `404` when an allowed content path is missing from storage instead of dereferencing a missing stat. [#852](https://github.com/galtproject/geesome-node/issues/852) closes response streams when storage streams fail after headers are written. The client-disconnect slice now destroys the upstream storage stream when the response closes and keeps range-stream byte counting behind the debug namespace. HEAD requests now reuse the GET metadata/path decision path for missing and forbidden storage ids, so they return `404`/`423` instead of empty `200` responses. Ranged GET requests now follow the same missing/forbidden storage decisions before parsing byte ranges or opening streams, and image/directory range requests now return `206` partial streams instead of falling back to full `200` sends while preserving metadata-derived content type after directory index path rewrites. Non-range GET now also streams content when storage stats provide size but no CID, using the already resolved path metadata for headers. Post-header storage stream errors and expected over-limit content-save failures now clean up without unconditional stderr noise, and HTTP access logs are opt-in through `GEESOME_ACCESS_LOGS=1` instead of default morgan output. The content-save performance check now has discoverable `check:performance:*` aliases, bounded env-configurable payload defaults, and calls the current `saveData(userId, data, name, options)` contract so #750 CPU checks can be repeated intentionally.
+Status: in progress. [#733](https://github.com/galtproject/geesome-node/issues/733) now has a focused API HEAD regression so content-data/file-catalog storage handlers can set their own `Content-Length` and content headers instead of being swallowed by the generic HEAD fallback. [#846](https://github.com/galtproject/geesome-node/issues/846) extends the same header behavior to gateway HEAD requests so published folder/IPFS-style paths can return storage headers. [#848](https://github.com/galtproject/geesome-node/issues/848) hardens byte-range handling so malformed or unsatisfiable ranges return `416` before storage streams are opened. [#850](https://github.com/galtproject/geesome-node/issues/850) returns `404` when an allowed content path is missing from storage instead of dereferencing a missing stat. [#852](https://github.com/galtproject/geesome-node/issues/852) closes response streams when storage streams fail after headers are written. The client-disconnect slice now destroys the upstream storage stream when the response closes and keeps range-stream byte counting behind the debug namespace. HEAD requests now reuse the GET metadata/path decision path for missing and forbidden storage ids, so they return `404`/`423` instead of empty `200` responses. Ranged GET requests now follow the same missing/forbidden storage decisions before parsing byte ranges or opening streams, and image/directory range requests now return `206` partial streams instead of falling back to full `200` sends while preserving metadata-derived content type after directory index path rewrites. Non-range GET now also streams content when storage stats provide size but no CID, using the already resolved path metadata for headers. Post-header storage stream errors and expected over-limit content-save failures now clean up without unconditional stderr noise, and HTTP access logs are opt-in through `GEESOME_ACCESS_LOGS=1` instead of default morgan output. The content-save performance check now has discoverable `check:performance:*` aliases, bounded env-configurable payload defaults, and calls the current `saveData(userId, data, name, options)` contract so #750 CPU checks can be repeated intentionally. The existing opt-in memory profiler now also records process CPU, event-loop utilization/delay, system load, and bounded API/gateway request interval counters so the next #750 incident can distinguish GeeSome JavaScript pressure, native/external service pressure, and request spikes without enabling high-volume access logs.
 
 Goal: fix the highest user-visible backend bugs before feature work.
 
@@ -148,6 +148,41 @@ Verification:
 - `test/storage.test.ts`
 - `test/app.test.ts`
 - `yarn test`
+
+<!-- todo-section: content-serving-cpu-attribution -->
+#### Content Serving: CPU Attribution
+
+Goal: turn [#750](https://github.com/galtproject/geesome-node/issues/750) from a
+system-saturation screenshot into a reproducible GeeSome, IPFS, proxy, request, or
+background-job profile before changing runtime behavior.
+
+Current state:
+
+- Opt-in runtime snapshots correlate process CPU, event-loop utilization/delay,
+  memory, system load, and bounded API/gateway request interval counters.
+- The profiler records no paths, query values, headers, bodies, user IDs, or
+  response payloads. Event-loop and request tracking remain disabled unless
+  `GEESOME_RUNTIME_PROFILE=1`, a runtime log file, or the exact
+  `DEBUG=geesome:runtime` namespace is configured; broad debug wildcards retain
+  only the legacy memory profiler behavior.
+- The operator workflow is documented in
+  [runtime-performance-diagnostics.md](./runtime-performance-diagnostics.md).
+
+Next incident work:
+
+- Capture profiler output alongside `pidstat`/`top`, nginx request metrics, Kubo
+  stats, and PostgreSQL activity during the same incident window.
+- If GeeSome CPU and event-loop utilization are high, capture a bounded Node CPU
+  profile and add a focused route/job benchmark for the hottest stack.
+- If system load is high while GeeSome CPU is low, investigate Kubo, nginx,
+  PostgreSQL, media conversion, or storage I/O before changing application loops.
+
+Verification:
+
+- Focused runtime-profiler unit tests cover completed and aborted request counts,
+  interval reset behavior, and numeric CPU/event-loop fields.
+- Existing API/gateway tests remain green with profiling disabled.
+<!-- /todo-section -->
 
 ### 4. Pinata And Pinning MVP
 

--- a/test/runtimeProfilerUnit.test.ts
+++ b/test/runtimeProfilerUnit.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert';
+import {EventEmitter} from 'node:events';
+import {
+	recordRuntimeSnapshot,
+	startMemoryProfiler,
+	stopMemoryProfiler,
+	trackRuntimeHttpRequest
+} from '../app/memoryProfiler.js';
+
+describe('runtime profiler', () => {
+	const originalRuntimeLogFile = process.env.GEESOME_RUNTIME_LOG_FILE;
+	const originalRuntimeInterval = process.env.GEESOME_RUNTIME_LOG_INTERVAL_SEC;
+	const originalRuntimeProfile = process.env.GEESOME_RUNTIME_PROFILE;
+	const originalDebug = process.env.DEBUG;
+
+	afterEach(() => {
+		stopMemoryProfiler();
+		setOptionalEnv('GEESOME_RUNTIME_LOG_FILE', originalRuntimeLogFile);
+		setOptionalEnv('GEESOME_RUNTIME_LOG_INTERVAL_SEC', originalRuntimeInterval);
+		setOptionalEnv('GEESOME_RUNTIME_PROFILE', originalRuntimeProfile);
+		setOptionalEnv('DEBUG', originalDebug);
+	});
+
+	it('does not attach request listeners while profiling is disabled', () => {
+		stopMemoryProfiler();
+		delete process.env.GEESOME_RUNTIME_LOG_FILE;
+		delete process.env.GEESOME_RUNTIME_PROFILE;
+		const response: any = new EventEmitter();
+		trackRuntimeHttpRequest('api', {method: 'GET'}, response);
+
+		assert.equal(response.listenerCount('finish'), 0);
+		assert.equal(response.listenerCount('close'), 0);
+		assert.equal(recordRuntimeSnapshot('disabled'), null);
+	});
+
+	it('does not enable request tracking from a broad debug wildcard', () => {
+		process.env.DEBUG = 'geesome*';
+		delete process.env.GEESOME_RUNTIME_LOG_FILE;
+		delete process.env.GEESOME_RUNTIME_PROFILE;
+		stopMemoryProfiler();
+		startMemoryProfiler();
+
+		const response: any = new EventEmitter();
+		trackRuntimeHttpRequest('api', {method: 'GET'}, response);
+		assert.equal(response.listenerCount('finish'), 0);
+		assert.equal(recordRuntimeSnapshot('wildcard'), null);
+	});
+
+	it('records bounded process, event-loop, and request interval diagnostics', () => {
+		process.env.GEESOME_RUNTIME_LOG_FILE = '/tmp/geesome-runtime-profiler-test.jsonl';
+		process.env.GEESOME_RUNTIME_LOG_INTERVAL_SEC = '3600';
+		startMemoryProfiler();
+
+		const response: any = new EventEmitter();
+		response.statusCode = 201;
+		response.writableEnded = true;
+		trackRuntimeHttpRequest('api', {method: 'post'}, response);
+		response.emit('finish');
+
+		const snapshot: any = recordRuntimeSnapshot('unit-test');
+		assert.equal(snapshot.label, 'unit-test');
+		assert.equal(typeof snapshot.processCpuPercent, 'number');
+		assert.equal(typeof snapshot.eventLoop.utilization, 'number');
+		assert.equal(snapshot.requests.api.started, 1);
+		assert.equal(snapshot.requests.api.completed, 1);
+		assert.equal(snapshot.requests.api.aborted, 0);
+		assert.equal(snapshot.requests.api.inFlight, 0);
+		assert.equal(snapshot.requests.api.methods.POST, 1);
+		assert.equal(snapshot.requests.api.statusClasses['2xx'], 1);
+
+		const nextSnapshot: any = recordRuntimeSnapshot('next-interval');
+		assert.equal(nextSnapshot.requests.api.started, 0);
+		assert.equal(nextSnapshot.requests.api.completed, 0);
+	});
+
+	it('records closed unfinished responses as aborted once', () => {
+		process.env.GEESOME_RUNTIME_LOG_FILE = '/tmp/geesome-runtime-profiler-test.jsonl';
+		process.env.GEESOME_RUNTIME_LOG_INTERVAL_SEC = '3600';
+		startMemoryProfiler();
+
+		const response: any = new EventEmitter();
+		response.statusCode = 200;
+		response.writableEnded = false;
+		trackRuntimeHttpRequest('gateway', {method: 'get'}, response);
+		response.emit('close');
+		response.emit('finish');
+
+		const snapshot: any = recordRuntimeSnapshot('aborted');
+		assert.equal(snapshot.requests.gateway.completed, 0);
+		assert.equal(snapshot.requests.gateway.aborted, 1);
+		assert.equal(snapshot.requests.gateway.inFlight, 0);
+	});
+});
+
+function setOptionalEnv(name: string, value: string | undefined): void {
+	if (typeof value === 'undefined') {
+		delete process.env[name];
+		return;
+	}
+	process.env[name] = value;
+}


### PR DESCRIPTION
## Summary

- extend the existing profiler with process CPU, event-loop utilization/delay, system load, and bounded API/gateway request interval counters
- keep event-loop monitoring and request listeners explicitly opt-in through `GEESOME_RUNTIME_PROFILE=1`, `GEESOME_RUNTIME_LOG_FILE`, or exact `DEBUG=geesome:runtime`
- preserve legacy memory-only behavior for existing `GEESOME_MEMORY_*` settings and broad deployment debug wildcards
- add operator guidance and a deterministic `content-serving-cpu-attribution` TODO section for issue #750

## Why

Issue #750 only shows system-wide saturation across GeeSome Node, nginx, and IPFS. Changing application loops without attribution would be speculative. These bounded, payload-free snapshots let the next incident distinguish JavaScript/event-loop pressure, native or external service pressure, and request spikes before selecting a focused fix.

## Safety

The profiler records no paths, query values, headers, request bodies, user IDs, or response payloads. When runtime profiling is disabled, the HTTP tracker returns before attaching response listeners. A regression test confirms that the common `DEBUG=geesome*` wildcard does not enable the new event-loop/request instrumentation.

## Verification

- focused profiler/API tests: 7 passing
- `npm run test:docker`: 422 passing, 11 pending
- `npm run todo:context -- content-serving-cpu-attribution`
- `git diff --check`

The repository-wide legacy `tsc --noEmit` command remains unusable because the checked-in compiler cannot parse existing current project/dependency syntax and tsconfig options; executable TypeScript imports and the Docker test runner are green.