### PR TITLE
Advertise encrypted chat transport in user manifests

### DIFF
--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -22,6 +22,11 @@ exponential backoff, and the optional interval worker retries recipients that
 were offline. Configure the public endpoint with `CHAT_PUBLIC_URL` or `DOMAIN`;
 set `CHAT_DELIVERY_WORKER=1` to enable background retries or
 `CHAT_AUTO_PROCESS_DELIVERIES=0` to disable the immediate post-write attempt.
+When a public endpoint is configured, the same canonical transport contract is
+included as `chatTransport` in signed user manifests. Browser clients can use
+that identity-bound hint to discover active recipient devices and submit the
+recipient endpoint with an encrypted event. Older user manifests and nodes
+without a public URL omit the field and remain valid.
 
 The communicator or PubSub layer may later wake peers sooner, but it is never
 the source of truth. Missing-range repair uses the signed

--- a/app/modules/chat/index.ts
+++ b/app/modules/chat/index.ts
@@ -43,6 +43,7 @@ import {
 	signChatAcknowledgement,
 	verifyChatDelivery
 } from './transport.js';
+import {buildChatPublicNodeInfoResponse} from './publicNodeInfo.js';
 
 const maxDeviceBundleBytes = 64 * 1024;
 const maxEnvelopeBytes = 1024 * 1024;
@@ -150,17 +151,7 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 		}
 
 		async getPublicNodeInfo() {
-			const publicUrl = getChatPublicUrl(app);
-			return {
-				protocol: chatDeliveryProtocol,
-				syncProtocol: chatSyncProtocol,
-				publicUrl,
-				inboxUrl: publicUrl ? `${publicUrl}/v1/chat/inbox` : null,
-				syncUrl: publicUrl ? `${publicUrl}/v1/chat/sync` : null,
-				deviceDiscoveryTemplate: publicUrl
-					? `${publicUrl}/v1/chat/public/users/{ownerId}/devices`
-					: null
-			};
+			return buildChatPublicNodeInfoResponse(getChatPublicUrl(app));
 		}
 
 		async revokeDevice(userId: number, deviceId: string) {

--- a/app/modules/chat/interface.ts
+++ b/app/modules/chat/interface.ts
@@ -1,4 +1,5 @@
 import type {IBackgroundWorker} from '../../backgroundWorker.js';
+import type {IChatPublicNodeInfoResponse} from './publicNodeInfo.js';
 
 export enum ChatEventState {
 	AcceptedLocal = 'accepted_local',
@@ -70,7 +71,7 @@ export default interface IGeesomeChatModule {
 	registerDevice(userId: number, publicBundle: any): Promise<any>;
 	getOwnDevices(userId: number, options?: {includeRevoked?: boolean}): Promise<any[]>;
 	getPublicDevices(ownerId: string): Promise<any[]>;
-	getPublicNodeInfo(): Promise<any>;
+	getPublicNodeInfo(): Promise<IChatPublicNodeInfoResponse>;
 	revokeDevice(userId: number, deviceId: string): Promise<any>;
 	acceptEncryptedEvent(
 		userId: number,

--- a/app/modules/chat/publicNodeInfo.ts
+++ b/app/modules/chat/publicNodeInfo.ts
@@ -1,0 +1,88 @@
+import {chatSyncProtocol} from './sync.js';
+import {chatDeliveryProtocol} from './transport.js';
+
+export interface IChatPublicNodeInfo {
+	protocol: typeof chatDeliveryProtocol;
+	syncProtocol: typeof chatSyncProtocol;
+	publicUrl: string;
+	inboxUrl: string;
+	syncUrl: string;
+	deviceDiscoveryTemplate: string;
+}
+
+export type IChatPublicNodeInfoResponse = IChatPublicNodeInfo | {
+	protocol: typeof chatDeliveryProtocol;
+	syncProtocol: typeof chatSyncProtocol;
+	publicUrl: null;
+	inboxUrl: null;
+	syncUrl: null;
+	deviceDiscoveryTemplate: null;
+};
+
+export function buildChatPublicNodeInfo(publicUrl?: string | null): IChatPublicNodeInfo | null {
+	const normalizedPublicUrl = normalizePublicUrl(publicUrl);
+	if (!normalizedPublicUrl) {
+		return null;
+	}
+	return {
+		protocol: chatDeliveryProtocol,
+		syncProtocol: chatSyncProtocol,
+		publicUrl: normalizedPublicUrl,
+		inboxUrl: `${normalizedPublicUrl}/v1/chat/inbox`,
+		syncUrl: `${normalizedPublicUrl}/v1/chat/sync`,
+		deviceDiscoveryTemplate: `${normalizedPublicUrl}/v1/chat/public/users/{ownerId}/devices`
+	};
+}
+
+export function buildChatPublicNodeInfoResponse(publicUrl?: string | null): IChatPublicNodeInfoResponse {
+	return buildChatPublicNodeInfo(publicUrl) || {
+		protocol: chatDeliveryProtocol,
+		syncProtocol: chatSyncProtocol,
+		publicUrl: null,
+		inboxUrl: null,
+		syncUrl: null,
+		deviceDiscoveryTemplate: null
+	};
+}
+
+export function normalizeChatPublicNodeInfo(value: any): IChatPublicNodeInfo | null {
+	if (
+		!value ||
+		value.protocol !== chatDeliveryProtocol ||
+		value.syncProtocol !== chatSyncProtocol
+	) {
+		return null;
+	}
+	const expected = buildChatPublicNodeInfo(value.publicUrl);
+	if (
+		!expected ||
+		value.inboxUrl !== expected.inboxUrl ||
+		value.syncUrl !== expected.syncUrl ||
+		value.deviceDiscoveryTemplate !== expected.deviceDiscoveryTemplate
+	) {
+		return null;
+	}
+	return expected;
+}
+
+function normalizePublicUrl(value?: string | null): string | null {
+	if (!value || typeof value !== 'string') {
+		return null;
+	}
+	try {
+		const url = new URL(value);
+		if (
+			(url.protocol !== 'https:' && url.protocol !== 'http:') ||
+			url.username ||
+			url.password ||
+			url.search ||
+			url.hash
+		) {
+			return null;
+		}
+		url.pathname = url.pathname.replace(/\/+$/, '');
+		return url.toString().replace(/\/$/, '');
+	} catch (_error) {
+		return null;
+	}
+}

--- a/app/modules/entityJsonManifest/index.ts
+++ b/app/modules/entityJsonManifest/index.ts
@@ -16,6 +16,7 @@ import IGeesomeEntityJsonManifestModule from "./interface.js";
 import {IGroupCategory} from "../groupCategory/interface.js";
 import {IContent, IUser} from "../database/interface.js";
 import {IGeesomeApp} from "../../interface.js";
+import {normalizeChatPublicNodeInfo} from "../chat/publicNodeInfo.js";
 import {
   addPostLocalIdToRemovedChanges,
   addPostManifestRefToChangedChanges,
@@ -59,7 +60,7 @@ export default async (app: IGeesomeApp) => {
   return getModule(app);
 };
 
-function getModule(app: IGeesomeApp) {
+export function getModule(app: IGeesomeApp) {
   app.checkModules(['database', 'group', 'accountStorage', 'staticId', 'storage']);
 
   class EntityJsonManifest implements IGeesomeEntityJsonManifestModule {
@@ -116,6 +117,13 @@ function getModule(app: IGeesomeApp) {
 
         if (user.avatarImage) {
           userManifest.avatarImage = this.getStorageRef(user.avatarImage.manifestStorageId);
+        }
+
+        const chatTransport = normalizeChatPublicNodeInfo(
+          await app.ms.chat?.getPublicNodeInfo?.()
+        );
+        if (chatTransport) {
+          userManifest.chatTransport = chatTransport;
         }
 
         this.setManifestMeta(userManifest, name);
@@ -238,6 +246,10 @@ function getModule(app: IGeesomeApp) {
         }
 
         user.manifestStaticStorageId = manifest.staticId;
+        const chatTransport = normalizeChatPublicNodeInfo(manifest.chatTransport);
+        if (chatTransport) {
+          user['chatTransport'] = chatTransport;
+        }
         log('manifestIdToDbObject:user', user);
 
         //TODO: check ipns for valid bound to ipld

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -442,8 +442,14 @@ claims durable reconciliation state with restart-safe leases, per-node and
 per-recipient batch limits, and retry backoff. Reconciliation keeps a restart-safe
 scan cursor separate from the fully verified source head so out-of-order live
 delivery cannot hide gaps. Remaining production work is browser device
-trust/recovery UX, group membership/key rotation, encrypted attachment lifecycle,
+trust verification, group membership/key rotation, encrypted attachment lifecycle,
 storage/retention quotas, and real multi-node browser e2e/restart/NAT testing.
+Browser device creation, protected local key storage, encrypted recovery,
+restore, fingerprint display, registration, and revocation are implemented in
+`geesome-ui`. Configured nodes now also advertise canonical chat transport
+metadata in signed user manifests so a browser can discover remote devices and
+route ciphertext to the identity-bound recipient node; older profiles omit the
+field and remain valid.
 
 Goal: replace the backend encryption PoC with an implementation plan that can become real end-to-end encrypted chat.
 
@@ -482,7 +488,12 @@ Delivered backend foundation:
 
 Next deliverables:
 
-- Complete browser device trust, key backup/recovery, verification, revocation, and multi-device UX without sending private keys to the node.
+- Add direct-message browser send/read UX using the advertised recipient
+  transport, local device keys, opaque event API, ordered reads, and client-side
+  dedupe. Show an actionable unavailable state for old recipient profiles that
+  have not yet republished a transport hint.
+- Complete explicit device trust verification and multi-device UX without
+  sending private keys to the node.
 - Define secure group membership changes and key rotation using a reviewed group protocol rather than extending the current pairwise envelope ad hoc.
 - Add encrypted attachment upload/download/key lifecycle and retention/quota policy.
 - Run real two-node browser e2e tests covering restart, temporary unreachability, duplicate/out-of-order delivery, bounded backfill, and NAT/bootstrap conditions.

--- a/test/chatPublicNodeInfo.test.ts
+++ b/test/chatPublicNodeInfo.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert';
+import {
+	buildChatPublicNodeInfo,
+	buildChatPublicNodeInfoResponse,
+	normalizeChatPublicNodeInfo
+} from '../app/modules/chat/publicNodeInfo.js';
+
+describe('chat public node info', () => {
+	it('builds the canonical same-origin chat transport contract', () => {
+		assert.deepEqual(buildChatPublicNodeInfo('https://node.example/'), {
+			protocol: 'geesome-chat-delivery-v1',
+			syncProtocol: 'geesome-chat-sync-v1',
+			publicUrl: 'https://node.example',
+			inboxUrl: 'https://node.example/v1/chat/inbox',
+			syncUrl: 'https://node.example/v1/chat/sync',
+			deviceDiscoveryTemplate: 'https://node.example/v1/chat/public/users/{ownerId}/devices'
+		});
+		assert.equal(buildChatPublicNodeInfo(null), null);
+		assert.deepEqual(buildChatPublicNodeInfoResponse(null), {
+			protocol: 'geesome-chat-delivery-v1',
+			syncProtocol: 'geesome-chat-sync-v1',
+			publicUrl: null,
+			inboxUrl: null,
+			syncUrl: null,
+			deviceDiscoveryTemplate: null
+		});
+	});
+
+	it('accepts only canonical endpoint paths from the advertised origin', () => {
+		const valid = buildChatPublicNodeInfo('https://node.example');
+		assert.deepEqual(normalizeChatPublicNodeInfo(valid), valid);
+		assert.equal(normalizeChatPublicNodeInfo({
+			...valid,
+			inboxUrl: 'https://internal.example/v1/chat/inbox'
+		}), null);
+		assert.equal(normalizeChatPublicNodeInfo({
+			...valid,
+			deviceDiscoveryTemplate: 'https://node.example/v1/users/{ownerId}'
+		}), null);
+		assert.equal(normalizeChatPublicNodeInfo({
+			...valid,
+			protocol: 'future-chat-protocol'
+		}), null);
+	});
+
+	it('rejects credentialed and non-HTTP public URLs', () => {
+		assert.equal(buildChatPublicNodeInfo('https://user:pass@node.example'), null);
+		assert.equal(buildChatPublicNodeInfo('file:///tmp/chat'), null);
+	});
+});

--- a/test/entityJsonManifestUserChat.test.ts
+++ b/test/entityJsonManifestUserChat.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert';
+import {getModule} from '../app/modules/entityJsonManifest/index.js';
+import {buildChatPublicNodeInfoResponse} from '../app/modules/chat/publicNodeInfo.js';
+
+describe('user manifest chat transport', () => {
+	it('advertises configured chat transport without changing user identity fields', async () => {
+		const manifestModule = getModule(createManifestApp(
+			buildChatPublicNodeInfoResponse('https://node.example')
+		));
+		const manifest = await manifestModule.generateManifest('user', {
+			id: 1,
+			name: 'alice',
+			title: 'Alice',
+			manifestStaticStorageId: 'owner-alice'
+		});
+
+		assert.equal(manifest.staticId, 'owner-alice');
+		assert.equal(manifest.publicKey, 'alice-public-key');
+		assert.deepEqual(manifest.chatTransport, {
+			protocol: 'geesome-chat-delivery-v1',
+			syncProtocol: 'geesome-chat-sync-v1',
+			publicUrl: 'https://node.example',
+			inboxUrl: 'https://node.example/v1/chat/inbox',
+			syncUrl: 'https://node.example/v1/chat/sync',
+			deviceDiscoveryTemplate: 'https://node.example/v1/chat/public/users/{ownerId}/devices'
+		});
+	});
+
+	it('omits transport for unconfigured nodes and invalid remote advertisements', async () => {
+		const unconfiguredModule = getModule(createManifestApp(
+			buildChatPublicNodeInfoResponse(null)
+		));
+		const manifest = await unconfiguredModule.generateManifest('user', {
+			id: 1,
+			name: 'alice',
+			manifestStaticStorageId: 'owner-alice'
+		});
+		assert.equal(manifest.chatTransport, undefined);
+
+		const invalidRemoteModule = getModule(createManifestApp(null, {
+			_entityName: 'user',
+			name: 'mallory',
+			staticId: 'owner-mallory',
+			publicKey: 'mallory-public-key',
+			chatTransport: {
+				...buildChatPublicNodeInfoResponse('https://node.example'),
+				inboxUrl: 'https://localhost/v1/chat/inbox'
+			}
+		}));
+		const imported = await invalidRemoteModule.manifestIdToDbObject(
+			'remote-user-manifest',
+			'user'
+		);
+		assert.equal(imported.chatTransport, undefined);
+	});
+
+	it('preserves a canonical transport when importing a remote user manifest', async () => {
+		const chatTransport = buildChatPublicNodeInfoResponse('https://remote.example');
+		const manifestModule = getModule(createManifestApp(null, {
+			_entityName: 'user',
+			name: 'bob',
+			staticId: 'owner-bob',
+			publicKey: 'bob-public-key',
+			chatTransport
+		}));
+		const imported = await manifestModule.manifestIdToDbObject(
+			'remote-user-manifest',
+			'user'
+		);
+
+		assert.deepEqual(imported.chatTransport, chatTransport);
+	});
+});
+
+function createManifestApp(publicNodeInfo, storedManifest: any = {}) {
+	return {
+		checkModules: () => true,
+		callHook: async () => true,
+		ms: {
+			accountStorage: {
+				getStaticIdPublicKeyByOr: async () => 'alice-public-key',
+				createRemoteAccount: async () => true
+			},
+			chat: {
+				getPublicNodeInfo: async () => publicNodeInfo
+			},
+			staticId: {
+				addStaticIdHistoryItem: async () => true
+			},
+			storage: {
+				getObject: async () => storedManifest
+			}
+		}
+	} as any;
+}


### PR DESCRIPTION
## Summary
- advertise canonical chat inbox, sync, and device-discovery metadata in signed user manifests when a public node URL is configured
- preserve older profiles and the existing unconfigured public-node response
- reject non-canonical, cross-origin, credentialed, or unsupported transport advertisements during manifest import
- update the secure-chat TODO so encrypted direct-message UI can consume this prerequisite next

## Verification
- focused chat, API, transport, and manifest tests: 11 passing
- full Docker suite: 581 passing, 11 pending; 5 cold IPFS write tests timed out at 60 seconds
- isolated warm rerun of those 5 timeout cases: 5 passing