### PR TITLE
Recover missing encrypted chat events automatically

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -36,7 +36,16 @@ export default {
     autoProcessDeliveries: process.env.CHAT_AUTO_PROCESS_DELIVERIES !== '0',
     deliveryWorkerIntervalMs: process.env.CHAT_DELIVERY_WORKER_INTERVAL_MS,
     deliveryWorkerLimit: process.env.CHAT_DELIVERY_WORKER_LIMIT,
-    deliveryClaimTtlMs: process.env.CHAT_DELIVERY_CLAIM_TTL_MS
+    deliveryClaimTtlMs: process.env.CHAT_DELIVERY_CLAIM_TTL_MS,
+    reconciliationWorker: process.env.CHAT_RECONCILIATION_WORKER === '1',
+    reconciliationWorkerIntervalMs: process.env.CHAT_RECONCILIATION_WORKER_INTERVAL_MS,
+    reconciliationWorkerLimit: process.env.CHAT_RECONCILIATION_WORKER_LIMIT,
+    reconciliationPerRecipientLimit: process.env.CHAT_RECONCILIATION_PER_RECIPIENT_LIMIT,
+    reconciliationClaimTtlMs: process.env.CHAT_RECONCILIATION_CLAIM_TTL_MS,
+    reconciliationRefreshIntervalMs: process.env.CHAT_RECONCILIATION_REFRESH_INTERVAL_MS,
+    reconciliationContinuationDelayMs: process.env.CHAT_RECONCILIATION_CONTINUATION_DELAY_MS,
+    reconciliationPageLimit: process.env.CHAT_RECONCILIATION_PAGE_LIMIT,
+    reconciliationMaxPages: process.env.CHAT_RECONCILIATION_MAX_PAGES
   },
   activityPubConfig: {
     enabled: process.env.ACTIVITYPUB_ENABLED === '1',

--- a/app/modules/chat/cron.ts
+++ b/app/modules/chat/cron.ts
@@ -1,32 +1,57 @@
-import {startIntervalWorker} from '../../backgroundWorker.js';
+import {createIntervalWorkerGroup} from '../../backgroundWorker.js';
 import type {IBackgroundWorker} from '../../backgroundWorker.js';
 import type {IGeesomeApp} from '../../interface.js';
 import type IGeesomeChatModule from './interface.js';
 
 const defaultChatDeliveryWorkerIntervalMs = 30 * 1000;
+const defaultChatReconciliationWorkerIntervalMs = 60 * 1000;
 
 export default function startChatDeliveryWorker(
 	app: IGeesomeApp,
 	chat: IGeesomeChatModule
 ): IBackgroundWorker | null {
-	if (!isChatDeliveryWorkerEnabled(app)) {
+	const deliveryEnabled = isEnabled(
+		app.config.chatConfig?.deliveryWorker
+	);
+	const reconciliationEnabled = isEnabled(
+		app.config.chatConfig?.reconciliationWorker
+	);
+	if (!deliveryEnabled && !reconciliationEnabled) {
 		return null;
 	}
-	return startIntervalWorker(
-		() => chat.processDeliveryQueue(getChatDeliveryWorkerOptions(app)),
-		{
-			intervalMs: parsePositiveInteger(
-				app.config.chatConfig?.deliveryWorkerIntervalMs,
-				defaultChatDeliveryWorkerIntervalMs
+	const workerGroup = createIntervalWorkerGroup();
+	if (deliveryEnabled) {
+		workerGroup.add(
+			() => chat.processDeliveryQueue(getChatDeliveryWorkerOptions(app)),
+			{
+				intervalMs: parsePositiveInteger(
+					app.config.chatConfig?.deliveryWorkerIntervalMs,
+					defaultChatDeliveryWorkerIntervalMs
+				),
+				runImmediately: true,
+				onError: error => console.error('processChatDeliveryQueue error', error)
+			}
+		);
+	}
+	if (reconciliationEnabled) {
+		workerGroup.add(
+			() => chat.processReconciliationQueue(
+				getChatReconciliationWorkerOptions(app)
 			),
-			runImmediately: true,
-			onError: error => console.error('processChatDeliveryQueue error', error)
-		}
-	);
+			{
+				intervalMs: parsePositiveInteger(
+					app.config.chatConfig?.reconciliationWorkerIntervalMs,
+					defaultChatReconciliationWorkerIntervalMs
+				),
+				runImmediately: true,
+				onError: error => console.error('processChatReconciliationQueue error', error)
+			}
+		);
+	}
+	return workerGroup;
 }
 
-function isChatDeliveryWorkerEnabled(app: IGeesomeApp): boolean {
-	const value = app.config.chatConfig?.deliveryWorker;
+function isEnabled(value): boolean {
 	return value === true || value === '1' || value === 'true';
 }
 
@@ -34,6 +59,19 @@ function getChatDeliveryWorkerOptions(app: IGeesomeApp) {
 	return {
 		limit: app.config.chatConfig?.deliveryWorkerLimit,
 		claimTtlMs: app.config.chatConfig?.deliveryClaimTtlMs
+	};
+}
+
+function getChatReconciliationWorkerOptions(app: IGeesomeApp) {
+	const config = app.config.chatConfig || {};
+	return {
+		limit: config.reconciliationWorkerLimit,
+		perRecipientLimit: config.reconciliationPerRecipientLimit,
+		claimTtlMs: config.reconciliationClaimTtlMs,
+		refreshIntervalMs: config.reconciliationRefreshIntervalMs,
+		continuationDelayMs: config.reconciliationContinuationDelayMs,
+		pageLimit: config.reconciliationPageLimit,
+		maxPages: config.reconciliationMaxPages
 	};
 }
 

--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -37,7 +37,26 @@ restart, and advances the verified cursor only when the signed response says no
 pages remain. This avoids treating the greatest event seen during out-of-order
 live retries as proof that earlier events were received.
 
+Automatic repair is disabled by default. Set `CHAT_RECONCILIATION_WORKER=1` to
+enable the interval worker. A separate model-synced `ChatSyncJob` row carries
+the next-attempt time, failure count, and expiring claim without changing the
+already-deployed cursor table. Missing job rows are restored idempotently from
+`ChatSyncState` before each bounded sweep. Workers use
+`FOR UPDATE SKIP LOCKED`, exponential retry backoff, a global batch limit, and
+a per-recipient batch limit. Claim tokens fence stale workers that finish after
+their lease expires, so restart or concurrent node processes cannot lose or
+regress repair work. The following environment variables tune the bounded worker:
+
+- `CHAT_RECONCILIATION_WORKER_INTERVAL_MS`
+- `CHAT_RECONCILIATION_WORKER_LIMIT`
+- `CHAT_RECONCILIATION_PER_RECIPIENT_LIMIT`
+- `CHAT_RECONCILIATION_CLAIM_TTL_MS`
+- `CHAT_RECONCILIATION_REFRESH_INTERVAL_MS`
+- `CHAT_RECONCILIATION_CONTINUATION_DELAY_MS`
+- `CHAT_RECONCILIATION_PAGE_LIMIT`
+- `CHAT_RECONCILIATION_MAX_PAGES`
+
 The backend delivery and repair foundation is now present. Remaining chat work
-includes automatic bounded reconciliation scheduling, browser trust/recovery
-UX, group membership and key rotation, encrypted attachment lifecycle, and
-multi-node browser e2e coverage.
+includes browser trust/recovery UX, group membership and key rotation,
+encrypted attachment lifecycle, retention policy, and multi-node browser e2e
+coverage.

--- a/app/modules/chat/index.ts
+++ b/app/modules/chat/index.ts
@@ -15,12 +15,14 @@ import {
 	getChatSyncPageCursor,
 	parseSyncPageSize
 } from './reconciliation.js';
+import {processChatReconciliationQueue} from './reconciliationQueue.js';
 import IGeesomeChatModule, {
 	ChatDeliveryState,
 	ChatEventState,
 	ChatReceiptState,
 	IChatDeliveryProcessOptions,
 	IChatReconcileOptions,
+	IChatReconciliationProcessOptions,
 	IChatRecipientEndpoint
 } from './interface.js';
 import {
@@ -79,6 +81,7 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 		async flushDatabase() {
 			await models.ChatEventReceipt.destroy({where: {}});
 			await models.ChatDelivery.destroy({where: {}});
+			await models.ChatSyncJob.destroy({where: {}});
 			await models.ChatSyncState.destroy({where: {}});
 			await models.ChatEventRecipient.destroy({where: {}});
 			await models.ChatEvent.destroy({where: {}});
@@ -538,6 +541,26 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 			};
 		}
 
+		async processReconciliationQueue(
+			processOptions: IChatReconciliationProcessOptions = {}
+		) {
+			return processChatReconciliationQueue(models, {
+				...processOptions,
+				reconcile: (userId, state) => this.reconcileConversation(
+					userId,
+					state.conversationId,
+					{
+						sourceOwnerId: state.sourceOwnerId,
+						sourcePublicKey: state.sourcePublicKey,
+						syncUrl: state.syncUrl,
+						limit: processOptions.pageLimit,
+						maxPages: processOptions.maxPages,
+						requestChatSync: processOptions.requestChatSync
+					}
+				)
+			});
+		}
+
 		async processDeliveryQueue(processOptions: IChatDeliveryProcessOptions = {}) {
 			return processChatDeliveryQueue(models, {
 				...processOptions,
@@ -706,29 +729,59 @@ async function rememberChatSyncSource(models, delivery: IChatDeliveryPayload) {
 	if (!delivery.sender.syncUrl) {
 		return;
 	}
+	const now = new Date();
 	const where = {
 		conversationId: delivery.envelope.conversationId,
 		recipientOwnerId: delivery.recipientOwnerId,
 		sourceOwnerId: delivery.sender.ownerId
 	};
-	const [state] = await models.ChatSyncState.findOrCreate({
+	const [state, created] = await models.ChatSyncState.findOrCreate({
 		where,
 		defaults: {
 			...where,
 			sourcePublicKey: delivery.sender.publicKey,
 			syncUrl: delivery.sender.syncUrl,
 			verifiedSourceSequence: '0',
-			scanAfterSourceSequence: '0'
+			scanAfterSourceSequence: '0',
+			lastSourceHeadSequence: delivery.sourceSequence
 		}
 	});
+	const observedSourceHeadSequence = maximumSequence(
+		state.lastSourceHeadSequence || '0',
+		delivery.sourceSequence
+	);
+	const hasNewSourceHead = observedSourceHeadSequence !==
+		String(state.lastSourceHeadSequence || '0');
 	if (
 		state.sourcePublicKey !== delivery.sender.publicKey ||
-		state.syncUrl !== delivery.sender.syncUrl
+		state.syncUrl !== delivery.sender.syncUrl ||
+		hasNewSourceHead
 	) {
 		await state.update({
 			sourcePublicKey: delivery.sender.publicKey,
-			syncUrl: delivery.sender.syncUrl
+			syncUrl: delivery.sender.syncUrl,
+			lastSourceHeadSequence: observedSourceHeadSequence
 		});
+	}
+	await scheduleChatSyncJob(models, state, now, created || hasNewSourceHead);
+}
+
+async function scheduleChatSyncJob(
+	models,
+	state,
+	now: Date,
+	expedite: boolean
+) {
+	const [job, created] = await models.ChatSyncJob.findOrCreate({
+		where: {chatSyncStateId: state.id},
+		defaults: {
+			chatSyncStateId: state.id,
+			recipientOwnerId: state.recipientOwnerId,
+			nextAttemptAt: now
+		}
+	});
+	if (!created && expedite && job.nextAttemptAt > now) {
+		await job.update({nextAttemptAt: now});
 	}
 }
 

--- a/app/modules/chat/interface.ts
+++ b/app/modules/chat/interface.ts
@@ -38,6 +38,18 @@ export interface IChatReconcileOptions {
 	requestChatSync?: (syncUrl: string, request: any) => Promise<any>;
 }
 
+export interface IChatReconciliationProcessOptions {
+	limit?: number;
+	perRecipientLimit?: number;
+	claimTtlMs?: number;
+	refreshIntervalMs?: number;
+	continuationDelayMs?: number;
+	pageLimit?: number;
+	maxPages?: number;
+	now?: Date;
+	requestChatSync?: (syncUrl: string, request: any) => Promise<any>;
+}
+
 export interface IChatDeviceBundleRecord {
 	id?: number;
 	userId: number;
@@ -71,6 +83,9 @@ export default interface IGeesomeChatModule {
 		userId: number,
 		conversationId: string,
 		options: IChatReconcileOptions
+	): Promise<any>;
+	processReconciliationQueue(
+		options?: IChatReconciliationProcessOptions
 	): Promise<any>;
 	processDeliveryQueue(options?: IChatDeliveryProcessOptions): Promise<any>;
 	getEventDeliveries(userId: number, messageId: string): Promise<any[]>;

--- a/app/modules/chat/models.ts
+++ b/app/modules/chat/models.ts
@@ -292,12 +292,67 @@ export default async function initializeChatModels(sequelize: Sequelize) {
 		]
 	} as any);
 
+	const ChatSyncJob = sequelize.define('chatSyncJob', {
+		chatSyncStateId: {
+			type: DataTypes.INTEGER,
+			allowNull: false
+		},
+		recipientOwnerId: {
+			type: DataTypes.STRING(500),
+			allowNull: false
+		},
+		nextAttemptAt: {
+			type: DataTypes.DATE,
+			allowNull: false,
+			defaultValue: DataTypes.NOW
+		},
+		failureCount: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			defaultValue: 0
+		},
+		claimedAt: {
+			type: DataTypes.DATE,
+			allowNull: true
+		},
+		claimExpiresAt: {
+			type: DataTypes.DATE,
+			allowNull: true
+		},
+		claimToken: {
+			type: DataTypes.STRING(64),
+			allowNull: true
+		},
+		lastError: {
+			type: DataTypes.TEXT,
+			allowNull: true
+		}
+	} as any, {
+		indexes: [
+			{
+				name: 'chat_sync_jobs_state_unique',
+				fields: ['chatSyncStateId'],
+				unique: true
+			},
+			{
+				name: 'chat_sync_jobs_due_idx',
+				fields: ['nextAttemptAt', 'claimExpiresAt', 'id']
+			},
+			{
+				name: 'chat_sync_jobs_recipient_due_idx',
+				fields: ['recipientOwnerId', 'nextAttemptAt', 'id']
+			}
+		]
+	} as any);
+
 	ChatEvent.hasMany(ChatEventRecipient, {as: 'recipients', foreignKey: 'chatEventId'});
 	ChatEventRecipient.belongsTo(ChatEvent, {as: 'event', foreignKey: 'chatEventId'});
 	ChatEvent.hasMany(ChatEventReceipt, {as: 'receipts', foreignKey: 'chatEventId'});
 	ChatEventReceipt.belongsTo(ChatEvent, {as: 'event', foreignKey: 'chatEventId'});
 	ChatEvent.hasMany(ChatDelivery, {as: 'deliveries', foreignKey: 'chatEventId'});
 	ChatDelivery.belongsTo(ChatEvent, {as: 'event', foreignKey: 'chatEventId'});
+	ChatSyncState.hasOne(ChatSyncJob, {as: 'syncJob', foreignKey: 'chatSyncStateId'});
+	ChatSyncJob.belongsTo(ChatSyncState, {as: 'syncState', foreignKey: 'chatSyncStateId'});
 
 	await ChatDevice.sync({});
 	await ChatConversationHead.sync({});
@@ -306,10 +361,20 @@ export default async function initializeChatModels(sequelize: Sequelize) {
 	await ChatDelivery.sync({});
 	await ChatEventReceipt.sync({});
 	await ChatSyncState.sync({});
+	await ChatSyncJob.sync({});
 
 	(ChatDelivery as any).claimDue = (options) => claimDueChatDeliveries(
 		sequelize,
 		ChatDelivery,
+		options
+	);
+	(ChatSyncJob as any).claimDue = (options) => claimDueChatSyncJobs(
+		sequelize,
+		ChatSyncJob,
+		options
+	);
+	(ChatSyncJob as any).backfillMissing = (options) => backfillMissingChatSyncJobs(
+		sequelize,
 		options
 	);
 
@@ -320,8 +385,119 @@ export default async function initializeChatModels(sequelize: Sequelize) {
 		ChatEventRecipient,
 		ChatDelivery,
 		ChatEventReceipt,
-		ChatSyncState
+		ChatSyncState,
+		ChatSyncJob
 	};
+}
+
+async function claimDueChatSyncJobs(
+	sequelize: Sequelize,
+	ChatSyncJob,
+	{now, claimExpiresAt, claimToken, limit, perRecipientLimit}
+) {
+	const claimedRows = await sequelize.query<{id: number}>(`
+		WITH ranked_jobs AS (
+			SELECT
+				id,
+				ROW_NUMBER() OVER (
+					PARTITION BY "recipientOwnerId"
+					ORDER BY "nextAttemptAt" ASC, id ASC
+				) AS recipient_rank
+			FROM "chatSyncJobs"
+			WHERE "nextAttemptAt" <= :now
+				AND ("claimExpiresAt" IS NULL OR "claimExpiresAt" <= :now)
+		),
+		due_jobs AS (
+			SELECT sync_job.id
+			FROM "chatSyncJobs" AS sync_job
+			JOIN ranked_jobs ON ranked_jobs.id = sync_job.id
+			WHERE ranked_jobs.recipient_rank <= :perRecipientLimit
+			ORDER BY sync_job."nextAttemptAt" ASC, sync_job.id ASC
+			FOR UPDATE OF sync_job SKIP LOCKED
+			LIMIT :limit
+		)
+		UPDATE "chatSyncJobs" AS sync_job
+		SET
+			"claimedAt" = :now,
+			"claimExpiresAt" = :claimExpiresAt,
+			"claimToken" = :claimToken,
+			"updatedAt" = :now
+		FROM due_jobs
+		WHERE sync_job.id = due_jobs.id
+		RETURNING sync_job.id
+	`, {
+		replacements: {
+			now,
+			claimExpiresAt,
+			claimToken,
+			limit,
+			perRecipientLimit
+		},
+		type: QueryTypes.SELECT
+	});
+	const claimedIds = claimedRows.map(row => row.id);
+	if (!claimedIds.length) {
+		return [];
+	}
+	const jobs = await ChatSyncJob.findAll({
+		where: {id: {[Op.in]: claimedIds}},
+		include: [{association: 'syncState', required: true}]
+	});
+	const jobById = new Map(
+		jobs.map(job => [Number(job.id), job])
+	);
+	return claimedIds
+		.map(id => jobById.get(Number(id)))
+		.filter(Boolean);
+}
+
+async function backfillMissingChatSyncJobs(
+	sequelize: Sequelize,
+	{now, limit, perRecipientLimit}
+) {
+	await sequelize.query(`
+		WITH missing_states AS (
+			SELECT
+				sync_state.id,
+				sync_state."recipientOwnerId",
+				ROW_NUMBER() OVER (
+					PARTITION BY sync_state."recipientOwnerId"
+					ORDER BY sync_state.id ASC
+				) AS recipient_rank
+			FROM "chatSyncStates" AS sync_state
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM "chatSyncJobs" AS sync_job
+				WHERE sync_job."chatSyncStateId" = sync_state.id
+			)
+		),
+		bounded_states AS (
+			SELECT id, "recipientOwnerId"
+			FROM missing_states
+			WHERE recipient_rank <= :perRecipientLimit
+			ORDER BY id ASC
+			LIMIT :limit
+		)
+		INSERT INTO "chatSyncJobs" (
+			"chatSyncStateId",
+			"recipientOwnerId",
+			"nextAttemptAt",
+			"failureCount",
+			"createdAt",
+			"updatedAt"
+		)
+		SELECT
+			bounded_state.id,
+			bounded_state."recipientOwnerId",
+			:now,
+			0,
+			:now,
+			:now
+		FROM bounded_states AS bounded_state
+		ON CONFLICT ("chatSyncStateId") DO NOTHING
+	`, {
+		replacements: {now, limit, perRecipientLimit}
+	});
 }
 
 async function claimDueChatDeliveries(

--- a/app/modules/chat/reconciliationQueue.ts
+++ b/app/modules/chat/reconciliationQueue.ts
@@ -1,0 +1,140 @@
+import {randomUUID} from 'node:crypto';
+import type {IChatReconciliationProcessOptions} from './interface.js';
+
+const defaultReconciliationLimit = 10;
+const defaultPerRecipientLimit = 2;
+const defaultClaimTtlMs = 5 * 60 * 1000;
+const defaultRefreshIntervalMs = 5 * 60 * 1000;
+const defaultContinuationDelayMs = 5 * 1000;
+const minimumRetryDelayMs = 5 * 1000;
+const maximumRetryDelayMs = 60 * 60 * 1000;
+
+export interface IProcessChatReconciliationOptions
+	extends IChatReconciliationProcessOptions {
+	reconcile(
+		userId: number,
+		state: any
+	): Promise<{complete: boolean}>;
+}
+
+export async function processChatReconciliationQueue(
+	models,
+	options: IProcessChatReconciliationOptions
+) {
+	const now = options.now || new Date();
+	const limit = parsePositiveInteger(options.limit, defaultReconciliationLimit);
+	const perRecipientLimit = Math.min(
+		parsePositiveInteger(options.perRecipientLimit, defaultPerRecipientLimit),
+		limit
+	);
+	const claimTtlMs = parsePositiveInteger(options.claimTtlMs, defaultClaimTtlMs);
+	await models.ChatSyncJob.backfillMissing({
+		now,
+		limit,
+		perRecipientLimit
+	});
+	const jobs = await models.ChatSyncJob.claimDue({
+		now,
+		claimExpiresAt: new Date(now.getTime() + claimTtlMs),
+		claimToken: randomUUID(),
+		limit,
+		perRecipientLimit
+	});
+	const result = {
+		processed: 0,
+		completed: 0,
+		pending: 0,
+		failed: 0,
+		superseded: 0
+	};
+	for (const job of jobs) {
+		result.processed += 1;
+		try {
+			const state = job.syncState;
+			if (!state) {
+				throw new Error('chat_sync_state_not_found');
+			}
+			const device = await models.ChatDevice.findOne({
+				where: {
+					ownerId: state.recipientOwnerId,
+					revokedAt: null
+				},
+				order: [['id', 'ASC']]
+			});
+			if (!device) {
+				throw new Error('chat_sync_recipient_device_not_found');
+			}
+			const reconciliation = await options.reconcile(
+				Number(device.userId),
+				state
+			);
+			const complete = reconciliation.complete === true;
+			const updated = await updateClaimedJob(models, job, {
+				nextAttemptAt: new Date(now.getTime() + parsePositiveInteger(
+					complete
+						? options.refreshIntervalMs
+						: options.continuationDelayMs,
+					complete
+						? defaultRefreshIntervalMs
+						: defaultContinuationDelayMs
+				)),
+				failureCount: 0,
+				claimedAt: null,
+				claimExpiresAt: null,
+				claimToken: null,
+				lastError: null
+			});
+			result[updated ? (complete ? 'completed' : 'pending') : 'superseded'] += 1;
+		} catch (error) {
+			const updated = await recordChatReconciliationFailure(
+				models,
+				job,
+				error,
+				now
+			);
+			result[updated ? 'failed' : 'superseded'] += 1;
+		}
+	}
+	return result;
+}
+
+async function recordChatReconciliationFailure(models, job, error, now: Date) {
+	const failureCount = Number(job.failureCount || 0) + 1;
+	return updateClaimedJob(models, job, {
+		nextAttemptAt: new Date(now.getTime() + getRetryDelayMs(failureCount)),
+		failureCount,
+		claimedAt: null,
+		claimExpiresAt: null,
+		claimToken: null,
+		lastError: getErrorMessage(error)
+	});
+}
+
+async function updateClaimedJob(models, job, update): Promise<boolean> {
+	const [updated] = await models.ChatSyncJob.update(update, {
+		where: {
+			id: job.id,
+			claimToken: job.claimToken
+		}
+	});
+	return updated === 1;
+}
+
+function getRetryDelayMs(failureCount: number): number {
+	return Math.min(
+		minimumRetryDelayMs * (2 ** Math.max(0, failureCount - 1)),
+		maximumRetryDelayMs
+	);
+}
+
+function getErrorMessage(error): string {
+	return String(error?.message || error || 'chat_sync_failed').slice(0, 2000);
+}
+
+function parsePositiveInteger(value, fallback: number): number {
+	const parsed = Number.parseInt(value as any, 10);
+	if (Number.isFinite(parsed) && parsed > 0) {
+		return parsed;
+	}
+	return fallback;
+}

--- a/check/databaseMigrationIntegrity.ts
+++ b/check/databaseMigrationIntegrity.ts
@@ -269,6 +269,11 @@ const expectedColumns: ExpectedColumn[] = [
   {table: 'chatSyncStates', columns: ['verifiedSourceSequence'], type: 'bigint'},
   {table: 'chatSyncStates', columns: ['scanAfterSourceSequence'], type: 'bigint'},
   {table: 'chatSyncStates', columns: ['lastSourceHeadSequence'], type: 'bigint'},
+  {table: 'chatSyncJobs', columns: ['nextAttemptAt'], type: 'timestamp with time zone'},
+  {table: 'chatSyncJobs', columns: ['failureCount'], type: 'integer'},
+  {table: 'chatSyncJobs', columns: ['claimedAt'], type: 'timestamp with time zone'},
+  {table: 'chatSyncJobs', columns: ['claimExpiresAt'], type: 'timestamp with time zone'},
+  {table: 'chatSyncJobs', columns: ['claimToken'], type: 'character varying'},
 ];
 
 const expectedIndexes: ExpectedIndex[] = [
@@ -381,6 +386,22 @@ const expectedIndexes: ExpectedIndex[] = [
     name: 'chat_sync_states_recipient_updated_idx',
     table: 'chatSyncStates',
     columns: ['recipientOwnerId', 'updatedAt', 'id']
+  },
+  {
+    name: 'chat_sync_jobs_state_unique',
+    table: 'chatSyncJobs',
+    columns: ['chatSyncStateId'],
+    unique: true
+  },
+  {
+    name: 'chat_sync_jobs_due_idx',
+    table: 'chatSyncJobs',
+    columns: ['nextAttemptAt', 'claimExpiresAt', 'id']
+  },
+  {
+    name: 'chat_sync_jobs_recipient_due_idx',
+    table: 'chatSyncJobs',
+    columns: ['recipientOwnerId', 'nextAttemptAt', 'id']
   },
 ];
 
@@ -518,6 +539,51 @@ const countChecks: CountCheck[] = [
           "lastSourceHeadSequence" IS NOT NULL
           AND "scanAfterSourceSequence" > "lastSourceHeadSequence"
         )
+    `,
+  },
+  {
+    name: 'chat sync retry and lease state is valid',
+    requirements: [{
+      table: 'chatSyncJobs',
+      columns: [
+        'nextAttemptAt',
+        'failureCount',
+        'claimedAt',
+        'claimExpiresAt',
+        'claimToken',
+      ],
+    }],
+    sql: `
+      SELECT COUNT(*) AS count
+      FROM "chatSyncJobs"
+      WHERE "nextAttemptAt" IS NULL
+        OR "failureCount" < 0
+        OR (
+          ("claimedAt" IS NULL) <>
+          ("claimExpiresAt" IS NULL)
+        )
+        OR (
+          ("claimedAt" IS NULL) <>
+          ("claimToken" IS NULL)
+        )
+        OR (
+          "claimedAt" IS NOT NULL
+          AND "claimExpiresAt" <= "claimedAt"
+        )
+    `,
+  },
+  {
+    name: 'chat sync jobs point to existing sync states',
+    requirements: [
+      {table: 'chatSyncJobs', columns: ['chatSyncStateId']},
+      {table: 'chatSyncStates', columns: ['id']},
+    ],
+    sql: `
+      SELECT COUNT(*) AS count
+      FROM "chatSyncJobs" job
+      LEFT JOIN "chatSyncStates" state
+        ON state.id = job."chatSyncStateId"
+      WHERE state.id IS NULL
     `,
   },
   duplicateCheck('storage object storageId duplicates', 'storageObjects', ['storageId']),

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -437,12 +437,13 @@ Verification:
 Status: browser-held device keys, signed opaque envelopes, PostgreSQL event
 ordering/receipts, authenticated HTTPS inter-node delivery, durable offline
 retry leases, recipient-signed acknowledgements, and signed bounded
-head/missing-range reconciliation are implemented. Reconciliation keeps a
-restart-safe scan cursor separate from the fully verified source head so
-out-of-order live delivery cannot hide gaps. Remaining production work is
-automatic bounded reconciliation scheduling, browser device trust/recovery UX,
-group membership/key rotation, encrypted attachment lifecycle, quotas/retention
-policy, and real multi-node browser e2e/restart/NAT testing.
+head/missing-range reconciliation are implemented. An opt-in bounded worker now
+claims durable reconciliation state with restart-safe leases, per-node and
+per-recipient batch limits, and retry backoff. Reconciliation keeps a restart-safe
+scan cursor separate from the fully verified source head so out-of-order live
+delivery cannot hide gaps. Remaining production work is browser device
+trust/recovery UX, group membership/key rotation, encrypted attachment lifecycle,
+storage/retention quotas, and real multi-node browser e2e/restart/NAT testing.
 
 Goal: replace the backend encryption PoC with an implementation plan that can become real end-to-end encrypted chat.
 
@@ -464,7 +465,7 @@ Delivery and stability direction:
 - Track `messageId`, `conversationId`, sender device, recipient device set, created timestamp, delivery attempts, and acknowledgement state separately from ciphertext. Status: implemented.
 - Add idempotent send APIs and client-side dedupe by `messageId`; retries must not create duplicate chat messages. Status: backend idempotency and conflict rejection implemented; keep client dedupe aligned.
 - Define ordering rules before UI work: append-only per-conversation sequence, Lamport/vector-style causal metadata, or another explicit merge rule for offline concurrent sends. Status: transaction-safe local append sequence plus authenticated source sequence and verified reconciliation cursor implemented.
-- Add store-and-forward paths for offline recipients and multi-device users. libp2p direct streams/pubsub can accelerate delivery, but API/IPFS backfill should be the recovery path. Status: durable sender queue, signed HTTPS delivery, and signed bounded backfill implemented; automatic reconciliation scheduling remains.
+- Add store-and-forward paths for offline recipients and multi-device users. libp2p direct streams/pubsub can accelerate delivery, but API/IPFS backfill should be the recovery path. Status: durable sender queue, signed HTTPS delivery, signed bounded backfill, and opt-in leased reconciliation scheduling are implemented.
 - Run realistic tests with restart, offline sender/recipient, NAT/browser clients, duplicate delivery, delayed delivery, and large attachments. Attachment bytes should be content-addressed separately and referenced from the encrypted envelope.
 
 Repo split:
@@ -481,7 +482,6 @@ Delivered backend foundation:
 
 Next deliverables:
 
-- Add an opt-in bounded reconciliation scheduler over durable `ChatSyncState` rows, with leases, backoff, restart recovery, and per-node/user quotas.
 - Complete browser device trust, key backup/recovery, verification, revocation, and multi-device UX without sending private keys to the node.
 - Define secure group membership changes and key rotation using a reviewed group protocol rather than extending the current pairwise envelope ad hoc.
 - Add encrypted attachment upload/download/key lifecycle and retention/quota policy.
@@ -490,7 +490,9 @@ Next deliverables:
 Verification:
 
 - Design review across `geesome-node`, `geesome-libs`, and `geesome-ui`.
-- Node tests for opaque envelope storage, inter-node delivery, delayed retry, signed acknowledgements, and bounded missing-range repair.
+- Node tests for opaque envelope storage, inter-node delivery, delayed retry,
+  signed acknowledgements, bounded missing-range repair, expired reconciliation
+  lease recovery, stale-worker fencing, and per-recipient claim quotas.
 - Frontend/browser tests once client crypto exists.
 
 <!-- /todo-section -->

--- a/test/chatCron.test.ts
+++ b/test/chatCron.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert';
+import startChatWorkers from '../app/modules/chat/cron.js';
+
+describe('chat cron service', () => {
+	it('keeps workers disabled by default', () => {
+		const worker = startChatWorkers(
+			{config: {chatConfig: {}}} as any,
+			{} as any
+		);
+		assert.equal(worker, null);
+	});
+
+	it('passes bounded reconciliation configuration to an opt-in worker', async () => {
+		let processOptions;
+		let signalRun;
+		const run = new Promise(resolve => {
+			signalRun = resolve;
+		});
+		const worker = startChatWorkers({
+			config: {
+				chatConfig: {
+					reconciliationWorker: true,
+					reconciliationWorkerIntervalMs: 60000,
+					reconciliationWorkerLimit: '7',
+					reconciliationPerRecipientLimit: '2',
+					reconciliationClaimTtlMs: '3000',
+					reconciliationRefreshIntervalMs: '5000',
+					reconciliationContinuationDelayMs: '1000',
+					reconciliationPageLimit: '4',
+					reconciliationMaxPages: '3'
+				}
+			}
+		} as any, {
+			processReconciliationQueue: async options => {
+				processOptions = options;
+				signalRun();
+			}
+		} as any);
+
+		await run;
+		await worker.stop();
+		assert.deepEqual(processOptions, {
+			limit: '7',
+			perRecipientLimit: '2',
+			claimTtlMs: '3000',
+			refreshIntervalMs: '5000',
+			continuationDelayMs: '1000',
+			pageLimit: '4',
+			maxPages: '3'
+		});
+	});
+
+	it('preserves the opt-in delivery worker configuration', async () => {
+		let processOptions;
+		let signalRun;
+		const run = new Promise(resolve => {
+			signalRun = resolve;
+		});
+		const worker = startChatWorkers({
+			config: {
+				chatConfig: {
+					deliveryWorker: true,
+					deliveryWorkerIntervalMs: 60000,
+					deliveryWorkerLimit: '9',
+					deliveryClaimTtlMs: '4000'
+				}
+			}
+		} as any, {
+			processDeliveryQueue: async options => {
+				processOptions = options;
+				signalRun();
+			}
+		} as any);
+
+		await run;
+		await worker.stop();
+		assert.deepEqual(processOptions, {
+			limit: '9',
+			claimTtlMs: '4000'
+		});
+	});
+});

--- a/test/chatIntegration.test.ts
+++ b/test/chatIntegration.test.ts
@@ -20,6 +20,7 @@ describe('chat persistence', function () {
 		const appConfig: any = (await import('../app/config.js')).default;
 		appConfig.storageConfig.jsNode.pass = 'test test test test test test test test test test';
 		appConfig.chatConfig.deliveryWorker = false;
+		appConfig.chatConfig.reconciliationWorker = false;
 		appConfig.chatConfig.autoProcessDeliveries = false;
 		app = await (await import('../app/index.js')).default({
 			storageConfig: appConfig.storageConfig,
@@ -300,6 +301,124 @@ describe('chat persistence', function () {
 		assert.equal(slowReconciliation.complete, true);
 		assert.equal(slowReconciliation.scanAfterSourceSequence, '4');
 		assert.equal(slowReconciliation.verifiedSourceSequence, '4');
+
+		const fifthEnvelope = await browserE2eeHelper.encryptEnvelope(
+			'fifth queued transport secret',
+			[bobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'postgres-queued-message-5',
+				conversationId: queuedEnvelope.conversationId
+			}
+		);
+		await app.ms.chat.acceptEncryptedEvent(alice.id, fifthEnvelope);
+		const ChatSyncState: any = app.ms.database.sequelize.models.chatSyncState;
+		let syncState = await ChatSyncState.findOne({
+			where: {
+				conversationId: queuedEnvelope.conversationId,
+				recipientOwnerId: bob.storageAccountId,
+				sourceOwnerId: alice.storageAccountId
+			}
+			});
+			const ChatSyncJob: any = app.ms.database.sequelize.models.chatSyncJob;
+			const queueNow = new Date('2026-06-01T00:00:00.000Z');
+			await ChatSyncJob.backfillMissing({
+				now: queueNow,
+				limit: 10,
+				perRecipientLimit: 10
+			});
+			let syncJob = await ChatSyncJob.findOne({
+				where: {chatSyncStateId: syncState.id}
+			});
+			await syncJob.update({
+			nextAttemptAt: new Date(queueNow.getTime() - 1000),
+			claimedAt: queueNow,
+			claimExpiresAt: new Date(queueNow.getTime() + 60000),
+			claimToken: 'live-worker-claim'
+		});
+		const liveLeaseResult = await app.ms.chat.processReconciliationQueue({
+			now: queueNow,
+			requestChatSync: (_syncUrl, request) =>
+				app.ms.chat.acceptSyncRequest(request)
+		});
+		assert.equal(liveLeaseResult.processed, 0);
+
+		await syncJob.update({
+			claimExpiresAt: new Date(queueNow.getTime() - 1)
+		});
+		const recoveredLeaseResult = await app.ms.chat.processReconciliationQueue({
+			now: queueNow,
+			refreshIntervalMs: 60000,
+			requestChatSync: (_syncUrl, request) =>
+				app.ms.chat.acceptSyncRequest(request)
+		});
+		assert.equal(recoveredLeaseResult.completed, 1);
+		syncState = await ChatSyncState.findByPk(syncState.id);
+		syncJob = await ChatSyncJob.findByPk(syncJob.id);
+		assert.equal(String(syncState.verifiedSourceSequence), '5');
+		assert.equal(syncJob.failureCount, 0);
+		assert.equal(syncJob.claimedAt, null);
+		assert.equal(syncJob.claimExpiresAt, null);
+		assert.equal(syncJob.claimToken, null);
+		assert.equal(syncJob.nextAttemptAt.toISOString(), '2026-06-01T00:01:00.000Z');
+
+		await syncJob.update({
+			nextAttemptAt: new Date(queueNow.getTime() - 1000)
+		});
+		const failedQueueResult = await app.ms.chat.processReconciliationQueue({
+			now: queueNow,
+			requestChatSync: async () => {
+				throw new Error('temporary_sync_failure');
+			}
+		});
+		assert.equal(failedQueueResult.failed, 1);
+		syncJob = await ChatSyncJob.findByPk(syncJob.id);
+		assert.equal(syncJob.failureCount, 1);
+		assert.equal(syncJob.lastError, 'temporary_sync_failure');
+		assert.equal(syncJob.claimedAt, null);
+		assert.equal(syncJob.claimExpiresAt, null);
+		assert.equal(syncJob.nextAttemptAt.toISOString(), '2026-06-01T00:00:05.000Z');
+
+		await ChatSyncState.bulkCreate([
+			{
+				conversationId: 'quota-conversation-1',
+				recipientOwnerId: bob.storageAccountId,
+				sourceOwnerId: 'quota-source-1',
+				sourcePublicKey: aliceTransportPublicKey,
+				syncUrl: 'https://alice.example/v1/chat/sync'
+			},
+			{
+				conversationId: 'quota-conversation-2',
+				recipientOwnerId: bob.storageAccountId,
+				sourceOwnerId: 'quota-source-2',
+				sourcePublicKey: aliceTransportPublicKey,
+				syncUrl: 'https://alice.example/v1/chat/sync'
+			},
+			{
+				conversationId: 'quota-conversation-3',
+				recipientOwnerId: alice.storageAccountId,
+				sourceOwnerId: 'quota-source-3',
+				sourcePublicKey: aliceTransportPublicKey,
+				syncUrl: 'https://alice.example/v1/chat/sync'
+			}
+		]);
+		await ChatSyncJob.backfillMissing({
+			now: queueNow,
+			limit: 10,
+			perRecipientLimit: 1
+		});
+		const quotaClaims = await ChatSyncJob.claimDue({
+			now: queueNow,
+			claimExpiresAt: new Date(queueNow.getTime() + 60000),
+			claimToken: 'quota-claim',
+			limit: 10,
+			perRecipientLimit: 1
+		});
+		assert.equal(quotaClaims.length, 2);
+		assert.equal(
+			new Set(quotaClaims.map(job => job.recipientOwnerId)).size,
+			2
+		);
 	});
 });
 

--- a/test/chatReconciliationQueue.test.ts
+++ b/test/chatReconciliationQueue.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert';
+import {processChatReconciliationQueue} from '../app/modules/chat/reconciliationQueue.js';
+
+let nextStateId = 1;
+
+describe('chat reconciliation queue', () => {
+	it('bounds claims and schedules complete and incomplete work separately', async () => {
+		const claimedOptions: any[] = [];
+		const completeJob = createJob({recipientOwnerId: 'recipient-1'});
+		const pendingJob = createJob({recipientOwnerId: 'recipient-2'});
+		const models = {
+			ChatSyncJob: {
+				backfillMissing: async () => undefined,
+				claimDue: async options => {
+					claimedOptions.push(options);
+					return [completeJob, pendingJob];
+				},
+				update: createClaimedJobUpdater([completeJob, pendingJob])
+			},
+			ChatDevice: {
+				findOne: async ({where}) => ({
+					userId: where.ownerId === 'recipient-1' ? 11 : 22
+				})
+			}
+		};
+		const now = new Date('2026-01-01T00:00:00.000Z');
+		const result = await processChatReconciliationQueue(models, {
+			now,
+			limit: 4,
+			perRecipientLimit: 2,
+			claimTtlMs: 1000,
+			refreshIntervalMs: 60000,
+			continuationDelayMs: 2000,
+			reconcile: async userId => ({complete: userId === 11})
+		});
+
+		assert.deepEqual(result, {
+			processed: 2,
+			completed: 1,
+			pending: 1,
+			failed: 0,
+			superseded: 0
+		});
+		assert.equal(claimedOptions[0].limit, 4);
+		assert.equal(claimedOptions[0].perRecipientLimit, 2);
+		assert.equal(claimedOptions[0].claimExpiresAt.toISOString(),
+			'2026-01-01T00:00:01.000Z');
+		assert.equal(completeJob.updates[0].nextAttemptAt.toISOString(),
+			'2026-01-01T00:01:00.000Z');
+		assert.equal(pendingJob.updates[0].nextAttemptAt.toISOString(),
+			'2026-01-01T00:00:02.000Z');
+	});
+
+	it('releases failed claims with bounded exponential backoff', async () => {
+		const job = createJob({
+			recipientOwnerId: 'recipient-1',
+			failureCount: 2
+		});
+		const models = {
+			ChatSyncJob: {
+				backfillMissing: async () => undefined,
+				claimDue: async () => [job],
+				update: createClaimedJobUpdater([job])
+			},
+			ChatDevice: {findOne: async () => ({userId: 11})}
+		};
+		const result = await processChatReconciliationQueue(models, {
+			now: new Date('2026-01-01T00:00:00.000Z'),
+			reconcile: async () => {
+				throw new Error('temporary_source_failure');
+			}
+		});
+
+		assert.equal(result.failed, 1);
+		assert.equal(job.updates[0].failureCount, 3);
+		assert.equal(job.updates[0].nextAttemptAt.toISOString(),
+			'2026-01-01T00:00:20.000Z');
+		assert.equal(job.updates[0].claimedAt, null);
+		assert.equal(job.updates[0].claimExpiresAt, null);
+		assert.equal(job.updates[0].claimToken, null);
+		assert.equal(job.updates[0].lastError, 'temporary_source_failure');
+	});
+
+	it('does not let an expired worker overwrite a newer claim', async () => {
+		const job = createJob({claimToken: 'old-claim'});
+		const models = {
+			ChatSyncJob: {
+				backfillMissing: async () => undefined,
+				claimDue: async () => [job],
+				update: async () => [0]
+			},
+			ChatDevice: {findOne: async () => ({userId: 11})}
+		};
+		const result = await processChatReconciliationQueue(models, {
+			reconcile: async () => ({complete: true})
+		});
+
+		assert.equal(result.superseded, 1);
+		assert.equal(result.completed, 0);
+		assert.equal(job.updates.length, 0);
+	});
+});
+
+function createJob(overrides: any = {}) {
+	const recipientOwnerId = overrides.recipientOwnerId || 'recipient';
+	const job: any = {
+		id: nextStateId++,
+		failureCount: 0,
+		claimToken: 'active-claim',
+		syncState: {
+			recipientOwnerId,
+			conversationId: `conversation-${nextStateId}`,
+			sourceOwnerId: `source-${nextStateId}`
+		},
+		updates: [],
+		...overrides
+	};
+	delete job.recipientOwnerId;
+	job.update = async update => {
+		job.updates.push(update);
+		Object.assign(job, update);
+		return job;
+	};
+	return job;
+}
+
+function createClaimedJobUpdater(jobs) {
+	return async (update, {where}) => {
+		const job = jobs.find(item =>
+			item.id === where.id &&
+			item.claimToken === where.claimToken
+		);
+		if (!job) {
+			return [0];
+		}
+		job.updates.push(update);
+		Object.assign(job, update);
+		return [1];
+	};
+}


### PR DESCRIPTION
## Summary
- add an opt-in durable chat reconciliation worker that recovers missing encrypted events after dropped pubsub notifications or process restarts
- claim work with bounded global and per-recipient quotas, expiring leases, exponential retry backoff, and stale-worker token fencing
- learn remote sync sources from incoming deliveries and keep completed conversations on a bounded refresh schedule
- document the worker controls and update the deterministic browser-first chat TODO section

## Migration and runtime safety
- adds a separate `ChatSyncJob` table through the existing Sequelize model-sync path; the merged `ChatSyncState` schema remains unchanged
- keeps the worker disabled by default, so existing deployments retain current behavior until explicitly enabled
- rehearsed upgrade from the exact schema produced by merged PR #1287 before running the new model sync
- validates job-to-state relations, lease shape, retry state, indexes, and all existing database invariants

## Verification
- focused chat scheduler/integration tests: 7 passing
- restored old-schema migration integrity audit: 258 passed, 0 failed, 0 skipped
- deterministic TODO section validation: passed
- full Docker suite on the upgraded database: 580 passing, 11 pending

Planning context: #1284