### PR TITLE
Deduplicate pending automatic pin jobs

### DIFF
--- a/app/modules/autoActions/index.ts
+++ b/app/modules/autoActions/index.ts
@@ -101,6 +101,21 @@ function getModule(app: IGeesomeApp, models) {
 			return this.setNextActions(res, nextActions).then(() => this.getAutoAction(res.id)) as IAutoAction;
 		}
 
+		async addUniqueAutoAction(userId, identityKey, autoAction) {
+			const normalizedIdentityKey = getAutoActionIdentityKey(identityKey);
+			const nextActions = await this.getNextActionsToStore(userId, autoAction.nextActions);
+			await this.encryptAutoActionIfNecessary(autoAction);
+			const {action, created} = await models.AutoAction.findOrCreateActiveByIdentity({
+				userId,
+				identityKey: normalizedIdentityKey,
+				autoAction
+			});
+			if (created) {
+				await this.setNextActions(action, nextActions);
+			}
+			return this.getAutoAction(action.id) as Promise<IAutoAction>;
+		}
+
 		async encryptAutoActionIfNecessary(autoAction) {
 			if (autoAction.isEncrypted && autoAction.funcArgs) {
 				autoAction.funcArgsEncrypted = await app.encryptTextWithAppPass(autoAction.funcArgs);
@@ -320,11 +335,19 @@ function getModule(app: IGeesomeApp, models) {
 		}
 
 		async flushDatabase() {
-			await pIteration.forEachSeries(['NextActionsPivot', 'AutoActionLog', 'AutoAction'], (modelName) => {
+			await pIteration.forEachSeries(['NextActionsPivot', 'AutoActionLog', 'AutoActionDedupeKey', 'AutoAction'], (modelName) => {
 				return models[modelName].destroy({where: {}});
 			});
 		}
 	}
 
 	return new AutoActionsModule();
+}
+
+function getAutoActionIdentityKey(identityKey): string {
+	const normalizedIdentityKey = String(identityKey || '').trim();
+	if (!normalizedIdentityKey || normalizedIdentityKey.length > 500) {
+		throw new Error('auto_action_identity_key_invalid');
+	}
+	return normalizedIdentityKey;
 }

--- a/app/modules/autoActions/interface.ts
+++ b/app/modules/autoActions/interface.ts
@@ -5,6 +5,8 @@ export default interface IGeesomeAutoActionsModule {
 
 	addAutoAction(userId: number, autoAction: IAutoAction): Promise<IAutoAction>;
 
+	addUniqueAutoAction(userId: number, identityKey: string, autoAction: IAutoAction): Promise<IAutoAction>;
+
 	updateAutoAction(userId: number, id: number, autoAction: IAutoAction): Promise<IAutoAction>;
 
 	getAutoActionsToExecute(): Promise<IAutoAction[]>;

--- a/app/modules/autoActions/models.ts
+++ b/app/modules/autoActions/models.ts
@@ -148,6 +148,33 @@ export default async function (sequelize: Sequelize) {
 
 	await AutoAction.sync({});
 
+	const AutoActionDedupeKey = sequelize.define('autoActionDedupeKey', {
+		identityKey: {
+			type: DataTypes.STRING(500),
+			allowNull: false
+		},
+		userId: {
+			type: DataTypes.INTEGER,
+			allowNull: false
+		},
+		autoActionId: {
+			type: DataTypes.INTEGER
+		}
+	} as any, {
+		indexes: [
+			{
+				name: 'auto_action_dedupe_keys_user_identity_unique',
+				fields: ['userId', 'identityKey'],
+				unique: true
+			},
+			{name: 'auto_action_dedupe_keys_action_idx', fields: ['autoActionId']}
+		]
+	} as any);
+	await AutoActionDedupeKey.sync({});
+	(AutoAction as any).findOrCreateActiveByIdentity = (options) => {
+		return findOrCreateActiveAutoActionByIdentity(sequelize, AutoAction, AutoActionDedupeKey, options);
+	};
+
 	const NextActionsPivot = sequelize.define('nextActionsPivot',{
 		baseActionId: {
 			type: DataTypes.INTEGER,
@@ -201,8 +228,51 @@ export default async function (sequelize: Sequelize) {
 
 	return {
 		AutoAction,
+		AutoActionDedupeKey,
 		autoActionExecutionClaimsSupported: includeExecutionClaimColumns,
 		NextActionsPivot: await NextActionsPivot.sync({}),
 		AutoActionLog: await AutoActionLog.sync({})
 	};
 };
+
+async function findOrCreateActiveAutoActionByIdentity(
+	sequelize: Sequelize,
+	AutoAction,
+	AutoActionDedupeKey,
+	options
+) {
+	return sequelize.transaction(async transaction => {
+		await AutoActionDedupeKey.findOrCreate({
+			where: {
+				userId: options.userId,
+				identityKey: options.identityKey
+			},
+			transaction
+		});
+		const dedupeKey = await AutoActionDedupeKey.findOne({
+			where: {
+				userId: options.userId,
+				identityKey: options.identityKey
+			},
+			transaction,
+			lock: transaction.LOCK.UPDATE
+		});
+		if (dedupeKey.autoActionId) {
+			const activeAction = await AutoAction.findOne({
+				where: {
+					id: dedupeKey.autoActionId,
+					userId: options.userId,
+					isActive: true
+				},
+				transaction
+			});
+			if (activeAction) {
+				return {action: activeAction, created: false};
+			}
+		}
+
+		const action = await AutoAction.create({...options.autoAction, userId: options.userId}, {transaction});
+		await dedupeKey.update({autoActionId: action.id}, {transaction});
+		return {action, created: true};
+	});
+}

--- a/app/modules/pin/index.ts
+++ b/app/modules/pin/index.ts
@@ -152,6 +152,26 @@ export function getModule(app: IGeesomeApp, models) {
 			return this.pinByAnyService(storageId, account, options, content)
 		}
 
+		async pinByAccountId(userId: number, accountId: number, storageId: string, options: any = {}): Promise<any> {
+			const account = await models.PinAccount.findOne({where: {id: accountId}})
+				.then(pinAccount => this.decryptPinAccountIfNecessary(pinAccount));
+			if (!account) {
+				throw new Error("pin_account_not_found");
+			}
+			let content = null;
+			if (account.groupId) {
+				if (!await app.ms.group.canEditGroup(userId, account.groupId)) {
+					throw new Error("not_permitted");
+				}
+				content = options?.postId
+					? await this.resolveGroupPostPinTarget(account.groupId, options.postId, storageId)
+					: null;
+			} else if (Number(account.userId) !== Number(userId)) {
+				throw new Error("not_permitted");
+			}
+			return this.pinByAnyService(storageId, account, options, content);
+		}
+
 		async pinByAnyService(storageId: string, account: IPinAccount, options?, content?) {
 			if (!account) {
 				throw new Error("pin_account_not_found");
@@ -223,8 +243,16 @@ export function getModule(app: IGeesomeApp, models) {
 				return [];
 			}
 			const autoPinAccounts = await this.getUserAutoPinAccounts(userId);
+			const targetsByAccount = autoPinAccounts.map(account => ({
+				account,
+				targets: [{storageId: content.storageId}]
+			}));
+			const pinnedStorageObjectKeys = await this.getPinnedStorageObjectKeys(targetsByAccount);
 			return pIteration.mapSeries(autoPinAccounts, (account) => {
-				return autoActions.addAutoAction(userId, getAutoPinAction(account, content));
+				if (pinnedStorageObjectKeys.has(getPinStorageObjectKey(account.id, content.storageId))) {
+					return null;
+				}
+				return queueAutoPinAction(autoActions, account, content.storageId, getAutoPinAction(account, content));
 			});
 		}
 
@@ -249,8 +277,10 @@ export function getModule(app: IGeesomeApp, models) {
 					if (pinnedStorageObjectKeys.has(getPinStorageObjectKey(account.id, target.storageId))) {
 						return;
 					}
-					actions.push(await autoActions.addAutoAction(
-						account.userId,
+					actions.push(await queueAutoPinAction(
+						autoActions,
+						account,
+						target.storageId,
 						getGroupAutoPinAction(account, post, target)
 					));
 				});
@@ -349,7 +379,7 @@ export function getModule(app: IGeesomeApp, models) {
 		}
 
 		async isAutoActionAllowed(userId, funcName, funcArgs) {
-			return ['pinByUserAccount', 'pinByGroupAccount'].includes(funcName);
+			return ['pinByUserAccount', 'pinByGroupAccount', 'pinByAccountId'].includes(funcName);
 		}
 	}
 
@@ -450,9 +480,9 @@ function getAutoPinAction(account: IPinAccount, content) {
 	const attempts = getAutoPinAttempts(autoPinOptions.attempts);
 	return {
 		moduleName: 'pin',
-		funcName: 'pinByUserAccount',
+		funcName: 'pinByAccountId',
 		funcArgs: JSON.stringify([
-			account.name,
+			account.id,
 			content.storageId,
 			{...getAutoPinMetadata(autoPinOptions.metadata), source: 'auto-pin'}
 		]),
@@ -469,10 +499,9 @@ function getGroupAutoPinAction(account: IPinAccount, post, target) {
 	const attempts = getAutoPinAttempts(autoPinOptions.attempts);
 	return {
 		moduleName: 'pin',
-		funcName: 'pinByGroupAccount',
+		funcName: 'pinByAccountId',
 		funcArgs: JSON.stringify([
-			post.groupId,
-			account.name,
+			account.id,
 			target.storageId,
 			{
 				...getAutoPinMetadata(autoPinOptions.metadata),
@@ -487,6 +516,14 @@ function getGroupAutoPinAction(account: IPinAccount, post, target) {
 		currentExecuteAttempts: attempts,
 		executeOn: new Date()
 	};
+}
+
+function queueAutoPinAction(autoActions, account: IPinAccount, storageId: string, action) {
+	const identityKey = `pin:pin:${account.id}:${storageId}`;
+	if (typeof autoActions.addUniqueAutoAction === 'function') {
+		return autoActions.addUniqueAutoAction(account.userId, identityKey, action);
+	}
+	return autoActions.addAutoAction(account.userId, action);
 }
 
 function getAutoPinAccountPolicy(account: IPinAccount): IPinAccount {

--- a/app/modules/pin/interface.ts
+++ b/app/modules/pin/interface.ts
@@ -19,6 +19,12 @@ export default interface IGeesomePinModule {
 
 	pinByGroupAccount(userId: number, groupId: number, name: string, storageId: string, options?): Promise<any>;
 
+	pinByAccountId(userId: number, accountId: number, storageId: string, options?): Promise<any>;
+
+	afterContentAdding(userId: number, content): Promise<any[]>;
+
+	afterPostManifestUpdate(userId: number, postId: number): Promise<any[]>;
+
 	recordPinnedStorageObject?(storageId: string, account: IPinAccount, content?: any, result?: any): Promise<IPinStorageObject | null>;
 }
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -270,13 +270,13 @@ Verification:
 <!-- todo-section: pinning-operability-and-reconciliation -->
 #### Pinning: Operability And Reconciliation
 
-Status: post-MVP backlog. Manual pinning, user automatic pinning, explicit group-post target policy, account UI, and group settings UI are shipped. The items below improve correctness under retries, multiple node processes, remote provider drift, and larger account/post volume; they are not blockers for the completed single-node MVP.
+Status: post-MVP backlog in progress. Manual pinning, user automatic pinning, explicit group-post target policy, account UI, group settings UI, and persistent pending-job deduplication are shipped. The remaining items improve correctness across multiple node processes, remote provider drift, and larger account/post volume; they are not blockers for the completed single-node MVP.
 
 Goal: make automatic pinning observably idempotent and make the per-account pin ledger the trustworthy source for remote pin state without silently changing or deleting remote pins.
 
 Scope:
 
-- Deduplicate pending automatic jobs by stable identity such as `(pinAccountId, storageId, operation)` before execution. The current ledger skips completed pins, but repeated manifest hooks can still enqueue duplicates while the first job is pending.
+- Completed 2026-07-16: deduplicate pending automatic jobs by stable `(userId, pinAccountId, storageId, operation)` identity before execution. A database-backed unique key serializes concurrent producers across processes, active jobs are reused, and inactive jobs can be replaced. New automatic jobs address accounts by immutable ID, execution rechecks user/group permission, and both user and group hooks skip already-pinned per-account ledger entries. Concurrent hook coverage and the full Docker suite pass (`466 passing`, `11 pending`).
 - Replace indefinitely stale process-local account-policy caches with a bounded TTL/version strategy or a cheap database-backed lookup. Account changes in one process must become visible to workers in another process without restart.
 - Decide and document group-account ownership: distinguish credential creator/owner from group scope, then keep user account lists from ambiguously mixing direct user accounts with group-scoped credentials. Preserve execution-time group permission checks.
 - Replace the silent first-100 group account scan with an explicit product limit, validation rule, or complete bounded traversal. A configured account must not be ignored merely because its sort position falls outside an implementation cap.
@@ -286,7 +286,7 @@ Scope:
 
 Verification:
 
-- Concurrency tests call the same post-manifest hook repeatedly before the worker runs and assert one pending job per account/storage operation.
+- Concurrency tests call the same content and post-manifest hooks repeatedly before the worker runs and assert one pending job per account/storage operation. Keep this coverage when adding new automatic pin producers.
 - Multi-instance or cache-version tests prove create/update/delete policy changes become visible without process restart.
 - Provider tests use an injected fake Pinata client for pinned, missing, failed, rate-limited, and recovered states; CI must not depend on live Pinata.
 - Ownership tests cover creator removal, group admin changes, same `storageId` across users, and exact post-attachment authorization.

--- a/test/autoActions.test.ts
+++ b/test/autoActions.test.ts
@@ -237,6 +237,44 @@ describe("autoActions", function () {
 		assert.deepEqual(secondPage.list.map(action => action.moduleName), ['action-3']);
 	});
 
+	it('deduplicates concurrent active actions by stable identity', async () => {
+		const testUser = (await app.ms.database.getAllUserList('user'))[0];
+		const createAction = () => ({
+			moduleName: 'pin',
+			funcName: 'pinByAccountId',
+			funcArgs: '[1,"storage-id",{}]',
+			isActive: true,
+			executePeriod: 0,
+			totalExecuteAttempts: 1,
+			currentExecuteAttempts: 1,
+			executeOn: new Date()
+		});
+
+		const actions = await Promise.all(Array.from({length: 10}, () => {
+			return autoActions.addUniqueAutoAction(
+				testUser.id,
+				'pin:pin:1:storage-id',
+				createAction()
+			);
+		}));
+
+		assert.equal(new Set(actions.map(action => action.id)).size, 1);
+		const activeActions = await autoActions.getUserActions(testUser.id, {
+			moduleName: 'pin',
+			funcName: 'pinByAccountId',
+			isActive: 'true'
+		});
+		assert.equal(activeActions.total, 1);
+
+		await autoActions.updateAutoAction(testUser.id, actions[0].id, {isActive: false});
+		const replacement = await autoActions.addUniqueAutoAction(
+			testUser.id,
+			'pin:pin:1:storage-id',
+			createAction()
+		);
+		assert.notEqual(replacement.id, actions[0].id);
+	});
+
 	it('claims due auto actions before cron execution', async () => {
 		const testUser = (await app.ms.database.getAllUserList('user'))[0];
 		const dueAction = await autoActions.addAutoAction(testUser.id, {

--- a/test/pin.test.ts
+++ b/test/pin.test.ts
@@ -224,9 +224,12 @@ describe("pin", function () {
 			});
 
 			const content = await app.ms.content.saveData(testUser.id, 'automatic pin', 'automatic-pin.txt');
+			await Promise.all(Array.from({length: 8}, () => {
+				return pins.afterContentAdding(testUser.id, content);
+			}));
 			const queued = await autoActions.getUserActions(testUser.id, {
 				moduleName: 'pin',
-				funcName: 'pinByUserAccount'
+				funcName: 'pinByAccountId'
 			});
 			assert.equal(queued.total, 1);
 			assert.equal(queued.list[0].isActive, true);
@@ -235,7 +238,7 @@ describe("pin", function () {
 
 			const completed = await autoActions.getUserActions(testUser.id, {
 				moduleName: 'pin',
-				funcName: 'pinByUserAccount'
+				funcName: 'pinByAccountId'
 			});
 			const pinnedContent = await app.ms.content.getContentByStorageAndUserId(content.storageId, testUser.id);
 			assert.equal(completed.list[0].isActive, false);
@@ -283,19 +286,22 @@ describe("pin", function () {
 			contents: [{id: content.id, view: ContentView.Attachment}]
 		});
 		const autoActions = app.ms['autoActions'] as IGeesomeAutoActionsModule;
+		await Promise.all(Array.from({length: 8}, () => {
+			return pins.afterPostManifestUpdate(postAuthor.id, post.id);
+		}));
 		await waitForCondition(async () => {
 			const actions = await autoActions.getUserActions(testUser.id, {
 				moduleName: 'pin',
-				funcName: 'pinByGroupAccount'
+				funcName: 'pinByAccountId'
 			});
 			return actions.total === 2;
 		});
 
 		const queued = await autoActions.getUserActions(testUser.id, {
 			moduleName: 'pin',
-			funcName: 'pinByGroupAccount'
+			funcName: 'pinByAccountId'
 		});
-		const storageIds = queued.list.map(action => JSON.parse(action.funcArgs)[2]).sort();
+		const storageIds = queued.list.map(action => JSON.parse(action.funcArgs)[1]).sort();
 		const storedPost = await app.ms.group.getPostPure(post.id);
 		assert.deepEqual(storageIds, [content.storageId, storedPost.manifestStorageId].sort());
 
@@ -305,7 +311,7 @@ describe("pin", function () {
 			await new CronService(app, autoActions).getActionsAndAddToQueueAndRun();
 			const completed = await autoActions.getUserActions(testUser.id, {
 				moduleName: 'pin',
-				funcName: 'pinByGroupAccount'
+				funcName: 'pinByAccountId'
 			});
 			const pinnedContent = await app.ms.content.getContentByStorageAndUserId(content.storageId, postAuthor.id);
 			assert(completed.list.every(action => action.isActive === false));

--- a/test/pinUnit.test.ts
+++ b/test/pinUnit.test.ts
@@ -293,6 +293,7 @@ describe("pin negative paths", function () {
 		const autoActions = [];
 		const pins: any = createPinModule([
 			{
+				id: 1,
 				userId: 1,
 				name: "automatic",
 				service: "pinata",
@@ -314,9 +315,9 @@ describe("pin negative paths", function () {
 
 		assert.equal(autoActions.length, 1);
 		assert.equal(autoActions[0].moduleName, "pin");
-		assert.equal(autoActions[0].funcName, "pinByUserAccount");
+		assert.equal(autoActions[0].funcName, "pinByAccountId");
 		assert.deepEqual(JSON.parse(autoActions[0].funcArgs), [
-			"automatic",
+			1,
 			"storage-id",
 			{source: "auto-pin", collection: "uploads"}
 		]);
@@ -397,8 +398,8 @@ describe("pin negative paths", function () {
 
 		assert.equal(autoActions.length, 2);
 		assert(autoActions.every(action => action.userId === 1));
-		assert(autoActions.every(action => action.funcName === "pinByGroupAccount"));
-		assert.deepEqual(autoActions.map(action => JSON.parse(action.funcArgs)[2]), [
+		assert(autoActions.every(action => action.funcName === "pinByAccountId"));
+		assert.deepEqual(autoActions.map(action => JSON.parse(action.funcArgs)[1]), [
 			"post-manifest",
 			"other-user-content"
 		]);


### PR DESCRIPTION
## Summary

- persist stable dedupe identities for active automatic actions so concurrent producers reuse one pending job
- queue automatic pins by immutable account ID and recheck user or group authorization at execution time
- skip user and group targets already present in the per-account pin ledger
- record the completed operability slice and remaining pinning backlog in the deterministic TODO section

## Why

Repeated content and post-manifest hooks could enqueue duplicate automatic pin jobs before the first job completed. Process-local checks could not prevent duplicates across concurrent requests or node processes, and queued actions addressed accounts by mutable names.

The new dedupe table is intentionally created through model sync while this work remains unreleased on `dev`, following the repository migration policy.

## Verification

- `npm run test:docker` (`466 passing`, `11 pending`)
- focused pin unit suite (`17 passing`)
- `npm run todo:context -- pinning-operability-and-reconciliation`
- `git diff --check`

Related to #750.
