### PR TITLE
Bound automatic pin policy cache staleness

### DIFF
--- a/app/modules/pin/index.ts
+++ b/app/modules/pin/index.ts
@@ -12,6 +12,18 @@ const pinAccountListParams: IListParamsOptions = {
 	allowedSortBy: ['name', 'service', 'createdAt', 'updatedAt', 'id'],
 	maxLimit: 100
 };
+const defaultAutoPinPolicyCacheTtlMs = 30000;
+const maxAutoPinPolicyCacheTtlMs = 5 * 60 * 1000;
+
+type IAutoPinPolicyCacheEntry = {
+	accounts: IPinAccount[];
+	expiresAt: number;
+};
+
+type IPinModuleOptions = {
+	autoPinPolicyCacheTtlMs?: number;
+	now?: () => number;
+};
 
 function getPinAccountListOrder(sortBy, sortDir) {
 	const direction = sortDir.toUpperCase();
@@ -30,9 +42,13 @@ export default async (app: IGeesomeApp) => {
 	return module;
 }
 
-export function getModule(app: IGeesomeApp, models) {
-	const autoPinAccountsByUser = new Map<number, IPinAccount[]>();
-	const autoPinAccountsByGroup = new Map<number, IPinAccount[]>();
+export function getModule(app: IGeesomeApp, models, options: IPinModuleOptions = {}) {
+	const autoPinAccountsByUser = new Map<number, IAutoPinPolicyCacheEntry>();
+	const autoPinAccountsByGroup = new Map<number, IAutoPinPolicyCacheEntry>();
+	const autoPinPolicyCacheTtlMs = getAutoPinPolicyCacheTtlMs(
+		options.autoPinPolicyCacheTtlMs ?? process.env.PIN_AUTO_POLICY_CACHE_TTL_MS
+	);
+	const now = options.now || Date.now;
 
 	class PinModule implements IGeesomePinModule {
 		async createAccount(userId: number, account: IPinAccount): Promise<IPinAccount> {
@@ -325,20 +341,22 @@ export function getModule(app: IGeesomeApp, models) {
 		}
 
 		async getUserAutoPinAccounts(userId) {
-			if (autoPinAccountsByUser.has(userId)) {
-				return autoPinAccountsByUser.get(userId);
+			const cachedAccounts = getCachedAutoPinAccounts(autoPinAccountsByUser, userId, now());
+			if (cachedAccounts) {
+				return cachedAccounts;
 			}
 			const accounts = await this.getUserAccountsList(userId, {limit: 100});
 			const autoPinAccounts = accounts
 				.filter(isUserAutoPinAccount)
 				.map(getAutoPinAccountPolicy);
-			autoPinAccountsByUser.set(userId, autoPinAccounts);
+			cacheAutoPinAccounts(autoPinAccountsByUser, userId, autoPinAccounts, now(), autoPinPolicyCacheTtlMs);
 			return autoPinAccounts;
 		}
 
 		async getGroupAutoPinAccounts(groupId) {
-			if (autoPinAccountsByGroup.has(groupId)) {
-				return autoPinAccountsByGroup.get(groupId);
+			const cachedAccounts = getCachedAutoPinAccounts(autoPinAccountsByGroup, groupId, now());
+			if (cachedAccounts) {
+				return cachedAccounts;
 			}
 			const accounts = await models.PinAccount.findAll({
 				where: {groupId},
@@ -348,7 +366,7 @@ export function getModule(app: IGeesomeApp, models) {
 			const autoPinAccounts = accounts
 				.filter(isGroupAutoPinAccount)
 				.map(getAutoPinAccountPolicy);
-			autoPinAccountsByGroup.set(groupId, autoPinAccounts);
+			cacheAutoPinAccounts(autoPinAccountsByGroup, groupId, autoPinAccounts, now(), autoPinPolicyCacheTtlMs);
 			return autoPinAccounts;
 		}
 
@@ -594,6 +612,33 @@ function invalidateAutoPinAccountCaches(userCache, groupCache, account: IPinAcco
 	if (account?.groupId) {
 		groupCache.delete(account.groupId);
 	}
+}
+
+function getAutoPinPolicyCacheTtlMs(value): number {
+	const ttlMs = Number.parseInt(value, 10);
+	if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+		return defaultAutoPinPolicyCacheTtlMs;
+	}
+	return Math.min(ttlMs, maxAutoPinPolicyCacheTtlMs);
+}
+
+function getCachedAutoPinAccounts(cache, key: number, now: number): IPinAccount[] | null {
+	const entry = cache.get(key);
+	if (!entry) {
+		return null;
+	}
+	if (entry.expiresAt <= now) {
+		cache.delete(key);
+		return null;
+	}
+	return entry.accounts;
+}
+
+function cacheAutoPinAccounts(cache, key: number, accounts: IPinAccount[], now: number, ttlMs: number) {
+	cache.set(key, {
+		accounts,
+		expiresAt: now + ttlMs
+	});
 }
 
 function getPlainAccount(account) {

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -270,14 +270,14 @@ Verification:
 <!-- todo-section: pinning-operability-and-reconciliation -->
 #### Pinning: Operability And Reconciliation
 
-Status: post-MVP backlog in progress. Manual pinning, user automatic pinning, explicit group-post target policy, account UI, group settings UI, and persistent pending-job deduplication are shipped. The remaining items improve correctness across multiple node processes, remote provider drift, and larger account/post volume; they are not blockers for the completed single-node MVP.
+Status: post-MVP backlog in progress. Manual pinning, user automatic pinning, explicit group-post target policy, account UI, group settings UI, persistent pending-job deduplication, and bounded cross-process policy-cache freshness are shipped. The remaining items improve ownership clarity, remote provider drift handling, and larger account/post volume; they are not blockers for the completed single-node MVP.
 
 Goal: make automatic pinning observably idempotent and make the per-account pin ledger the trustworthy source for remote pin state without silently changing or deleting remote pins.
 
 Scope:
 
 - Completed 2026-07-16: deduplicate pending automatic jobs by stable `(userId, pinAccountId, storageId, operation)` identity before execution. A database-backed unique key serializes concurrent producers across processes, active jobs are reused, and inactive jobs can be replaced. New automatic jobs address accounts by immutable ID, execution rechecks user/group permission, and both user and group hooks skip already-pinned per-account ledger entries. Concurrent hook coverage and the full Docker suite pass (`466 passing`, `11 pending`).
-- Replace indefinitely stale process-local account-policy caches with a bounded TTL/version strategy or a cheap database-backed lookup. Account changes in one process must become visible to workers in another process without restart.
+- Completed 2026-07-16: replace indefinitely stale process-local account-policy caches with expiring snapshots. Same-process create/update/delete writes still invalidate immediately; changes made through another process become visible after 30 seconds by default without a restart. `PIN_AUTO_POLICY_CACHE_TTL_MS` can shorten the window or use `0` to disable reuse, and values are capped at five minutes. A deterministic two-module test covers remote update/delete/create visibility before and after expiry; the full Docker suite passes (`467 passing`, `11 pending`).
 - Decide and document group-account ownership: distinguish credential creator/owner from group scope, then keep user account lists from ambiguously mixing direct user accounts with group-scoped credentials. Preserve execution-time group permission checks.
 - Replace the silent first-100 group account scan with an explicit product limit, validation rule, or complete bounded traversal. A configured account must not be ignored merely because its sort position falls outside an implementation cap.
 - Treat `PinStorageObject` per-account rows as canonical remote-pin claims. Keep `Content.isPinned` or `StorageObject.isPinned` only as a derived aggregate, because one storage ID can be pinned by multiple accounts/providers and remote state can drift.
@@ -287,7 +287,7 @@ Scope:
 Verification:
 
 - Concurrency tests call the same content and post-manifest hooks repeatedly before the worker runs and assert one pending job per account/storage operation. Keep this coverage when adding new automatic pin producers.
-- Multi-instance or cache-version tests prove create/update/delete policy changes become visible without process restart.
+- Keep the deterministic multi-module cache test proving create/update/delete policy changes become visible without process restart.
 - Provider tests use an injected fake Pinata client for pinned, missing, failed, rate-limited, and recovered states; CI must not depend on live Pinata.
 - Ownership tests cover creator removal, group admin changes, same `storageId` across users, and exact post-attachment authorization.
 - If schema changes become release-bound, add the production migration and migration-integrity checks at release preparation; while changes remain unreleased on `dev`, keep model-sync-only tables aligned with the repo migration rules.

--- a/test/pinUnit.test.ts
+++ b/test/pinUnit.test.ts
@@ -11,7 +11,8 @@ function createPinModule(
 	markedStorageObjects: any[] = [],
 	pinnedStorageObjects: any[] = [],
 	autoActions: any[] = [],
-	postsById: Record<number, any> = {}
+	postsById: Record<number, any> = {},
+	moduleOptions: any = {}
 ) {
 	return getPinModule({
 		encryptTextWithAppPass: async (text) => `encrypted:${text}`,
@@ -128,7 +129,7 @@ function createPinModule(
 				return [created, true];
 			}
 		}
-	});
+	}, moduleOptions);
 }
 
 describe("pin negative paths", function () {
@@ -478,6 +479,57 @@ describe("pin negative paths", function () {
 
 		assert.equal(autoActions.length, 1);
 		assert.equal(JSON.parse(autoActions[0].funcArgs)[1], "second-storage");
+	});
+
+	it("refreshes auto pin policy changes made by another module after the bounded ttl", async () => {
+		const accounts: any[] = [{
+			id: 1,
+			userId: 1,
+			name: "automatic",
+			service: "pinata",
+			options: JSON.stringify({autoPin: {enabled: false}})
+		}];
+		const autoActions = [];
+		let now = 0;
+		const moduleOptions = {
+			autoPinPolicyCacheTtlMs: 100,
+			now: () => now
+		};
+		const firstPins: any = createPinModule(
+			accounts, {}, [1], [], [], autoActions, {}, moduleOptions
+		);
+		const secondPins: any = createPinModule(
+			accounts, {}, [1], [], [], [], {}, moduleOptions
+		);
+
+		await firstPins.afterContentAdding(1, {storageId: "initial-disabled"});
+		await secondPins.updateAccount(1, 1, {options: {autoPin: {enabled: true}}});
+		await firstPins.afterContentAdding(1, {storageId: "update-before-expiry"});
+		assert.equal(autoActions.length, 0);
+
+		now = 100;
+		await firstPins.afterContentAdding(1, {storageId: "update-after-expiry"});
+		assert.equal(autoActions.length, 1);
+
+		await secondPins.deleteAccount(1, 1);
+		await firstPins.afterContentAdding(1, {storageId: "delete-before-expiry"});
+		assert.equal(autoActions.length, 2);
+
+		now = 200;
+		await firstPins.afterContentAdding(1, {storageId: "delete-after-expiry"});
+		assert.equal(autoActions.length, 2);
+
+		await secondPins.createAccount(1, {
+			name: "replacement",
+			service: "pinata",
+			options: {autoPin: {enabled: true}}
+		});
+		await firstPins.afterContentAdding(1, {storageId: "create-before-expiry"});
+		assert.equal(autoActions.length, 2);
+
+		now = 300;
+		await firstPins.afterContentAdding(1, {storageId: "create-after-expiry"});
+		assert.equal(autoActions.length, 3);
 	});
 
 	it("marks content and storage object pinned after a successful remote pin", async () => {


### PR DESCRIPTION
## Summary

- expire user and group automatic-pin policy snapshots after a bounded TTL
- keep same-process create, update, and delete invalidation immediate
- make cross-process policy changes visible within 30 seconds by default
- allow operators to shorten the TTL or disable cache reuse, while capping it at five minutes
- add deterministic two-module coverage for update, delete, and create visibility

## Why

Automatic pin account policy was cached indefinitely in each node process. An account changed through another process could therefore remain enabled or disabled until the stale process restarted.

This keeps the read optimization without adding a refresh worker or turning cached snapshots into authorization data. Pin execution still reloads the account and rechecks user or group permission from the database.

## Configuration

`PIN_AUTO_POLICY_CACHE_TTL_MS` defaults to `30000`. Set it to `0` to disable cache reuse. Values above `300000` are clamped.

## Verification

- focused pin unit suite (`18 passing`)
- `npm run test:docker` (`467 passing`, `11 pending`)
- `npm run todo:context -- pinning-operability-and-reconciliation`
- `git diff --check`

Related to #750.
