### PR TITLE
Close database and auto-action workers on shutdown

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -114,6 +114,8 @@ function getModule(config, appPass) {
 
     apiKeyContext = new AsyncLocalStorage<any>();
 
+    stopPromise: Promise<void> | null = null;
+
     ms: {
       database: IGeesomeDatabaseModule,
       content: IGeesomeContentModule,
@@ -702,7 +704,14 @@ function getModule(config, appPass) {
     }
 
     async stop() {
-      await pIteration.forEachSeries(this.config.modules, async (moduleName: string) => {
+      if (!this.stopPromise) {
+        this.stopPromise = this.stopModules();
+      }
+      return this.stopPromise;
+    }
+
+    async stopModules() {
+      await pIteration.forEachSeries(reverse(clone(this.config.modules)), async (moduleName: string) => {
         if (this.ms[moduleName] && this.ms[moduleName].stop) {
           log(`Stop ${moduleName} module...`);
           try {

--- a/app/modules/autoActions/cron.ts
+++ b/app/modules/autoActions/cron.ts
@@ -1,11 +1,45 @@
 import {IGeesomeApp} from "../../interface.js";
+import helpers from "../../helpers.js";
 import IGeesomeAutoActionsModule from "./interface.js";
 import CronService from "./cronService.js";
 
-export default (app: IGeesomeApp, autoActionsModule: IGeesomeAutoActionsModule) => {
-	const cronService = new CronService(app, autoActionsModule);
+const defaultAutoActionsCronIntervalMs = 60 * 1000;
 
-	setInterval(async () => {
-		await cronService.getActionsAndAddToQueueAndRun().catch(e => console.error('getActionsAndAddToQueue error', e));
-	}, 60 * 1000);
+export interface IAutoActionsCronWorker {
+	stop(): Promise<void>;
+}
+
+interface IAutoActionsCronOptions {
+	intervalMs?: number;
+	cronService?: CronService;
+}
+
+export default (
+	app: IGeesomeApp,
+	autoActionsModule: IGeesomeAutoActionsModule,
+	options: IAutoActionsCronOptions = {}
+): IAutoActionsCronWorker => {
+	const cronService = options.cronService || new CronService(app, autoActionsModule);
+	const intervalMs = helpers.parsePositiveInteger(options.intervalMs, defaultAutoActionsCronIntervalMs);
+	let runPromise: Promise<any> | null = null;
+	let stopped = false;
+	const timer = setInterval(() => {
+		if (stopped || runPromise) {
+			return;
+		}
+		runPromise = cronService.getActionsAndAddToQueueAndRun()
+			.catch(e => console.error('getActionsAndAddToQueue error', e))
+			.finally(() => {
+				runPromise = null;
+			});
+	}, intervalMs);
+	timer.unref?.();
+
+	return {
+		async stop() {
+			stopped = true;
+			clearInterval(timer);
+			await runPromise;
+		}
+	};
 }

--- a/app/modules/autoActions/index.ts
+++ b/app/modules/autoActions/index.ts
@@ -7,6 +7,7 @@ import IGeesomeAutoActionsModule, {IAutoAction, IAutoActionClaimOptions} from ".
 import {IGeesomeApp} from "../../interface.js";
 import {IListParamsOptions} from "../database/interface.js";
 import helpers from "../../helpers.js";
+import type {IAutoActionsCronWorker} from "./cron.js";
 const {some, orderBy, reverse} = _;
 const log = debug('geesome:app:autoActions');
 const autoActionExecuteBatchLimit = 100;
@@ -71,7 +72,7 @@ export default async (app: IGeesomeApp) => {
 	const models = await (await import("./models.js")).default(app.ms.database.sequelize);
 	const module = await getModule(app, models);
 	(await import('./api.js')).default(app, module);
-	(await import('./cron.js')).default(app, module);
+	module.setCronWorker((await import('./cron.js')).default(app, module));
 	return module;
 }
 
@@ -79,6 +80,18 @@ function getModule(app: IGeesomeApp, models) {
 	const executionClaimsSupported = models.autoActionExecutionClaimsSupported === true;
 
 	class AutoActionsModule implements IGeesomeAutoActionsModule {
+		cronWorker: IAutoActionsCronWorker | null = null;
+
+		setCronWorker(cronWorker: IAutoActionsCronWorker) {
+			this.cronWorker = cronWorker;
+		}
+
+		async stop() {
+			const cronWorker = this.cronWorker;
+			this.cronWorker = null;
+			await cronWorker?.stop();
+		}
+
 		async addAutoAction(userId, autoAction) {
 			const nextActions = await this.getNextActionsToStore(userId, autoAction.nextActions);
 

--- a/app/modules/autoActions/interface.ts
+++ b/app/modules/autoActions/interface.ts
@@ -1,4 +1,6 @@
 export default interface IGeesomeAutoActionsModule {
+	stop(): Promise<void>;
+
 	addSerialAutoActions(userId: number, autoActions: IAutoAction[]): Promise<IAutoAction[]>;
 
 	addAutoAction(userId: number, autoAction: IAutoAction): Promise<IAutoAction>;

--- a/app/modules/database/index.ts
+++ b/app/modules/database/index.ts
@@ -133,6 +133,7 @@ class PostgresDatabase implements IGeesomeDatabaseModule {
   sequelize: any;
   models: any;
   config: any;
+  stopPromise: Promise<void> | null = null;
 
   constructor(_app, _sequelize, _models, _config) {
     this.app = _app;
@@ -208,6 +209,13 @@ class PostgresDatabase implements IGeesomeDatabaseModule {
     return new SessionStore({
       db: this.sequelize,
     });
+  }
+
+  async stop() {
+    if (!this.stopPromise) {
+      this.stopPromise = this.sequelize.close();
+    }
+    return this.stopPromise;
   }
 
   async flushDatabase() {

--- a/app/modules/database/interface.ts
+++ b/app/modules/database/interface.ts
@@ -16,6 +16,8 @@ export interface IGeesomeDatabaseModule {
 
   getSessionStore(): any;
 
+  stop(): Promise<void>;
+
   flushDatabase(): Promise<void>;
 
   addApiKey(apiKey): Promise<IUserApiKey>;

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -196,7 +196,7 @@ Verification:
 <!-- todo-section: database-connection-worker-lifecycle -->
 #### Runtime Reliability: Database Connection And Worker Lifecycle
 
-Status: planned from a real full-suite signal. The 2026-07-14 Docker run completed with `431 passing, 11 pending`, but late Telegram-import tests coincided with repeated `SequelizeConnectionError: sorry, too many clients already` errors from the auto-action worker. The tests still passed, so the immediate task is attribution and lifecycle correction rather than a speculative pool-size increase.
+Status: first lifecycle correction implemented from a real full-suite signal. The original 2026-07-14 Docker run completed with `431 passing, 11 pending`, but late Telegram-import tests coincided with repeated `SequelizeConnectionError: sorry, too many clients already` errors from the auto-action worker. Attribution found that every test app opened the shared Sequelize pool but `app.stop()` never closed it, while the always-on auto-action interval was not owned or drained by its module. App shutdown now runs once in reverse startup order, the database closes its pool last, and the auto-action module clears its interval and awaits an in-flight run. A full Docker rerun completed with `433 passing, 11 pending` and no PostgreSQL client-exhaustion errors. Remaining work is the opt-in ActivityPub/Bluesky timer lifecycle, fire-and-forget worker drains, and bounded connection-budget diagnostics rather than a speculative pool-size increase.
 
 Goal: give all long-lived workers and module-owned Sequelize instances an explicit connection budget and deterministic shutdown path, then prove normal test and application lifecycles do not exhaust PostgreSQL clients.
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -111,6 +111,16 @@ describe("app", function () {
 		// assert.notEqual(contentObj.storageAccountId, null);
 	});
 
+	it('closes the database pool once during repeated shutdown', async () => {
+		await app.stop();
+		await app.stop();
+
+		await assert.rejects(
+			() => app.ms.database.sequelize.authenticate(),
+			/closed/i
+		);
+	});
+
 	it('keeps one user limit row per user and name', async () => {
 		const adminUser = (await app.ms.database.getAllUserList('admin'))[0];
 		const testUser = (await app.ms.database.getAllUserList('user'))[0];

--- a/test/autoActions.test.ts
+++ b/test/autoActions.test.ts
@@ -48,7 +48,6 @@ describe("autoActions", function () {
 
 	afterEach(async () => {
 		await app.stop();
-		await app.flushDatabase();
 	});
 
 	it('autoActions should be executed successfully', async () => {

--- a/test/autoActionsCronService.test.ts
+++ b/test/autoActionsCronService.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import CronService from "../app/modules/autoActions/cronService.js";
+import startAutoActionsCron from "../app/modules/autoActions/cron.js";
 
 describe("autoActions cron service", () => {
 	it('does not requeue an action while it is already running', async () => {
@@ -56,4 +57,46 @@ describe("autoActions cron service", () => {
 		assert.equal(runCalls, 1);
 		assert.equal(cronService.actionIdsInQueueOrProcess.has(action.id), false);
 	});
+
+	it('stops scheduling and waits for an in-flight run', async () => {
+		let releaseRun;
+		let markStarted;
+		let runCalls = 0;
+		const runReleased = new Promise((resolve) => {
+			releaseRun = resolve;
+		});
+		const runStarted = new Promise((resolve) => {
+			markStarted = resolve;
+		});
+		const cronService = {
+			async getActionsAndAddToQueueAndRun() {
+				runCalls++;
+				markStarted(true);
+				await runReleased;
+			}
+		};
+		const worker = startAutoActionsCron({} as any, {} as any, {
+			intervalMs: 1,
+			cronService: cronService as any
+		});
+
+		await runStarted;
+		let stopResolved = false;
+		const stopPromise = worker.stop().then(() => {
+			stopResolved = true;
+		});
+		await wait(5);
+		assert.equal(stopResolved, false);
+
+		releaseRun(true);
+		await stopPromise;
+		await wait(5);
+
+		assert.equal(stopResolved, true);
+		assert.equal(runCalls, 1);
+	});
 });
+
+function wait(timeoutMs: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, timeoutMs));
+}


### PR DESCRIPTION
## Summary

- make app shutdown idempotent and stop modules in reverse startup order
- close the shared Sequelize pool from the database module after feature workers stop
- make the auto-action interval owned, non-overlapping, unref'd, and awaitable
- add repeated-shutdown and in-flight worker lifecycle coverage
- record the root cause and remaining worker-lifecycle follow-ups in the deterministic TODO section

## Root cause

Each integration-test app opened a Sequelize pool, but `app.stop()` never closed it. The always-on auto-action interval was also untracked and could continue polling after its app had stopped. Accumulated pools eventually reached PostgreSQL's client limit late in the suite.

## Compatibility

This changes shutdown behavior only. Runtime startup, schema, APIs, and persisted data are unchanged. Shutdown now drains the auto-action worker before closing the shared database pool.

## Validation

- `node --import tsx ./node_modules/.bin/mocha test/autoActionsCronService.test.ts`
- `npm run todo:context -- database-connection-worker-lifecycle`
- `npm run test:docker`: 433 passing, 11 pending
- full rerun reached the late Telegram tests without `too many clients already`
- `git diff --check`
