### PR TITLE
Ship browser-encrypted chat attachments

### DIFF
--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -72,9 +72,12 @@ regress repair work. The following environment variables tune the bounded worker
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
 direct-message send/read UX and explicit device trust verification are present
-in `geesome-ui`. Remaining chat work includes browser attachment
-encryption/decryption UX, group membership and key rotation, retention/quota
-policy, and real multi-node browser e2e coverage.
+in `geesome-ui`. The browser also encrypts attachment bytes before upload, keeps
+private attachment descriptors inside the encrypted envelope, authenticates
+downloaded ciphertext before preview/download, and preserves the text-only
+envelope for rolling compatibility. Remaining chat work includes attachment
+deletion, quota, abandoned-upload cleanup, and retention policy, group membership
+and key rotation, and real multi-node browser e2e coverage.
 
 See [Reliable IPFS Chat Research](../../../../docs/ipfs-chat-reliability-research.md)
 for the transport and delivery analysis behind these boundaries.

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -207,6 +207,12 @@ TODO.
   reads ordered sequence pages, exposes delivery/setup states, and lets users
   compare stable fingerprints, verify devices, review key changes, and distinguish
   unverified, verified, changed, and revoked devices.
+- `geesome-ui` encrypts attachment bytes before upload, sends only generic
+  ciphertext files to the node, and keeps original names, media types, IVs, and
+  content keys inside the encrypted message payload. Recipients fetch ciphertext
+  on demand, authenticate it before rendering, preview only safe raster formats,
+  and can retry failed integrity/download attempts. Text-only messages retain the
+  older UTF-8 envelope shape for rolling frontend compatibility.
 - `geesome-node` registers only public device bundles and persists only signed
   opaque envelopes plus routing, sequence, receipt, and delivery metadata.
 - Outgoing encrypted-attachment references are accepted only when every
@@ -231,6 +237,6 @@ TODO.
   sequence/head reconciliation as the correctness boundary.
 
 This is a browser-first encrypted direct-message foundation, not completion of
-production-secure chat. Browser attachment encryption and decryption UX,
-reviewed group membership/key rotation, retention/quota policy, and real
-two-node browser testing remain in the active TODO.
+production-secure chat. Attachment deletion, quota, abandoned-upload cleanup,
+and retention policy, reviewed group membership/key rotation, and real two-node
+browser testing remain in the active TODO.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -113,10 +113,12 @@ Remaining delivery order:
 
 1. Complete encrypted attachments. Sender-side ownership and retention checks,
    durable event-to-storage references, and recipient fetch/pin-before-ack are
-   implemented. Next, add browser encryption before upload, wrapped content-key
-   descriptors inside the encrypted envelope, authenticated download/decryption,
-   previews, corruption behavior, deletion, quota, retry, and retention without
-   exposing plaintext, original file metadata, or keys to the node.
+   implemented. Browsers now encrypt before upload, keep wrapped content-key
+   descriptors inside the encrypted envelope, authenticate downloads, render
+   safe raster previews, report corruption, and reuse successful uploads when
+   event submission is retried. Next, define deletion, quota, abandoned-upload
+   cleanup, and retention policy without exposing plaintext, original file
+   metadata, or keys to the node.
 2. Select and review the group protocol before extending pairwise envelopes.
    Define membership epochs and rotate future-message keys when members/devices
    are added, removed, replaced, or revoked. Evaluate MLS, Matrix-style

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@geesome/ui": "https://github.com/galtproject/geesome-ui#78421dc",
+    "@geesome/ui": "https://github.com/galtproject/geesome-ui#4c155e9",
     "@revoinc/async-busboy": "^2.0.3",
     "apidoc": "^1.2.0",
     "apidoc-plugin-ts": "git+https://github.com/MicrowaveDev/apidoc-plugin-ts.git#afc63f1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,9 +1236,9 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@geesome/ui@https://github.com/galtproject/geesome-ui#78421dc":
+"@geesome/ui@https://github.com/galtproject/geesome-ui#4c155e9":
   version "0.1.0"
-  resolved "https://github.com/galtproject/geesome-ui#78421dc742255afe242ef7e5254eed65f6e5e92f"
+  resolved "https://github.com/galtproject/geesome-ui#4c155e933bfdb916671e04f0b9f19a3243aaa8dd"
 
 "@helia/bitswap@^3.2.3":
   version "3.2.3"


### PR DESCRIPTION
## Summary

- pin the packaged frontend to the merged browser-encrypted attachment implementation
- ship ciphertext-only attachment upload, authenticated browser download, and safe raster previews
- move delivered behavior into implemented documentation while keeping deletion, quota, cleanup, and retention work open

## Validation

- `yarn install --no-optional --ignore-scripts`
- verified installed `@geesome/ui` contains `encryptedChatAttachments.ts`
- `npm run test:frontend-dist-publish`
- `npm run todo:sections`
- `npm run todo:context -- browser-first-chat-e2ee`
- `docker build --target frontend-build --progress=plain -t geesome-node-frontend-chat-test .`

The exact merged UI revision was separately validated with its 13 browser E2E scenarios and a Node 18 production build before this consumer pin.