### PR TITLE
Retain sender-owned encrypted chat attachments

### DIFF
--- a/app/modules/chat/index.ts
+++ b/app/modules/chat/index.ts
@@ -57,6 +57,10 @@ export default async function initializeChatModule(app: IGeesomeApp, options: an
 	const models = options.models || await (await import('./models.js')).default(
 		app.ms.database.sequelize
 	);
+	app.ms.database.registerStorageIdReferenceSource?.({
+		model: models.ChatEventAttachment,
+		columns: ['storageId']
+	});
 	const module = getModule(app, models, options);
 	(await import('./api.js')).default(app, module);
 	module.setDeliveryWorker((await import('./cron.js')).default(app, module));
@@ -84,6 +88,7 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 			await models.ChatDelivery.destroy({where: {}});
 			await models.ChatSyncJob.destroy({where: {}});
 			await models.ChatSyncState.destroy({where: {}});
+			await models.ChatEventAttachment.destroy({where: {}});
 			await models.ChatEventRecipient.destroy({where: {}});
 			await models.ChatEvent.destroy({where: {}});
 			await models.ChatConversationHead.destroy({where: {}});
@@ -207,6 +212,7 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 
 			const envelopeJson = JSON.stringify(envelope);
 			const eventHash = getEventHash(envelope);
+			const attachmentStorageIds = getAttachmentStorageIds(envelope);
 			const recipientEndpoints = await normalizeRecipientEndpoints(
 				envelope,
 				eventOptions.recipientEndpoints,
@@ -226,6 +232,11 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 				}
 				return result;
 			}
+			const attachmentContents = await getOwnedAttachmentContents(
+				app,
+				userId,
+				attachmentStorageIds
+			);
 
 			try {
 				const result = await app.ms.database.sequelize.transaction(async transaction => {
@@ -261,6 +272,14 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 							userId: localUsersByKey.get(keyId) || null,
 							ownerId: recipientOwnersByKey.get(keyId),
 							keyId
+						})),
+						{transaction}
+					);
+					await models.ChatEventAttachment.bulkCreate(
+						attachmentContents.map(content => ({
+							chatEventId: event.id,
+							contentId: content.id,
+							storageId: content.storageId
 						})),
 						{transaction}
 					);
@@ -1107,8 +1126,39 @@ function isSafeEnvelopeMetadata(metadata): boolean {
 		) {
 			return false;
 		}
+		if (
+			new Set(metadata.attachmentStorageIds).size !==
+			metadata.attachmentStorageIds.length
+		) {
+			return false;
+		}
 	}
 	return true;
+}
+
+function getAttachmentStorageIds(envelope): string[] {
+	return envelope.metadata?.attachmentStorageIds || [];
+}
+
+async function getOwnedAttachmentContents(
+	app: IGeesomeApp,
+	userId: number,
+	storageIds: string[]
+) {
+	if (!storageIds.length) {
+		return [];
+	}
+	const contents = await app.ms.database.getContentByStorageIdListAndUserId(
+		storageIds,
+		userId
+	);
+	const contentsByStorageId = new Map(
+		contents.map(content => [content.storageId, content])
+	);
+	if (storageIds.some(storageId => !contentsByStorageId.has(storageId))) {
+		throw chatError('chat_attachment_not_owned', 403);
+	}
+	return storageIds.map(storageId => contentsByStorageId.get(storageId));
 }
 
 function hasExactKeys(value, expectedKeys: string[]): boolean {

--- a/app/modules/chat/models.ts
+++ b/app/modules/chat/models.ts
@@ -143,6 +143,30 @@ export default async function initializeChatModels(sequelize: Sequelize) {
 		]
 	} as any);
 
+	const ChatEventAttachment = sequelize.define('chatEventAttachment', {
+		chatEventId: {
+			type: DataTypes.INTEGER,
+			allowNull: false
+		},
+		contentId: {
+			type: DataTypes.INTEGER,
+			allowNull: true
+		},
+		storageId: {
+			type: DataTypes.STRING(200),
+			allowNull: false
+		}
+	} as any, {
+		indexes: [
+			{
+				name: 'chat_event_attachments_event_storage_unique',
+				fields: ['chatEventId', 'storageId'],
+				unique: true
+			},
+			{name: 'chat_event_attachments_storage_idx', fields: ['storageId', 'chatEventId']}
+		]
+	} as any);
+
 	const ChatDelivery = sequelize.define('chatDelivery', {
 		chatEventId: {
 			type: DataTypes.INTEGER,
@@ -347,6 +371,8 @@ export default async function initializeChatModels(sequelize: Sequelize) {
 
 	ChatEvent.hasMany(ChatEventRecipient, {as: 'recipients', foreignKey: 'chatEventId'});
 	ChatEventRecipient.belongsTo(ChatEvent, {as: 'event', foreignKey: 'chatEventId'});
+	ChatEvent.hasMany(ChatEventAttachment, {as: 'attachments', foreignKey: 'chatEventId'});
+	ChatEventAttachment.belongsTo(ChatEvent, {as: 'event', foreignKey: 'chatEventId'});
 	ChatEvent.hasMany(ChatEventReceipt, {as: 'receipts', foreignKey: 'chatEventId'});
 	ChatEventReceipt.belongsTo(ChatEvent, {as: 'event', foreignKey: 'chatEventId'});
 	ChatEvent.hasMany(ChatDelivery, {as: 'deliveries', foreignKey: 'chatEventId'});
@@ -358,6 +384,7 @@ export default async function initializeChatModels(sequelize: Sequelize) {
 	await ChatConversationHead.sync({});
 	await ChatEvent.sync({});
 	await ChatEventRecipient.sync({});
+	await ChatEventAttachment.sync({});
 	await ChatDelivery.sync({});
 	await ChatEventReceipt.sync({});
 	await ChatSyncState.sync({});
@@ -383,6 +410,7 @@ export default async function initializeChatModels(sequelize: Sequelize) {
 		ChatConversationHead,
 		ChatEvent,
 		ChatEventRecipient,
+		ChatEventAttachment,
 		ChatDelivery,
 		ChatEventReceipt,
 		ChatSyncState,

--- a/app/modules/database/index.ts
+++ b/app/modules/database/index.ts
@@ -23,6 +23,7 @@ import {
   IContentDeleteSafetyBlocker,
   IGeesomeDatabaseModule,
   IStorageIdReferenceOptions,
+  IStorageIdReferenceSource,
   IListParams,
   IListParamsOptions,
   IObject,
@@ -148,6 +149,7 @@ class PostgresDatabase implements IGeesomeDatabaseModule {
   connectionDiagnostics: DatabaseConnectionDiagnostics;
   connectionBudget: DatabaseConnectionBudget | null;
   stopPromise: Promise<void> | null = null;
+  storageIdReferenceSources: IStorageIdReferenceSource[] = [];
 
   constructor(_app, _sequelize, _models, _config, _connectionDiagnostics, _connectionBudget) {
     this.app = _app;
@@ -610,7 +612,13 @@ class PostgresDatabase implements IGeesomeDatabaseModule {
       this.models.Content.count({where: otherContentsWhere}),
       this.models.Content.count({where: previewRefsWhere}),
       this.getStorageObjectPinProvenance(storageId),
-      countDerivedStorageIdReferences(this.models, this.sequelize, storageId, options),
+      countDerivedStorageIdReferences(
+        this.models,
+        this.sequelize,
+        storageId,
+        options,
+        this.storageIdReferenceSources
+      ),
       countStorageObjectChildReferences(this.models, this.sequelize, storageId, {
         ...options,
         excludeContentId,
@@ -625,6 +633,30 @@ class PostgresDatabase implements IGeesomeDatabaseModule {
       storageObjectChildRefs,
       pinProvenance,
     };
+  }
+
+  registerStorageIdReferenceSource(source: IStorageIdReferenceSource) {
+    if (
+      !source?.model ||
+      !Array.isArray(source.columns) ||
+      !source.columns.length ||
+      source.columns.some(column =>
+        typeof column !== 'string' ||
+        !/^[A-Za-z_][A-Za-z0-9_]*$/.test(column)
+      )
+    ) {
+      throw new Error('storage_id_reference_source_invalid');
+    }
+    if (this.storageIdReferenceSources.some(existing =>
+      existing.model === source.model &&
+      existing.columns.join('\0') === source.columns.join('\0')
+    )) {
+      return;
+    }
+    this.storageIdReferenceSources.push({
+      model: source.model,
+      columns: [...source.columns]
+    });
   }
 
   async getStorageObjectPinProvenance(storageId: string) {

--- a/app/modules/database/interface.ts
+++ b/app/modules/database/interface.ts
@@ -85,6 +85,8 @@ export interface IGeesomeDatabaseModule {
 
   countStorageIdReferences(storageId, excludeContentId?, options?: IStorageIdReferenceOptions): Promise<IStorageIdReferenceCounts>;
 
+  registerStorageIdReferenceSource?(source: IStorageIdReferenceSource): void;
+
   getStorageObjectPinProvenance(storageId: string): Promise<IStorageObjectPinProvenance>;
 
   countContentReferences(contentId): Promise<IContentReferenceCounts>;
@@ -298,6 +300,11 @@ export interface IStorageIdReferenceCounts {
   derivedStorageRefs: number;
   storageObjectChildRefs: number;
   pinProvenance: IStorageObjectPinProvenance;
+}
+
+export interface IStorageIdReferenceSource {
+  model: any;
+  columns: string[];
 }
 
 export interface IStorageObjectPinProvenance {

--- a/app/modules/database/storageReferenceHelpers.ts
+++ b/app/modules/database/storageReferenceHelpers.ts
@@ -38,8 +38,20 @@ export async function getStorageObjectPinProvenance(models, sequelize, storageId
   };
 }
 
-export async function countDerivedStorageIdReferences(models, sequelize, storageId, options: any = {}) {
-  return countDirectDerivedStorageIdReferences(models, sequelize, storageId, options);
+export async function countDerivedStorageIdReferences(
+  models,
+  sequelize,
+  storageId,
+  options: any = {},
+  registeredSources: any[] = []
+) {
+  return countDirectDerivedStorageIdReferences(
+    models,
+    sequelize,
+    storageId,
+    options,
+    registeredSources
+  );
 }
 
 export async function countStorageObjectChildReferences(models, sequelize, storageId, options: any = {}) {
@@ -123,9 +135,15 @@ async function isStorageObjectReferenceSourceVisible(
   return false;
 }
 
-async function countDirectDerivedStorageIdReferences(models, sequelize, storageId, options: any = {}) {
+async function countDirectDerivedStorageIdReferences(
+  models,
+  sequelize,
+  storageId,
+  options: any = {},
+  registeredSources: any[] = []
+) {
   const refCounts = await Promise.all([
-    ...derivedStorageReferenceSources.map((source) => {
+    ...[...derivedStorageReferenceSources, ...registeredSources].map((source) => {
       return countStorageIdColumnReferences(models, sequelize, source, storageId, options);
     }),
     countLatestStaticIdHistoryFallbackReferences(models, sequelize, storageId),
@@ -236,14 +254,17 @@ const derivedStorageReferenceSources = [
 ];
 
 async function countStorageIdColumnReferences(models, sequelize, source, storageId, options) {
-  const model = getReferenceModel(models, sequelize, source.modelNames);
+  const model = source.model || getReferenceModel(models, sequelize, source.modelNames);
   if (!model) {
     return 0;
   }
   const where: any = {
     [Op.or]: source.columns.map((column) => ({[column]: storageId})),
   };
-  if (options.excludeFileCatalogItemId && source.modelNames.includes('FileCatalogItem')) {
+  if (
+    options.excludeFileCatalogItemId &&
+    source.modelNames?.includes('FileCatalogItem')
+  ) {
     where.id = {[Op.ne]: options.excludeFileCatalogItemId};
   }
   return model.count({

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -204,9 +204,16 @@ TODO.
 - `geesome-ui` generates and stores private device keys in the browser, supports
   encrypted recovery/restore and revocation, discovers identity-bound recipient
   devices, encrypts/decrypts direct messages locally, deduplicates by message ID,
-  reads ordered sequence pages, and exposes delivery/setup states.
+  reads ordered sequence pages, exposes delivery/setup states, and lets users
+  compare stable fingerprints, verify devices, review key changes, and distinguish
+  unverified, verified, changed, and revoked devices.
 - `geesome-node` registers only public device bundles and persists only signed
   opaque envelopes plus routing, sequence, receipt, and delivery metadata.
+- Outgoing encrypted-attachment references are accepted only when every
+  content-addressed ciphertext object belongs to the authenticated sender. Chat
+  stores normalized event-to-storage references, and registers them with the
+  shared deletion-safety scanner so queued events cannot be orphaned by content
+  cleanup.
 - Authenticated HTTPS delivery has durable retry leases, bounded backoff,
   recipient-signed acknowledgements, source-head comparison, signed missing-range
   repair, and an opt-in bounded reconciliation worker.
@@ -219,6 +226,6 @@ TODO.
   sequence/head reconciliation as the correctness boundary.
 
 This is a browser-first encrypted direct-message foundation, not completion of
-production-secure chat. Explicit device trust, encrypted attachments, reviewed
-group membership/key rotation, retention/quota policy, and real two-node browser
-testing remain in the active TODO.
+production-secure chat. Recipient-side attachment fetch/pin acknowledgement,
+browser attachment UX, reviewed group membership/key rotation, retention/quota
+policy, and real two-node browser testing remain in the active TODO.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -106,26 +106,27 @@ Current safety boundary:
   state instead of falling back to plaintext.
 - Direct messages are the implemented E2EE foundation. Chat must not be
   described as production-secure for attachments or groups until explicit
-  device trust, attachment lifecycle, membership/key rotation, retention, and
-  real multi-node browser tests are complete.
+  attachment lifecycle, membership/key rotation, retention, and real multi-node
+  browser tests are complete.
 
 Remaining delivery order:
 
-1. Add explicit device trust verification and multi-device trust UX. Users must
-   be able to compare stable fingerprints, distinguish unverified/new/revoked
-   devices, and deliberately accept key changes without exposing private keys.
-2. Encrypt attachments in the browser before content-addressed upload. Define
-   wrapped content-key metadata, authenticated download/decryption, corruption
-   behavior, deletion, quota, retry, and retention without exposing plaintext or
-   keys to the node.
-3. Select and review the group protocol before extending pairwise envelopes.
+1. Complete encrypted attachments. Sender-side ownership checks and durable
+   event-to-storage references are implemented. Next, make the recipient fetch,
+   verify, persist, and pin every ciphertext object before signing delivery
+   acknowledgement; surface missing or corrupt objects as retryable delivery
+   failures. Then add browser encryption before upload, wrapped content-key
+   descriptors inside the encrypted envelope, authenticated download/decryption,
+   previews, corruption behavior, deletion, quota, retry, and retention without
+   exposing plaintext, original file metadata, or keys to the node.
+2. Select and review the group protocol before extending pairwise envelopes.
    Define membership epochs and rotate future-message keys when members/devices
    are added, removed, replaced, or revoked. Evaluate MLS, Matrix-style
    device/session handling, or another maintained browser-capable protocol.
-4. Run real two-node browser tests across restart, temporary unreachability,
+3. Run real two-node browser tests across restart, temporary unreachability,
    duplicate/out-of-order delivery, bounded repair, revoked devices, and
    NAT/bootstrap/reciprocal-peering conditions.
-5. Define operator-visible queue/reconciliation metrics and explicit encrypted
+4. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old
    conversations as E2EE.

--- a/test/chatIntegration.test.ts
+++ b/test/chatIntegration.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert';
 import {createHash} from 'node:crypto';
 import browserE2eeHelper from 'geesome-libs/src/browserE2eeHelper.js';
-import {CorePermissionName} from '../app/modules/database/interface.js';
+import {
+	ContentStorageType,
+	CorePermissionName
+} from '../app/modules/database/interface.js';
 import type {IGeesomeApp} from '../app/interface.js';
 import {
 	chatDeliveryProtocol,
@@ -420,7 +423,48 @@ describe('chat persistence', function () {
 			2
 		);
 	});
+
+	it('protects sender-owned attachment ciphertext from content cleanup', async () => {
+		const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: alice.storageAccountId,
+			deviceId: 'alice-attachment-browser'
+		});
+		const bobDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: bob.storageAccountId,
+			deviceId: 'bob-attachment-browser'
+		});
+		await app.ms.chat.registerDevice(alice.id, aliceDevice.publicBundle);
+		await app.ms.chat.registerDevice(bob.id, bobDevice.publicBundle);
+		const attachment = await app.ms.database.addContent({
+			userId: alice.id,
+			storageType: ContentStorageType.IPFS,
+			mimeType: 'application/octet-stream',
+			storageId: testAttachmentStorageId,
+			size: 32,
+			name: 'encrypted-chat-attachment'
+		} as any);
+		const envelope = await browserE2eeHelper.encryptEnvelope(
+			JSON.stringify({text: '', attachments: [{storageId: testAttachmentStorageId}]}),
+			[bobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'postgres-attachment-message-1',
+				conversationId: 'postgres-attachment-conversation-1',
+				metadata: {attachmentStorageIds: [testAttachmentStorageId]}
+			}
+		);
+
+		await app.ms.chat.acceptEncryptedEvent(alice.id, envelope);
+		const references = await app.ms.database.countStorageIdReferences(
+			testAttachmentStorageId,
+			attachment.id
+		);
+
+		assert.equal(references.derivedStorageRefs, 1);
+	});
 });
+
+const testAttachmentStorageId = 'QmYwAPJzv5CZsnAzt8auVZRnGi9iS3hBghG9V1sA9j3z2H';
 
 function getEnvelopeHash(envelope): string {
 	return createHash('sha256').update([

--- a/test/chatModule.test.ts
+++ b/test/chatModule.test.ts
@@ -67,6 +67,58 @@ describe('chat module', () => {
 		);
 	});
 
+	it('retains only attachment ciphertext owned by the authenticated sender', async () => {
+		const {chat, rows} = createChatHarness({
+			contents: [{id: 7, userId: 1, storageId: testAttachmentStorageId}]
+		});
+		const alice = await createDevice('owner-alice', 'alice-browser');
+		const bob = await createDevice('owner-bob', 'bob-browser');
+		await chat.registerDevice(1, alice.publicBundle);
+		await chat.registerDevice(2, bob.publicBundle);
+		const envelope = await createEnvelope(
+			'encrypted attachment descriptor',
+			alice,
+			bob,
+			'message-attachment',
+			{attachmentStorageIds: [testAttachmentStorageId]}
+		);
+
+		await chat.acceptEncryptedEvent(1, envelope);
+		assert.deepEqual(rows.attachments.map(row => ({
+			chatEventId: row.chatEventId,
+			contentId: row.contentId,
+			storageId: row.storageId
+		})), [{
+			chatEventId: rows.events[0].id,
+			contentId: 7,
+			storageId: testAttachmentStorageId
+		}]);
+
+		const unownedEnvelope = await createEnvelope(
+			'encrypted attachment descriptor',
+			alice,
+			bob,
+			'message-unowned-attachment',
+			{attachmentStorageIds: [testUnownedAttachmentStorageId]}
+		);
+		await assert.rejects(
+			() => chat.acceptEncryptedEvent(1, unownedEnvelope),
+			/chat_attachment_not_owned/
+		);
+		const duplicateEnvelope = await createEnvelope(
+			'encrypted duplicate attachment descriptor',
+			alice,
+			bob,
+			'message-duplicate-attachment',
+			{attachmentStorageIds: [testAttachmentStorageId, testAttachmentStorageId]}
+		);
+		await assert.rejects(
+			() => chat.acceptEncryptedEvent(1, duplicateEnvelope),
+			/encrypted_envelope_fields_invalid/
+		);
+		assert.equal(rows.events.length, 1);
+	});
+
 	it('rejects revoked sender and locally known recipient devices', async () => {
 		const {chat} = createChatHarness();
 		const alice = await createDevice('owner-alice', 'alice-browser');
@@ -143,7 +195,10 @@ async function createDevice(ownerId: string, deviceId: string) {
 	});
 }
 
-async function createEnvelope(message, sender, recipient, messageId: string) {
+const testAttachmentStorageId = 'QmYwAPJzv5CZsnAzt8auVZRnGi9iS3hBghG9V1sA9j3z2H';
+const testUnownedAttachmentStorageId = 'QmPChd2hVbrJ6i4y6XvYxQm8Y8hWgX9kL4nR7tV2cD5fEa';
+
+async function createEnvelope(message, sender, recipient, messageId: string, metadata?) {
 	return browserE2eeHelper.encryptEnvelope(
 		message,
 		[recipient.publicBundle],
@@ -151,24 +206,32 @@ async function createEnvelope(message, sender, recipient, messageId: string) {
 		{
 			messageId,
 			conversationId: 'conversation-1',
-			createdAt: '2026-07-28T00:01:00.000Z'
+			createdAt: '2026-07-28T00:01:00.000Z',
+			metadata
 		}
 	);
 }
 
-function createChatHarness() {
+function createChatHarness(options: any = {}) {
 	const rows = {
 		devices: [],
 		heads: [],
 		events: [],
+		attachments: [],
 		recipients: [],
-		receipts: []
+		receipts: [],
+		contents: options.contents || []
 	};
 	const models = createModels(rows);
 	const app: any = {
 		checkUserCan: async () => true,
 		ms: {
 			database: {
+				getContentByStorageIdListAndUserId: async (storageIds, userId) => {
+					return rows.contents.filter(content =>
+						content.userId === userId && storageIds.includes(content.storageId)
+					);
+				},
 				getUser: async userId => ({
 					id: userId,
 					storageAccountId: userId === 1 ? 'owner-alice' : 'owner-bob'
@@ -247,6 +310,10 @@ function createModels(rows) {
 		ChatEventRecipient: {
 			bulkCreate: async records => records.map(record => addRow(rows.recipients, record)),
 			destroy: async () => clearRows(rows.recipients)
+		},
+		ChatEventAttachment: {
+			bulkCreate: async records => records.map(record => addRow(rows.attachments, record)),
+			destroy: async () => clearRows(rows.attachments)
 		},
 		ChatEventReceipt: {
 			findOrCreate: async ({where, defaults}) => {

--- a/test/storageReferenceHelpersUnit.test.ts
+++ b/test/storageReferenceHelpersUnit.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import {Op} from 'sequelize';
+import {countDerivedStorageIdReferences} from '../app/modules/database/storageReferenceHelpers.js';
+
+describe('storage reference helpers', () => {
+	it('counts storage reference sources registered by product modules', async () => {
+		const storageId = 'attachment-storage-id';
+		const referenceModel = {
+			count: async ({where}) => {
+				assert.deepEqual(where[Op.or], [{storageId}]);
+				return 2;
+			}
+		};
+
+		const count = await countDerivedStorageIdReferences(
+			{},
+			{models: {}},
+			storageId,
+			{},
+			[{model: referenceModel, columns: ['storageId']}]
+		);
+
+		assert.equal(count, 2);
+	});
+});


### PR DESCRIPTION
## Summary

- validate that attachment ciphertext CIDs belong to the authenticated sender before accepting a new encrypted chat event
- persist event-to-attachment references transactionally and include module-owned references in shared deletion safety
- reject duplicate attachment CIDs and advance the secure-chat implemented/TODO documents

## Why

Chat envelopes already allowed attachment storage IDs, but the node did not verify ownership or retain a durable reference. Content cleanup could therefore orphan a queued encrypted message before the recipient fetched it.

## Validation

- 23 non-PostgreSQL chat, delivery, reconciliation, API, transport, and storage-reference tests pass
- deterministic TODO section listing and secure-chat context generation pass
- `git diff --check` passes
- PostgreSQL integration coverage was added, but the local integration run could not start because the configured `geesome` database password does not match the running PostgreSQL instance
- the repository-wide TypeScript check remains unavailable because the installed TypeScript version cannot parse the existing `es2023`/Node16 project configuration and current dependency declarations
