### PR TITLE
Pin encrypted chat attachments before acknowledgement

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -37,6 +37,7 @@ export default {
     deliveryWorkerIntervalMs: process.env.CHAT_DELIVERY_WORKER_INTERVAL_MS,
     deliveryWorkerLimit: process.env.CHAT_DELIVERY_WORKER_LIMIT,
     deliveryClaimTtlMs: process.env.CHAT_DELIVERY_CLAIM_TTL_MS,
+    attachmentPinTimeoutMs: process.env.CHAT_ATTACHMENT_PIN_TIMEOUT_MS,
     reconciliationWorker: process.env.CHAT_RECONCILIATION_WORKER === '1',
     reconciliationWorkerIntervalMs: process.env.CHAT_RECONCILIATION_WORKER_INTERVAL_MS,
     reconciliationWorkerLimit: process.env.CHAT_RECONCILIATION_WORKER_LIMIT,

--- a/app/modules/chat/api.ts
+++ b/app/modules/chat/api.ts
@@ -32,11 +32,12 @@ export default function registerChatApi(app: IGeesomeApp, chat: IGeesomeChatModu
 	 * @api {post} /v1/chat/inbox Receive encrypted inter-node event
 	 * @apiName ReceiveEncryptedChatDelivery
 	 * @apiGroup Chat
-	 * @apiDescription Verifies the sender static-identity signature, browser device signature, encrypted envelope, destination owner, and active local recipient key before idempotently storing ciphertext. Returns a recipient-identity-signed acknowledgement.
+	 * @apiDescription Verifies the sender static-identity signature, browser device signature, encrypted envelope, destination owner, and active local recipient key. Referenced encrypted attachment objects are recursively fetched and pinned before the event is idempotently stored and a recipient-identity-signed acknowledgement is returned.
 	 * @apiBody {Object} delivery Signed `geesome-chat-delivery-v1` payload.
 	 * @apiSuccess {String} deliveryId Stable delivery identifier.
 	 * @apiSuccess {String} acceptedSequence Recipient node sequence.
 	 * @apiSuccess {Object} signature Recipient static-identity signature.
+	 * @apiError (503) AttachmentUnavailable Referenced attachment ciphertext could not be fetched and pinned; the sender may retry delivery.
 	 */
 	app.ms.api.onPost('chat/inbox', async (req, res) => {
 		return res.send(await chat.acceptRemoteDelivery(req.body.delivery));

--- a/app/modules/chat/attachmentStorage.ts
+++ b/app/modules/chat/attachmentStorage.ts
@@ -1,0 +1,58 @@
+import type IGeesomeStorageModule from '../storage/interface.js';
+
+const defaultAttachmentPinTimeoutMs = 10 * 1000;
+const maximumAttachmentPinTimeoutMs = 12 * 1000;
+
+export async function pinRemoteChatAttachments(
+	storage: IGeesomeStorageModule,
+	storageIds: string[],
+	options: {timeoutMs?: number} = {}
+) {
+	const timeoutMs = parseAttachmentPinTimeout(options.timeoutMs);
+	if (!storageIds.length) {
+		return;
+	}
+	let activeStorageId = storageIds[0];
+	let timedOut = false;
+	const pinAll = async () => {
+		for (const storageId of storageIds) {
+			if (timedOut) {
+				return;
+			}
+			activeStorageId = storageId;
+			await storage.addPin(storageId);
+		}
+	};
+	let timeout;
+	try {
+		await Promise.race([
+			pinAll(),
+			new Promise((_resolve, reject) => {
+				timeout = setTimeout(() => {
+					timedOut = true;
+					reject(new Error('chat_attachment_pin_timeout'));
+				}, timeoutMs);
+			})
+		]);
+	} catch {
+		throw createAttachmentFetchError(activeStorageId);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function parseAttachmentPinTimeout(value): number {
+	const parsed = Number(value);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return defaultAttachmentPinTimeoutMs;
+	}
+	return Math.min(Math.floor(parsed), maximumAttachmentPinTimeoutMs);
+}
+
+function createAttachmentFetchError(storageId: string) {
+	const error: any = new Error('chat_attachment_fetch_failed');
+	error.code = 503;
+	error.retryable = true;
+	error.storageId = storageId;
+	return error;
+}

--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -16,6 +16,15 @@ receiving node verifies that identity, the browser device bundle, and the
 encrypted envelope before storing it. The recipient signs the acknowledgement
 with its own static-account key.
 
+Encrypted attachment objects remain opaque content-addressed bytes. The sender
+accepts only attachment CIDs owned by the authenticated user and keeps durable
+event references so cleanup cannot orphan queued delivery. The recipient
+recursively fetches and pins every referenced CID before committing the remote
+event and signing its acknowledgement. Missing or stalled pins return a
+retryable service error. `CHAT_ATTACHMENT_PIN_TIMEOUT_MS` can lower the
+whole attachment-batch deadline; it is capped below the sender's HTTPS request
+timeout so stalled IPFS operations cannot hold delivery indefinitely.
+
 One database delivery row is maintained per event and remote recipient owner.
 Claims use `FOR UPDATE SKIP LOCKED`, failed attempts are released with bounded
 exponential backoff, and the optional interval worker retries recipients that
@@ -62,10 +71,10 @@ regress repair work. The following environment variables tune the bounded worker
 - `CHAT_RECONCILIATION_MAX_PAGES`
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
-direct-message send/read UX are present in `geesome-ui`. Remaining chat work
-includes explicit device trust verification, group membership and key rotation,
-encrypted attachment lifecycle, retention/quota policy, and real multi-node
-browser e2e coverage.
+direct-message send/read UX and explicit device trust verification are present
+in `geesome-ui`. Remaining chat work includes browser attachment
+encryption/decryption UX, group membership and key rotation, retention/quota
+policy, and real multi-node browser e2e coverage.
 
 See [Reliable IPFS Chat Research](../../../../docs/ipfs-chat-reliability-research.md)
 for the transport and delivery analysis behind these boundaries.

--- a/app/modules/chat/index.ts
+++ b/app/modules/chat/index.ts
@@ -44,6 +44,7 @@ import {
 	verifyChatDelivery
 } from './transport.js';
 import {buildChatPublicNodeInfoResponse} from './publicNodeInfo.js';
+import {pinRemoteChatAttachments} from './attachmentStorage.js';
 
 const maxDeviceBundleBytes = 64 * 1024;
 const maxEnvelopeBytes = 1024 * 1024;
@@ -368,6 +369,10 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 				throw chatError('chat_delivery_recipient_device_not_found', 404);
 			}
 
+			const attachmentStorageIds = getAttachmentStorageIds(envelope);
+			await pinRemoteChatAttachments(app.ms.storage, attachmentStorageIds, {
+				timeoutMs: app.config.chatConfig?.attachmentPinTimeoutMs
+			});
 			const eventHash = getEventHash(envelope);
 			const existing = await models.ChatEvent.findOne({
 				where: {messageId: envelope.messageId}
@@ -729,6 +734,14 @@ async function createRemoteChatEvent(
 			userId: localUsersByKey.get(recipient.keyId) || null,
 			ownerId: recipient.ownerId,
 			keyId: recipient.keyId
+		})),
+		{transaction}
+	);
+	await models.ChatEventAttachment.bulkCreate(
+		getAttachmentStorageIds(envelope).map(storageId => ({
+			chatEventId: event.id,
+			contentId: null,
+			storageId
 		})),
 		{transaction}
 	);

--- a/app/modules/storage/interface.ts
+++ b/app/modules/storage/interface.ts
@@ -30,6 +30,8 @@ export default interface IGeesomeStorageModule {
 
   getFileDataText(filePath): Promise<any>;
 
+  addPin(hash): Promise<any>;
+
   unPin(hash, options?): Promise<any>;
 
   remove(hash, options?): Promise<any>;

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -214,6 +214,11 @@ TODO.
   stores normalized event-to-storage references, and registers them with the
   shared deletion-safety scanner so queued events cannot be orphaned by content
   cleanup.
+- Recipient nodes recursively fetch and pin every referenced attachment
+  ciphertext DAG before committing the remote event and signing its delivery
+  acknowledgement. Missing or unavailable objects return a retryable service
+  failure, and stalled IPFS pins are bounded below the sender request timeout,
+  so the sender queue cannot report a false delivery and will retry.
 - Authenticated HTTPS delivery has durable retry leases, bounded backoff,
   recipient-signed acknowledgements, source-head comparison, signed missing-range
   repair, and an opt-in bounded reconciliation worker.
@@ -226,6 +231,6 @@ TODO.
   sequence/head reconciliation as the correctness boundary.
 
 This is a browser-first encrypted direct-message foundation, not completion of
-production-secure chat. Recipient-side attachment fetch/pin acknowledgement,
-browser attachment UX, reviewed group membership/key rotation, retention/quota
-policy, and real two-node browser testing remain in the active TODO.
+production-secure chat. Browser attachment encryption and decryption UX,
+reviewed group membership/key rotation, retention/quota policy, and real
+two-node browser testing remain in the active TODO.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -111,11 +111,9 @@ Current safety boundary:
 
 Remaining delivery order:
 
-1. Complete encrypted attachments. Sender-side ownership checks and durable
-   event-to-storage references are implemented. Next, make the recipient fetch,
-   verify, persist, and pin every ciphertext object before signing delivery
-   acknowledgement; surface missing or corrupt objects as retryable delivery
-   failures. Then add browser encryption before upload, wrapped content-key
+1. Complete encrypted attachments. Sender-side ownership and retention checks,
+   durable event-to-storage references, and recipient fetch/pin-before-ack are
+   implemented. Next, add browser encryption before upload, wrapped content-key
    descriptors inside the encrypted envelope, authenticated download/decryption,
    previews, corruption behavior, deletion, quota, retry, and retention without
    exposing plaintext, original file metadata, or keys to the node.

--- a/test/chatAttachmentStorage.test.ts
+++ b/test/chatAttachmentStorage.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert';
+import {pinRemoteChatAttachments} from '../app/modules/chat/attachmentStorage.js';
+
+describe('chat attachment storage', () => {
+	it('awaits every remote ciphertext pin before returning', async () => {
+		const pinned = [];
+		const storage: any = {
+			addPin: async storageId => {
+				pinned.push(storageId);
+			}
+		};
+
+		await pinRemoteChatAttachments(storage, ['first-cid', 'second-cid']);
+
+		assert.deepEqual(pinned, ['first-cid', 'second-cid']);
+	});
+
+	it('returns a retryable service error when a ciphertext cannot be pinned', async () => {
+		const storage: any = {
+			addPin: async () => {
+				throw new Error('ipfs object unavailable');
+			}
+		};
+
+		await assert.rejects(
+			() => pinRemoteChatAttachments(storage, ['missing-cid']),
+			(error: any) => {
+				assert.equal(error.message, 'chat_attachment_fetch_failed');
+				assert.equal(error.code, 503);
+				assert.equal(error.retryable, true);
+				assert.equal(error.storageId, 'missing-cid');
+				return true;
+			}
+		);
+	});
+
+	it('bounds the whole attachment batch below the delivery request timeout', async () => {
+		const storage: any = {
+			addPin: async () => new Promise(() => {})
+		};
+		const startedAt = Date.now();
+
+		await assert.rejects(
+			() => pinRemoteChatAttachments(storage, ['stalled-cid'], {timeoutMs: 5}),
+			/chat_attachment_fetch_failed/
+		);
+
+		assert.ok(Date.now() - startedAt < 1000);
+	});
+});

--- a/test/chatIntegration.test.ts
+++ b/test/chatIntegration.test.ts
@@ -168,7 +168,8 @@ describe('chat persistence', function () {
 			aliceDevice,
 			{
 				messageId: 'postgres-remote-message-1',
-				conversationId: 'postgres-remote-conversation'
+				conversationId: 'postgres-remote-conversation',
+				metadata: {attachmentStorageIds: [testAttachmentStorageId]}
 			}
 		);
 		const aliceTransportKey = await app.ms.accountStorage.getAccountPeerId(
@@ -195,7 +196,17 @@ describe('chat persistence', function () {
 			publicKey: aliceTransportPublicKey,
 			sign: async data => Buffer.from(await aliceTransportKey.privKey.sign(data))
 		});
-		const acknowledgement = await app.ms.chat.acceptRemoteDelivery(delivery);
+		const pinnedAttachmentStorageIds = [];
+		const addPin = app.ms.storage.addPin.bind(app.ms.storage);
+		app.ms.storage.addPin = async storageId => {
+			pinnedAttachmentStorageIds.push(storageId);
+		};
+		let acknowledgement;
+		try {
+			acknowledgement = await app.ms.chat.acceptRemoteDelivery(delivery);
+		} finally {
+			app.ms.storage.addPin = addPin;
+		}
 		const remoteEventHash = getEnvelopeHash(remoteEnvelope);
 		await verifyChatAcknowledgement(acknowledgement, {
 			deliveryId,
@@ -212,6 +223,12 @@ describe('chat persistence', function () {
 		assert.equal(remoteEvents.list[0].state, 'received_remote');
 		assert.equal(remoteEvents.list[0].sourceSequence, '15');
 		assert.equal(JSON.stringify(remoteEvents.list[0]).includes('remote transport secret'), false);
+		assert.deepEqual(pinnedAttachmentStorageIds, [testAttachmentStorageId]);
+		assert.equal(
+			(await app.ms.database.countStorageIdReferences(testAttachmentStorageId))
+				.derivedStorageRefs,
+			1
+		);
 
 		const firstReconciliation = await app.ms.chat.reconcileConversation(
 			bob.id,


### PR DESCRIPTION
## Summary

- recursively fetch and pin every remote encrypted attachment CID before committing its chat event or signing acknowledgement
- bound the whole pin batch below the sender transport timeout and return retryable 503 on missing or stalled IPFS objects
- persist recipient-side attachment references and document the completed availability boundary

## Why

The recipient previously acknowledged encrypted events without proving that referenced attachment ciphertext was available locally. A sender could therefore stop retrying while the recipient had only the envelope and a missing CID.

## Validation

- 26 focused chat, delivery, reconciliation, API, transport, and storage-reference tests pass
- rebuilt Docker image: chat attachment helper and PostgreSQL chat persistence tests pass, 5 total
- API docs generation, security route inventory, deterministic TODO listing/context, and `git diff --check` pass
- the broad Docker suite passed all chat coverage, including the new integration test; 9 unrelated Kubo-heavy app/static-site/storage tests timed out during the 29-minute run, and a targeted rerun reproduced those existing storage-operation stalls
