### PR TITLE
Allow bounded SVG text presentation attributes

### DIFF
--- a/app/modules/imageComposition/docs/overview.md
+++ b/app/modules/imageComposition/docs/overview.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 `imageComposition` owns versioned baked image Contents whose base raster remains
-immutable and whose overlays are stored as safe, backend-generated SVG Contents.
+immutable and whose overlays are stored as safe, validated SVG Contents.
 It has no Post, Group, publication, or client-specific source dependency.
 
 ## Public API
@@ -31,10 +31,14 @@ catalog item mandatory.
 
 - The baked PNG is the default renderable Content and carries the versioned
   semantic recipe in `properties.imageComposition`.
-- The base raster and generated SVG stickers are referenced through durable
+- The base raster and validated SVG stickers are referenced through durable
   `ContentDependency` edges.
-- Sticker text is validated semantic input; clients never submit SVG markup.
-- Generated SVGs are escaped, deterministic, self-contained, and stored as raw
+- Client-defined SVGs are restricted to a small element and attribute allowlist.
+  Passive text presentation values are validated per element and grammar.
+- SVGs remain deterministic and self-contained: scripts, event handlers, style
+  blocks, CSS functions, external resources, links, filters, masks, and
+  clip-paths are rejected.
+- Accepted SVGs are stored as raw
   immutable Contents with restrictive serving headers.
 - Previews are baked from the final PNG, so ordinary clients show stickers
   without composition-specific preview logic.

--- a/app/modules/imageComposition/svg.ts
+++ b/app/modules/imageComposition/svg.ts
@@ -17,6 +17,30 @@ const ALLOWED_SVG_ATTRIBUTES = new Set([
 ]);
 const FORBIDDEN_SVG_SOURCE = /(?:<!DOCTYPE|<!ENTITY|<\?xml|url\s*\()/i;
 const SVG_ROOT_SOURCE = /^<svg(?:\s|>)[\s\S]*(?:<\/svg>|\/>)$/i;
+const FORBIDDEN_SVG_ATTRIBUTE_VALUE =
+	/(?:url\s*\(|javascript:|data:|https?:|ipfs:|ipns:)/i;
+const SVG_TEXT_TAGS = new Set(['text', 'tspan']);
+const FONT_WIDTH_KEYWORDS = new Set([
+	'normal', 'ultra-condensed', 'extra-condensed', 'condensed',
+	'semi-condensed', 'semi-expanded', 'expanded', 'extra-expanded',
+	'ultra-expanded',
+]);
+const FONT_VARIANT_KEYWORDS = new Set([
+	'normal', 'small-caps', 'all-small-caps', 'petite-caps',
+	'all-petite-caps', 'unicase', 'titling-caps',
+]);
+const TEXT_DECORATION_KEYWORDS = new Set([
+	'none', 'underline', 'overline', 'line-through',
+]);
+const SAFE_SPACING_VALUE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:px|em|rem|%)?$/;
+const TEXT_PRESENTATION_ATTRIBUTE_VALIDATORS = new Map([
+	['font-stretch', isSafeFontWidth],
+	['font-width', isSafeFontWidth],
+	['letter-spacing', isSafeSpacing],
+	['word-spacing', isSafeSpacing],
+	['font-variant', isSafeFontVariant],
+	['text-decoration', isSafeTextDecoration],
+]);
 
 export interface ValidatedImageCompositionStickerSvg {
 	mimeType: 'image/svg+xml';
@@ -53,10 +77,11 @@ export function validateAndNormalizeImageCompositionStickerSvg(value: unknown): 
 			return;
 		}
 		for (const [attributeName, attributeValue] of Object.entries(element.attribs || {})) {
-			if (!ALLOWED_SVG_ATTRIBUTES.has(attributeName)
-				|| /^on/i.test(attributeName)
-				|| (attributeName !== 'xmlns'
-					&& /(?:url\s*\(|javascript:|data:|https?:|ipfs:|ipns:)/i.test(String(attributeValue)))) {
+			if (!isAllowedSvgAttribute(
+				element.tagName,
+				attributeName,
+				attributeValue,
+			)) {
 				valid = false;
 				return;
 			}
@@ -77,6 +102,72 @@ export function validateAndNormalizeImageCompositionStickerSvg(value: unknown): 
 
 export function getImageCompositionStickerSvgHash(svg: string) {
 	return `sha256:${createHash('sha256').update(svg, 'utf8').digest('hex')}`;
+}
+
+function isAllowedSvgAttribute(
+	tagName: string,
+	attributeName: string,
+	attributeValue: unknown,
+) {
+	if (/^on/i.test(attributeName)) {
+		return false;
+	}
+	if (attributeName !== 'xmlns'
+		&& FORBIDDEN_SVG_ATTRIBUTE_VALUE.test(String(attributeValue))) {
+		return false;
+	}
+	if (ALLOWED_SVG_ATTRIBUTES.has(attributeName)) {
+		return true;
+	}
+	const textAttributeValidator =
+		TEXT_PRESENTATION_ATTRIBUTE_VALIDATORS.get(attributeName);
+	return SVG_TEXT_TAGS.has(tagName)
+		&& Boolean(textAttributeValidator?.(attributeValue));
+}
+
+function isSafeFontWidth(value: unknown) {
+	if (typeof value !== 'string') {
+		return false;
+	}
+	if (FONT_WIDTH_KEYWORDS.has(value)) {
+		return true;
+	}
+	const percentage = /^(\d+(?:\.\d+)?)%$/.exec(value);
+	if (!percentage) {
+		return false;
+	}
+	const number = Number(percentage[1]);
+	return number >= 50 && number <= 200;
+}
+
+function isSafeSpacing(value: unknown) {
+	if (value === 'normal') {
+		return true;
+	}
+	if (typeof value !== 'string' || !SAFE_SPACING_VALUE.test(value)) {
+		return false;
+	}
+	const number = Number.parseFloat(value);
+	return Number.isFinite(number) && Math.abs(number) <= 10_000;
+}
+
+function isSafeFontVariant(value: unknown) {
+	return typeof value === 'string' && FONT_VARIANT_KEYWORDS.has(value);
+}
+
+function isSafeTextDecoration(value: unknown) {
+	if (typeof value !== 'string') {
+		return false;
+	}
+	const keywords = value.trim().split(/\s+/);
+	if (!keywords.length || keywords.length > 3) {
+		return false;
+	}
+	if (keywords.includes('none')) {
+		return keywords.length === 1;
+	}
+	return new Set(keywords).size === keywords.length
+		&& keywords.every(keyword => TEXT_DECORATION_KEYWORDS.has(keyword));
 }
 
 function isSafeViewBox(value: unknown) {

--- a/test/imageCompositionSvg.test.ts
+++ b/test/imageCompositionSvg.test.ts
@@ -31,6 +31,56 @@ describe('image composition SVG validation', () => {
 		assert.equal(validateAndNormalizeImageCompositionStickerSvg(svg).svg, svg);
 	});
 
+	it('accepts bounded passive text presentation attributes on text elements', () => {
+		const svg = [
+			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">',
+			'<text x="10" y="30" font-stretch="condensed" font-width="75%"',
+			' letter-spacing="-0.5" word-spacing="1.25px"',
+			' font-variant="small-caps" text-decoration="underline line-through">',
+			'<tspan font-stretch="125%" letter-spacing="normal">Text</tspan>',
+			'</text></svg>',
+		].join('');
+		assert.equal(validateAndNormalizeImageCompositionStickerSvg(svg).svg, svg);
+	});
+
+	it('rejects text presentation attributes on non-text elements', () => {
+		for (const attribute of [
+			'font-stretch="condensed"',
+			'font-width="75%"',
+			'letter-spacing="1"',
+			'word-spacing="1px"',
+			'font-variant="small-caps"',
+			'text-decoration="underline"',
+		]) {
+			const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M0 0" ${attribute}/></svg>`;
+			assert.throws(
+				() => validateAndNormalizeImageCompositionStickerSvg(svg),
+				/composition_invalid/,
+			);
+		}
+	});
+
+	it('rejects unbounded or functional text presentation values', () => {
+		for (const attribute of [
+			'font-stretch="49%"',
+			'font-stretch="201%"',
+			'font-stretch="calc(100%)"',
+			'font-width="wider"',
+			'letter-spacing="10001px"',
+			'letter-spacing="var(--spacing)"',
+			'word-spacing="1vh"',
+			'font-variant="small-caps contextual"',
+			'text-decoration="none underline"',
+			'text-decoration="underline underline"',
+		]) {
+			const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><text ${attribute}>Text</text></svg>`;
+			assert.throws(
+				() => validateAndNormalizeImageCompositionStickerSvg(svg),
+				/composition_invalid/,
+			);
+		}
+	});
+
 	it('rejects active content, external resources, CSS URLs, and XML entities', () => {
 		const attacks = [
 			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><script>alert(1)</script></svg>',


### PR DESCRIPTION
## Summary

- allow passive SVG text presentation attributes only on `text` and `tspan`
- validate font width/stretch, spacing, font variant, and text decoration with bounded grammars
- document the client-defined SVG trust boundary and keep active/resource-bearing SVG features rejected

## Verification

- `node --import tsx --experimental-global-customevent ./node_modules/.bin/mocha --require ./test/setupQuietLogs.cjs test/imageCompositionSvg.test.ts --exit -t 10000` — 7 passing
- `npm run test:docker` — blocked by the existing `dev` schema mismatch: `imageCompositionOperations.resultFileCatalogItemId` is indexed but absent, causing cascading setup failures
- `./node_modules/.bin/tsc --noEmit` — blocked by the repository local TypeScript/toolchain baseline (syntax errors in existing sources and dependency declarations)

Closes #1272