### PR TITLE
Add opt-in automatic pin actions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -289,7 +289,7 @@ geesomeClient.init().then(async () => {
 
 ## TODO:
 - Stabilize content serving, upload limits, client-disconnect stream cleanup, and high-CPU paths reported in open operational issues. Opt-in runtime diagnostics now correlate process CPU/event-loop pressure with bounded API/gateway request counters for the next production incident.
-- Finish the existing Pinata/pinning path with manual and auto pin flows exposed cleanly in API/UI.
+- Finish the existing Pinata/pinning path: manual API/UI and opt-in backend auto pinning exist; add the profile toggle and define group/post auto-pin policy.
 - API key permissions and expiration are enforced; keep extending scoped service-token tests as new integrations land.
 - Run a focused security review of API authorization and encryption boundaries before expanding integrations and production E2EE.
 - Keep shared package versions aligned across `geesome-node`, `geesome-libs`, and `geesome-ui`, while treating Vue/ethers/mime major-line differences as separate migrations.

--- a/app/modules/autoActions/index.ts
+++ b/app/modules/autoActions/index.ts
@@ -268,7 +268,7 @@ function getModule(app: IGeesomeApp, models) {
 		}
 
 		async handleAutoActionSuccessfulExecution(_userId, _actionId, _response, _rootActionId?) {
-			let {totalExecuteAttempts, userId} = await models.AutoAction.findOne({where: {id: _actionId}});
+			let {totalExecuteAttempts, executePeriod, userId} = await models.AutoAction.findOne({where: {id: _actionId}});
 			if (_userId !== userId) {
 				throw new Error("userId_dont_match");
 			}
@@ -280,7 +280,8 @@ function getModule(app: IGeesomeApp, models) {
 				response: JSON.stringify(_response)
 			});
 			return this.updateAutoActionExecuteOn(userId, _actionId, {
-				currentExecuteAttempts: totalExecuteAttempts
+				currentExecuteAttempts: totalExecuteAttempts,
+				isActive: Boolean(executePeriod)
 			})
 		}
 

--- a/app/modules/pin/api.ts
+++ b/app/modules/pin/api.ts
@@ -8,6 +8,7 @@ function sanitizePinAccount(account) {
     const plainAccount = account.toJSON ? account.toJSON() : {...account};
     delete plainAccount.secretApiKey;
     delete plainAccount.secretApiKeyEncrypted;
+    plainAccount.options = parsePinAccountOptions(plainAccount.options);
     return plainAccount;
 }
 
@@ -47,12 +48,23 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      *
      * @apiInterface (./interface.ts) {IPinAccount} apiBody
      * @apiInterface (./interface.ts) {IPinAccount} apiSuccess
+     * @apiBody {Object} [options] Pin account behavior options.
+     * @apiBody {Object} [options.autoPin] Automatic pin settings for newly saved content. This is supported only for user-owned accounts; group account automation requires explicit group/post policy.
+     * @apiBody {Boolean} [options.autoPin.enabled=false] Enqueue a one-shot pin action whenever the account owner saves new content.
+     * @apiBody {Number{1-10}} [options.autoPin.attempts=3] Maximum worker attempts for each automatic pin.
+     * @apiBody {Object} [options.autoPin.metadata] Flat Pinata metadata keyvalues added to automatic requests.
      *
      * @apiExample {curl} Example usage
      *   curl -X POST http://localhost:2052/v1/user/pin/create-account \
      *     -H "Authorization: Bearer geesome-api-key" \
      *     -H "Content-Type: application/json" \
      *     -d '{"name":"pinata","service":"pinata","apiKey":"pinata-key","secretApiKey":"pinata-secret"}'
+     *
+     * @apiExample {curl} Create an automatic Pinata account
+     *   curl -X POST http://localhost:2052/v1/user/pin/create-account \
+     *     -H "Authorization: Bearer geesome-api-key" \
+     *     -H "Content-Type: application/json" \
+     *     -d '{"name":"automatic-pinata","service":"pinata","apiKey":"pinata-key","secretApiKey":"pinata-secret","isEncrypted":true,"options":{"autoPin":{"enabled":true,"attempts":3,"metadata":{"collection":"uploads"}}}}'
      *
      * @apiExample {curl} Create a group Pinata account with encrypted secret
      *   curl -X POST http://localhost:2052/v1/user/pin/create-account \
@@ -78,6 +90,7 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
      * @apiParam {Number} id Pin account id.
      * @apiInterface (./interface.ts) {IPinAccount} apiBody
      * @apiInterface (./interface.ts) {IPinAccount} apiSuccess
+     * @apiBody {Object} [options] Replaces pin account behavior options. Set `options.autoPin.enabled` for automatic pinning on a user-owned account.
      *
      * @apiExample {curl} Rotate a Pinata secret
      *   curl -X POST http://localhost:2052/v1/user/pin/update-account/15 \
@@ -210,4 +223,19 @@ export default (app: IGeesomeApp, pinModule: IGeesomePinModule) => {
     app.ms.api.onAuthorizedPost('user/pin/account/:accountName/pin-content/:storageId/by-group/:groupId', async (req, res) => {
         res.send(await pinModule.pinByGroupAccount(req.user.id, req.params.groupId, req.params.accountName, req.params.storageId, req.body));
     });
+}
+
+function parsePinAccountOptions(options) {
+    if (!options) {
+        return {};
+    }
+    if (typeof options === 'object') {
+        return options;
+    }
+    try {
+        const parsedOptions = JSON.parse(options);
+        return parsedOptions && typeof parsedOptions === 'object' ? parsedOptions : {};
+    } catch (e) {
+        return {};
+    }
 }

--- a/app/modules/pin/docs/overview.md
+++ b/app/modules/pin/docs/overview.md
@@ -12,11 +12,15 @@ The `pin` module stores pinning-service accounts and sends storage pin requests,
 - Pin result recording in `PinStorageObject` when the model is available.
 - Marking content and canonical storage objects as pinned after successful remote pin requests.
 - A narrow auto-action allowlist for `pinByUserAccount` and `pinByGroupAccount`.
+- Opt-in production of one-shot auto actions when a user-owned account's owner saves new content.
 
 ## Async Boundaries
 
 - The module does not own a durable worker queue itself.
 - Long-running or scheduled pinning should be driven by `autoActions` or another producer that calls the pin methods.
+- Set `options.autoPin.enabled` on a user-owned account to enqueue newly saved content. `attempts` is clamped to `1..10` and defaults to `3`; optional flat `metadata` is forwarded to Pinata.
+- Successful one-shot actions are deactivated. Failed actions reuse the existing bounded retry and action-log behavior.
+- Group accounts are not triggered from the raw content hook because an upload has no group/post context. A future group policy must select the group account only after content is attached to an eligible post.
 - The current Pinata path only pins storage IDs backed by content owned by the pin-account owner; storage ID alone is not enough authorization.
 - Remote pin results should be recorded so storage-space analysis and cleanup safety can see remote pin state.
 
@@ -25,6 +29,7 @@ The `pin` module stores pinning-service accounts and sends storage pin requests,
 - Do not store plain secret keys when `isEncrypted` is set.
 - Do not infer pin safety from a successful HTTP response alone; keep DB state in sync.
 - Do not add broad auto-action access. Keep the allowlist small and permission-aware.
+- Keep automatic pinning opt-in. Existing accounts and malformed/unknown account options remain manual-only.
 - New pin providers should normalize status, remote IDs, errors, and account ownership before being exposed.
 
 ## Related Docs

--- a/app/modules/pin/index.ts
+++ b/app/modules/pin/index.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import pIteration from 'p-iteration';
-import IGeesomePinModule, {IPinAccount} from "./interface.js";
+import IGeesomePinModule, {IPinAccount, IPinAccountOptions} from "./interface.js";
 import {IListParams, IListParamsOptions} from "../database/interface.js";
 import {IGeesomeApp} from "../../interface.js";
 import helpers from "../../helpers.js";
@@ -29,15 +29,19 @@ export default async (app: IGeesomeApp) => {
 }
 
 export function getModule(app: IGeesomeApp, models) {
+	const autoPinAccountsByUser = new Map<number, IPinAccount[]>();
+
 	class PinModule implements IGeesomePinModule {
 		async createAccount(userId: number, account: IPinAccount): Promise<IPinAccount> {
 			if (account.groupId && !(await app.ms.group.canEditGroup(userId, account.groupId))) {
 				throw new Error("not_permitted");
 			}
-			return models.PinAccount.create({
-				...await this.encryptPinAccountIfNecessary(account),
+			const createdAccount = await models.PinAccount.create({
+				...await this.encryptPinAccountIfNecessary(preparePinAccountForStorage(account)),
 				userId
-			})
+			});
+			autoPinAccountsByUser.delete(userId);
+			return createdAccount;
 		}
 
 		async updateAccount(userId: number, id: number, updateData: IPinAccount): Promise<IPinAccount> {
@@ -46,9 +50,14 @@ export function getModule(app: IGeesomeApp, models) {
 				throw new Error("pin_account_not_found");
 			}
 			await this.checkCanManageAccount(userId, account);
-			return models.PinAccount.update(await this.encryptPinAccountIfNecessary(updateData), {where: {id}})
+			const updatedAccount = await models.PinAccount.update(
+				await this.encryptPinAccountIfNecessary(preparePinAccountForStorage(updateData)),
+				{where: {id}}
+			)
 				.then(() => models.PinAccount.findOne({where: {id}}))
 				.then(acc => this.decryptPinAccountIfNecessary(acc));
+			autoPinAccountsByUser.delete(account.userId);
+			return updatedAccount;
 		}
 
 		async deleteAccount(userId: number, id: number): Promise<{success: boolean}> {
@@ -58,6 +67,7 @@ export function getModule(app: IGeesomeApp, models) {
 			}
 			await this.checkCanManageAccount(userId, account);
 			await models.PinAccount.destroy({where: {id}});
+			autoPinAccountsByUser.delete(account.userId);
 			return {success: true};
 		}
 
@@ -169,7 +179,7 @@ export function getModule(app: IGeesomeApp, models) {
 				await app.ms.database.markStorageObjectPinnedByContent(content);
 				await this.recordPinnedStorageObject(storageId, account, content, result);
 			}
-			return result;
+			return result?.data ?? result;
 		}
 
 		async recordPinnedStorageObject(storageId: string, account: IPinAccount, content?, result?) {
@@ -194,6 +204,29 @@ export function getModule(app: IGeesomeApp, models) {
 			return pinStorageObject;
 		}
 
+		async afterContentAdding(userId, content) {
+			const autoActions = app.ms['autoActions'];
+			if (!autoActions || typeof autoActions.addAutoAction !== 'function') {
+				return [];
+			}
+			const autoPinAccounts = await this.getUserAutoPinAccounts(userId);
+			return pIteration.mapSeries(autoPinAccounts, (account) => {
+				return autoActions.addAutoAction(userId, getAutoPinAction(account, content));
+			});
+		}
+
+		async getUserAutoPinAccounts(userId) {
+			if (autoPinAccountsByUser.has(userId)) {
+				return autoPinAccountsByUser.get(userId);
+			}
+			const accounts = await this.getUserAccountsList(userId, {limit: 100});
+			const autoPinAccounts = accounts
+				.filter(isUserAutoPinAccount)
+				.map(getAutoPinAccountPolicy);
+			autoPinAccountsByUser.set(userId, autoPinAccounts);
+			return autoPinAccounts;
+		}
+
 		async encryptPinAccountIfNecessary(pinAccount: IPinAccount) {
 			if (pinAccount.isEncrypted && pinAccount.secretApiKey) {
 				pinAccount.secretApiKeyEncrypted = await app.encryptTextWithAppPass(pinAccount.secretApiKey);
@@ -213,6 +246,7 @@ export function getModule(app: IGeesomeApp, models) {
 		}
 
 		async flushDatabase() {
+			autoPinAccountsByUser.clear();
 			await pIteration.forEachSeries(['PinStorageObject', 'PinAccount'], (modelName) => {
 				return models[modelName].destroy({where: {}});
 			});
@@ -282,4 +316,79 @@ function stringifyPinResult(result) {
 	} catch (e) {
 		return JSON.stringify({error: 'pin_result_unserializable'});
 	}
+}
+
+function preparePinAccountForStorage(account: IPinAccount): IPinAccount {
+	if (!account || typeof account.options !== 'object') {
+		return account;
+	}
+	return {
+		...account,
+		options: JSON.stringify(account.options)
+	};
+}
+
+function isUserAutoPinAccount(account: IPinAccount) {
+	if (account.groupId) {
+		return false;
+	}
+	return getPinAccountOptions(account).autoPin?.enabled === true;
+}
+
+function getAutoPinAction(account: IPinAccount, content) {
+	const autoPinOptions = getPinAccountOptions(account).autoPin || {};
+	const attempts = getAutoPinAttempts(autoPinOptions.attempts);
+	return {
+		moduleName: 'pin',
+		funcName: 'pinByUserAccount',
+		funcArgs: JSON.stringify([
+			account.name,
+			content.storageId,
+			{...getAutoPinMetadata(autoPinOptions.metadata), source: 'auto-pin'}
+		]),
+		isActive: true,
+		executePeriod: 0,
+		totalExecuteAttempts: attempts,
+		currentExecuteAttempts: attempts,
+		executeOn: new Date()
+	};
+}
+
+function getAutoPinAccountPolicy(account: IPinAccount): IPinAccount {
+	return {
+		name: account.name,
+		options: getPinAccountOptions(account)
+	};
+}
+
+function getPinAccountOptions(account: IPinAccount): IPinAccountOptions {
+	if (!account?.options) {
+		return {};
+	}
+	if (typeof account.options === 'object') {
+		return account.options;
+	}
+	try {
+		const options = JSON.parse(account.options);
+		return options && typeof options === 'object' ? options : {};
+	} catch (e) {
+		return {};
+	}
+}
+
+function getAutoPinAttempts(value) {
+	const attempts = Number.parseInt(value, 10);
+	if (!Number.isFinite(attempts)) {
+		return 3;
+	}
+	return Math.min(Math.max(attempts, 1), 10);
+}
+
+function getAutoPinMetadata(metadata) {
+	if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+		return {};
+	}
+	return Object.fromEntries(Object.entries(metadata).filter(([, value]) => {
+		return ['string', 'number', 'boolean'].includes(typeof value);
+	}));
 }

--- a/app/modules/pin/interface.ts
+++ b/app/modules/pin/interface.ts
@@ -33,7 +33,15 @@ export interface IPinAccount {
 	isEncrypted?: boolean;
 	secretApiKeyEncrypted?: string;
 	secretApiKey?: string;
-	options?: string;
+	options?: string | IPinAccountOptions;
+}
+
+export interface IPinAccountOptions {
+	autoPin?: {
+		enabled?: boolean;
+		attempts?: number;
+		metadata?: Record<string, string | number | boolean>;
+	};
 }
 
 export interface IPinStorageObject {

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -184,9 +184,10 @@ Verification:
 - Existing API/gateway tests remain green with profiling disabled.
 <!-- /todo-section -->
 
+<!-- todo-section: pinata-and-pinning-mvp -->
 ### 4. Pinata And Pinning MVP
 
-Status: in progress. [#854](https://github.com/galtproject/geesome-node/issues/854) hardens direct pin negative paths with explicit missing-account, unknown-service, and missing-content errors before remote pinning is attempted. [#856](https://github.com/galtproject/geesome-node/issues/856) keeps pin account secret updates encrypted and returns an explicit missing-account error for update calls. [#858](https://github.com/galtproject/geesome-node/issues/858) forwards caller pin options into Pinata metadata and normalizes remote Pinata failures to `pinata_pin_failed`. [#868](https://github.com/galtproject/geesome-node/issues/868) documents the account and direct pin API flows, examples, forwarded Pinata keyvalues, and common pin errors. [#872](https://github.com/galtproject/geesome-node/issues/872) enforces group edit permission before creating/deleting group-owned pin accounts and keeps pin secrets write-only in API responses. The same node PR consumes `geesome-ui` [#5](https://github.com/galtproject/geesome-ui/issues/5), [#7](https://github.com/galtproject/geesome-ui/issues/7), and [#6](https://github.com/galtproject/geesome-ui/pull/6) at commit `4c24162` so the profile UI can configure pin accounts, delete them, upload a file, pin its `storageId` through the user-owned account endpoint, and carry first-pass e2e/screenshot coverage plus repo-local e2e/screenshot review instructions.
+Status: in progress. [#854](https://github.com/galtproject/geesome-node/issues/854) hardens direct pin negative paths with explicit missing-account, unknown-service, and missing-content errors before remote pinning is attempted. [#856](https://github.com/galtproject/geesome-node/issues/856) keeps pin account secret updates encrypted and returns an explicit missing-account error for update calls. [#858](https://github.com/galtproject/geesome-node/issues/858) forwards caller pin options into Pinata metadata and normalizes remote Pinata failures to `pinata_pin_failed`. [#868](https://github.com/galtproject/geesome-node/issues/868) documents the account and direct pin API flows, examples, forwarded Pinata keyvalues, and common pin errors. [#872](https://github.com/galtproject/geesome-node/issues/872) enforces group edit permission before creating/deleting group-owned pin accounts and keeps pin secrets write-only in API responses. The same node PR consumes `geesome-ui` [#5](https://github.com/galtproject/geesome-ui/issues/5), [#7](https://github.com/galtproject/geesome-ui/issues/7), and [#6](https://github.com/galtproject/geesome-ui/pull/6) at commit `4c24162` so the profile UI can configure pin accounts, delete them, upload a file, pin its `storageId` through the user-owned account endpoint, and carry first-pass e2e/screenshot coverage plus repo-local e2e/screenshot review instructions. User-owned accounts can now opt into automatic pinning through structured account options; each new-content hook creates a bounded one-shot `autoActions` job, and successful one-shot actions are deactivated instead of being selected again every minute.
 
 Goal: turn "Pin to services like pinata from UI" into a shippable backend/API slice first.
 
@@ -195,7 +196,8 @@ Scope:
 - Audit `pin` module behavior for encrypted account storage, account ownership, group account permissions, and Pinata request error handling. Group-owned account creation/deletion now checks edit permission, and API responses no longer echo pin secrets; keep the same boundary in the future UI.
 - Add API docs/examples for account creation, listing, and pin-by-user/group calls.
 - Add negative-path tests for missing account, unknown service, remote Pinata error, and group permission denial.
-- Wire auto/manual pin behavior through existing `autoActions` only after the direct pin path is tested.
+- Add the profile-UI toggle and attempt/metadata controls for user-account automatic pinning.
+- Define a separate group/post policy before enabling group-account automatic pinning; raw uploads do not yet identify which group should own the remote pin.
 
 Likely modules:
 
@@ -209,6 +211,7 @@ Verification:
 - `test/pin.test.ts`
 - `test/autoActions.test.ts`
 - `yarn test`
+<!-- /todo-section -->
 
 ### 5. API Key Permissions And Expiration
 

--- a/test/autoActions.test.ts
+++ b/test/autoActions.test.ts
@@ -344,4 +344,37 @@ describe("autoActions", function () {
 		assert.deepEqual(JSON.parse(logs[0].response), longResponse);
 		assert.equal(JSON.parse(logs[1].error), 'x'.repeat(400));
 	});
+
+	it('deactivates successful one-shot actions and keeps recurring actions active', async () => {
+		const testUser = (await app.ms.database.getAllUserList('user'))[0];
+		const oneShot = await autoActions.addAutoAction(testUser.id, {
+			moduleName: 'content',
+			funcName: 'saveDataAndGetStorageId',
+			funcArgs: '[]',
+			isActive: true,
+			totalExecuteAttempts: 3,
+			currentExecuteAttempts: 3,
+			executePeriod: 0,
+			executeOn: new Date()
+		});
+		const recurring = await autoActions.addAutoAction(testUser.id, {
+			moduleName: 'content',
+			funcName: 'saveDataAndGetStorageId',
+			funcArgs: '[]',
+			isActive: true,
+			totalExecuteAttempts: 3,
+			currentExecuteAttempts: 3,
+			executePeriod: 60,
+			executeOn: new Date()
+		});
+
+		await autoActions.handleAutoActionSuccessfulExecution(testUser.id, oneShot.id, {ok: true});
+		await autoActions.handleAutoActionSuccessfulExecution(testUser.id, recurring.id, {ok: true});
+
+		const storedOneShot = await (autoActions as any).getAutoAction(oneShot.id);
+		const storedRecurring = await (autoActions as any).getAutoAction(recurring.id);
+		assert.equal(storedOneShot.isActive, false);
+		assert.equal(storedRecurring.isActive, true);
+		assert(storedRecurring.executeOn.getTime() > recurring.executeOn.getTime());
+	});
 });

--- a/test/pin.test.ts
+++ b/test/pin.test.ts
@@ -8,8 +8,11 @@
  */
 
 import assert from "assert";
+import axios from "axios";
 import {CorePermissionName} from "../app/modules/database/interface.js";
 import IGeesomePinModule from "../app/modules/pin/interface.js";
+import IGeesomeAutoActionsModule from "../app/modules/autoActions/interface.js";
+import CronService from "../app/modules/autoActions/cronService.js";
 import {IGeesomeApp} from "../app/interface.js";
 
 function isUniqueConstraintError(error: Error) {
@@ -191,5 +194,42 @@ describe("pin", function () {
 			}),
 			isUniqueConstraintError
 		);
+	});
+
+	it('queues and executes opted-in automatic pins once', async () => {
+		const testUser = (await app.ms.database.getAllUserList('user'))[0];
+		const autoActions = app.ms['autoActions'] as IGeesomeAutoActionsModule;
+		const originalAxiosPost = axios.post;
+		axios.post = async (url, body) => ({data: {IpfsHash: body.hashToPin}}) as any;
+
+		try {
+			await pins.createAccount(testUser.id, {
+				name: 'automatic-pinata',
+				service: 'pinata',
+				apiKey: '111',
+				secretApiKey: '222',
+				options: {autoPin: {enabled: true, attempts: 2}}
+			});
+
+			const content = await app.ms.content.saveData(testUser.id, 'automatic pin', 'automatic-pin.txt');
+			const queued = await autoActions.getUserActions(testUser.id, {
+				moduleName: 'pin',
+				funcName: 'pinByUserAccount'
+			});
+			assert.equal(queued.total, 1);
+			assert.equal(queued.list[0].isActive, true);
+
+			await new CronService(app, autoActions).getActionsAndAddToQueueAndRun();
+
+			const completed = await autoActions.getUserActions(testUser.id, {
+				moduleName: 'pin',
+				funcName: 'pinByUserAccount'
+			});
+			const pinnedContent = await app.ms.content.getContentByStorageAndUserId(content.storageId, testUser.id);
+			assert.equal(completed.list[0].isActive, false);
+			assert.equal(pinnedContent.isPinned, true);
+		} finally {
+			axios.post = originalAxiosPost;
+		}
 	});
 });

--- a/test/pinApiUnit.test.ts
+++ b/test/pinApiUnit.test.ts
@@ -50,7 +50,8 @@ describe("pin api", function () {
 			apiKey: "pinata-key",
 			secretApiKey: "pinata-secret",
 			secretApiKeyEncrypted: "encrypted-pinata-secret",
-			isEncrypted: true
+			isEncrypted: true,
+			options: JSON.stringify({autoPin: {enabled: true}})
 		};
 		const {call} = createPinApiHarness({
 			createAccount: async () => ({...secretAccount}),
@@ -70,6 +71,7 @@ describe("pin api", function () {
 		assert.equal(created.secretApiKey, undefined);
 		assert.equal(created.secretApiKeyEncrypted, undefined);
 		assert.equal(created.apiKey, "pinata-key");
+		assert.deepEqual(created.options, {autoPin: {enabled: true}});
 
 		const updated = await call("POST", "user/pin/update-account/:id", {params: {id: 1}});
 		assert.equal(updated.secretApiKey, undefined);
@@ -81,6 +83,7 @@ describe("pin api", function () {
 		});
 		assert.equal(userAccounts.list[0].secretApiKey, undefined);
 		assert.equal(userAccounts.list[0].secretApiKeyEncrypted, undefined);
+		assert.deepEqual(userAccounts.list[0].options, {autoPin: {enabled: true}});
 		assert.deepEqual(userAccountListParams, {limit: "7", sortBy: "name"});
 
 		const groupAccounts = await call("GET", "user/pin/group-accounts/:groupId", {

--- a/test/pinUnit.test.ts
+++ b/test/pinUnit.test.ts
@@ -8,12 +8,20 @@ function createPinModule(
 	contentByStorageId: Record<string, any> = {},
 	editableGroupIds: number[] = [1],
 	markedStorageObjects: any[] = [],
-	pinnedStorageObjects: any[] = []
+	pinnedStorageObjects: any[] = [],
+	autoActions: any[] = []
 ) {
 	return getPinModule({
 		encryptTextWithAppPass: async (text) => `encrypted:${text}`,
 		decryptTextWithAppPass: async (text) => text.replace(/^encrypted:/, ""),
 		ms: {
+			autoActions: {
+				addAutoAction: async (userId, action) => {
+					const created = {id: autoActions.length + 1, userId, ...action};
+					autoActions.push(created);
+					return created;
+				}
+			},
 			content: {
 				getContentByStorageAndUserId: async (storageId, userId) => {
 					const content = contentByStorageId[storageId];
@@ -258,7 +266,7 @@ describe("pin negative paths", function () {
 			{"storage-id": {id: 10, userId: 1, name: "content-name"}}
 		);
 
-		await pins.pinByUserAccount(1, "pinata", "storage-id", {source: "auto-action"});
+		const response = await pins.pinByUserAccount(1, "pinata", "storage-id", {source: "auto-action"});
 
 		assert.deepEqual(pinataRequest.body, {
 			hostNodes: ["node-address"],
@@ -270,6 +278,77 @@ describe("pin negative paths", function () {
 		});
 		assert.equal(pinataRequest.config.headers.pinata_api_key, "pinata-key");
 		assert.equal(pinataRequest.config.headers.pinata_secret_api_key, "pinata-secret");
+		assert.deepEqual(response, {ok: true});
+	});
+
+	it("queues one-shot auto pin actions only for opted-in user accounts", async () => {
+		const autoActions = [];
+		const pins: any = createPinModule([
+			{
+				userId: 1,
+				name: "automatic",
+				service: "pinata",
+				options: JSON.stringify({
+					autoPin: {enabled: true, attempts: 20, metadata: {collection: "uploads"}}
+				})
+			},
+			{userId: 1, name: "manual", service: "pinata"},
+			{
+				userId: 1,
+				groupId: 10,
+				name: "group-automatic",
+				service: "pinata",
+				options: {autoPin: {enabled: true}}
+			}
+		], {}, [10], [], [], autoActions);
+
+		await pins.afterContentAdding(1, {storageId: "storage-id"});
+
+		assert.equal(autoActions.length, 1);
+		assert.equal(autoActions[0].moduleName, "pin");
+		assert.equal(autoActions[0].funcName, "pinByUserAccount");
+		assert.deepEqual(JSON.parse(autoActions[0].funcArgs), [
+			"automatic",
+			"storage-id",
+			{source: "auto-pin", collection: "uploads"}
+		]);
+		assert.equal(autoActions[0].isActive, true);
+		assert.equal(autoActions[0].executePeriod, 0);
+		assert.equal(autoActions[0].totalExecuteAttempts, 10);
+		assert.equal(autoActions[0].currentExecuteAttempts, 10);
+		assert(autoActions[0].executeOn instanceof Date);
+	});
+
+	it("stores structured pin account options as JSON", async () => {
+		const accounts = [];
+		const pins = createPinModule(accounts);
+
+		await pins.createAccount(1, {
+			name: "automatic",
+			service: "pinata",
+			options: {autoPin: {enabled: true}}
+		});
+
+		assert.equal(accounts[0].options, JSON.stringify({autoPin: {enabled: true}}));
+	});
+
+	it("invalidates cached auto pin policy when an account is updated", async () => {
+		const accounts: any[] = [{
+			id: 1,
+			userId: 1,
+			name: "automatic",
+			service: "pinata",
+			options: JSON.stringify({autoPin: {enabled: false}})
+		}];
+		const autoActions = [];
+		const pins: any = createPinModule(accounts, {}, [1], [], [], autoActions);
+
+		await pins.afterContentAdding(1, {storageId: "first-storage"});
+		await pins.updateAccount(1, 1, {options: {autoPin: {enabled: true}}});
+		await pins.afterContentAdding(1, {storageId: "second-storage"});
+
+		assert.equal(autoActions.length, 1);
+		assert.equal(JSON.parse(autoActions[0].funcArgs)[1], "second-storage");
 	});
 
 	it("marks content and storage object pinned after a successful remote pin", async () => {


### PR DESCRIPTION
## Summary
- enqueue bounded one-shot pin jobs when a user-owned pin account opts into `options.autoPin.enabled`
- deactivate successful one-shot actions while preserving recurring action scheduling and bounded failure retries
- normalize Pinata results and account options for durable action logs and clean API responses
- cache non-secret per-user auto-pin policy and invalidate it when accounts change
- document the backend flow and retain group-account/UI policy as explicit follow-up work

## Safety and compatibility
- existing accounts remain manual-only because auto pinning is explicitly opt-in
- no schema migration is required; structured options use the existing `PinAccount.options` column
- group accounts are excluded until a group/post-aware ownership policy exists
- cached policy contains only account names and options, never credentials
- retries are clamped to 1-10 and successful one-shot jobs cannot be claimed again

## Verification
- `npm run test:docker`: 425 passing, 11 pending
- focused Docker pin/autoActions suite: 24 passing
- focused host pin unit/API suite: 15 passing
- `npm run generate-docs`
- `npm run security:route-inventory:update`
- `npm run security:route-inventory`
- `git diff --check`

Advances #495.