### PR TITLE
Bound encrypted chat attachment admission

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -38,6 +38,8 @@ export default {
     deliveryWorkerLimit: process.env.CHAT_DELIVERY_WORKER_LIMIT,
     deliveryClaimTtlMs: process.env.CHAT_DELIVERY_CLAIM_TTL_MS,
     attachmentPinTimeoutMs: process.env.CHAT_ATTACHMENT_PIN_TIMEOUT_MS,
+    maxAttachmentBytes: process.env.CHAT_MAX_ATTACHMENT_BYTES,
+    maxEventAttachmentBytes: process.env.CHAT_MAX_EVENT_ATTACHMENT_BYTES,
     reconciliationWorker: process.env.CHAT_RECONCILIATION_WORKER === '1',
     reconciliationWorkerIntervalMs: process.env.CHAT_RECONCILIATION_WORKER_INTERVAL_MS,
     reconciliationWorkerLimit: process.env.CHAT_RECONCILIATION_WORKER_LIMIT,

--- a/app/modules/chat/api.ts
+++ b/app/modules/chat/api.ts
@@ -126,6 +126,7 @@ export default function registerChatApi(app: IGeesomeApp, chat: IGeesomeChatModu
 	 * @apiBody {String} [recipientEndpoints.inboxUrl] Public HTTPS GeeSome chat inbox.
 	 * @apiSuccess {Object} event Stored opaque event and assigned sequence.
 	 * @apiSuccess {Boolean} replay Whether the same message was already accepted.
+	 * @apiError (413) AttachmentTooLarge A referenced ciphertext file or the combined attachment bytes exceed the configured chat limits.
 	 */
 	app.ms.api.onAuthorizedPost('chat/events', async (req, res) => {
 		return res.send(await chat.acceptEncryptedEvent(req.user.id, req.body.envelope, {

--- a/app/modules/chat/attachmentStorage.ts
+++ b/app/modules/chat/attachmentStorage.ts
@@ -2,19 +2,40 @@ import type IGeesomeStorageModule from '../storage/interface.js';
 
 const defaultAttachmentPinTimeoutMs = 10 * 1000;
 const maximumAttachmentPinTimeoutMs = 12 * 1000;
+const defaultMaximumAttachmentBytes = 25 * 1024 * 1024;
+const defaultMaximumEventAttachmentBytes = 100 * 1024 * 1024;
+
+export interface IChatAttachmentLimits {
+	maxAttachmentBytes?: number;
+	maxEventAttachmentBytes?: number;
+}
 
 export async function pinRemoteChatAttachments(
 	storage: IGeesomeStorageModule,
 	storageIds: string[],
-	options: {timeoutMs?: number} = {}
+	options: {timeoutMs?: number} & IChatAttachmentLimits = {}
 ) {
 	const timeoutMs = parseAttachmentPinTimeout(options.timeoutMs);
+	const limits = getChatAttachmentLimits(options);
 	if (!storageIds.length) {
 		return;
 	}
 	let activeStorageId = storageIds[0];
 	let timedOut = false;
+	let totalBytes = 0;
 	const pinAll = async () => {
+		for (const storageId of storageIds) {
+			if (timedOut) {
+				return;
+			}
+			activeStorageId = storageId;
+			const stat = await storage.getFileStat(storageId);
+			if (stat?.size === undefined || stat?.size === null) {
+				throw new Error('chat_attachment_stat_missing');
+			}
+			const size = parseAttachmentSize(stat?.size);
+			totalBytes = assertChatAttachmentSize(storageId, size, totalBytes, limits);
+		}
 		for (const storageId of storageIds) {
 			if (timedOut) {
 				return;
@@ -34,11 +55,43 @@ export async function pinRemoteChatAttachments(
 				}, timeoutMs);
 			})
 		]);
-	} catch {
+	} catch (error) {
+		if (isChatAttachmentQuotaError(error)) {
+			throw error;
+		}
 		throw createAttachmentFetchError(activeStorageId);
 	} finally {
 		clearTimeout(timeout);
 	}
+}
+
+export function assertOwnedChatAttachmentQuota(
+	contents: Array<{storageId?: string; size?: number | string}>,
+	options: IChatAttachmentLimits = {}
+) {
+	const limits = getChatAttachmentLimits(options);
+	let totalBytes = 0;
+	for (const content of contents) {
+		const storageId = String(content.storageId || '');
+		const size = parseAttachmentSize(content.size);
+		totalBytes = assertChatAttachmentSize(storageId, size, totalBytes, limits);
+	}
+	return totalBytes;
+}
+
+export function getChatAttachmentLimits(
+	options: IChatAttachmentLimits = {}
+) {
+	return {
+		maxAttachmentBytes: parsePositiveByteLimit(
+			options.maxAttachmentBytes,
+			defaultMaximumAttachmentBytes
+		),
+		maxEventAttachmentBytes: parsePositiveByteLimit(
+			options.maxEventAttachmentBytes,
+			defaultMaximumEventAttachmentBytes
+		)
+	};
 }
 
 function parseAttachmentPinTimeout(value): number {
@@ -47,6 +100,50 @@ function parseAttachmentPinTimeout(value): number {
 		return defaultAttachmentPinTimeoutMs;
 	}
 	return Math.min(Math.floor(parsed), maximumAttachmentPinTimeoutMs);
+}
+
+function parsePositiveByteLimit(value, fallback: number): number {
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+		return fallback;
+	}
+	return parsed;
+}
+
+function parseAttachmentSize(value): number {
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed < 0) {
+		throw createAttachmentQuotaError('', 'chat_attachment_size_invalid');
+	}
+	return parsed;
+}
+
+function assertChatAttachmentSize(
+	storageId: string,
+	size: number,
+	currentTotalBytes: number,
+	limits: {maxAttachmentBytes: number; maxEventAttachmentBytes: number}
+): number {
+	if (size > limits.maxAttachmentBytes) {
+		throw createAttachmentQuotaError(storageId, 'chat_attachment_too_large');
+	}
+	const totalBytes = currentTotalBytes + size;
+	if (!Number.isSafeInteger(totalBytes) || totalBytes > limits.maxEventAttachmentBytes) {
+		throw createAttachmentQuotaError(storageId, 'chat_attachment_quota_exceeded');
+	}
+	return totalBytes;
+}
+
+function createAttachmentQuotaError(storageId: string, message: string) {
+	const error: any = new Error(message);
+	error.code = 413;
+	error.retryable = false;
+	error.storageId = storageId || undefined;
+	return error;
+}
+
+function isChatAttachmentQuotaError(error): boolean {
+	return error?.code === 413 && error?.retryable === false;
 }
 
 function createAttachmentFetchError(storageId: string) {

--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -69,6 +69,8 @@ regress repair work. The following environment variables tune the bounded worker
 - `CHAT_RECONCILIATION_CONTINUATION_DELAY_MS`
 - `CHAT_RECONCILIATION_PAGE_LIMIT`
 - `CHAT_RECONCILIATION_MAX_PAGES`
+- `CHAT_MAX_ATTACHMENT_BYTES`
+- `CHAT_MAX_EVENT_ATTACHMENT_BYTES`
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
 direct-message send/read UX and explicit device trust verification are present
@@ -76,8 +78,16 @@ in `geesome-ui`. The browser also encrypts attachment bytes before upload, keeps
 private attachment descriptors inside the encrypted envelope, authenticates
 downloaded ciphertext before preview/download, and preserves the text-only
 envelope for rolling compatibility. Remaining chat work includes attachment
-deletion, quota, abandoned-upload cleanup, and retention policy, group membership
-and key rotation, and real multi-node browser e2e coverage.
+deletion, aggregate quota, abandoned-upload cleanup, and retention policy, group
+membership and key rotation, and real multi-node browser e2e coverage.
+
+Attachment admission is bounded without inspecting plaintext. Local events use
+the sender-owned `Content.size`, while remote deliveries resolve the ciphertext
+size before pinning. The default limits are 25 MiB per attachment and 100 MiB
+across one event. Operators can override them with
+`CHAT_MAX_ATTACHMENT_BYTES` and `CHAT_MAX_EVENT_ATTACHMENT_BYTES`. Objects that
+cannot be resolved return a retryable service error; objects over either limit
+return a permanent `413` and are not pinned or stored as chat events.
 
 See [Reliable IPFS Chat Research](../../../../docs/ipfs-chat-reliability-research.md)
 for the transport and delivery analysis behind these boundaries.

--- a/app/modules/chat/index.ts
+++ b/app/modules/chat/index.ts
@@ -44,7 +44,10 @@ import {
 	verifyChatDelivery
 } from './transport.js';
 import {buildChatPublicNodeInfoResponse} from './publicNodeInfo.js';
-import {pinRemoteChatAttachments} from './attachmentStorage.js';
+import {
+	assertOwnedChatAttachmentQuota,
+	pinRemoteChatAttachments
+} from './attachmentStorage.js';
 
 const maxDeviceBundleBytes = 64 * 1024;
 const maxEnvelopeBytes = 1024 * 1024;
@@ -238,6 +241,7 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 				userId,
 				attachmentStorageIds
 			);
+			assertOwnedChatAttachmentQuota(attachmentContents, getAttachmentLimits(app));
 
 			try {
 				const result = await app.ms.database.sequelize.transaction(async transaction => {
@@ -371,7 +375,8 @@ export function getModule(app: IGeesomeApp, models, options: any = {}): IGeesome
 
 			const attachmentStorageIds = getAttachmentStorageIds(envelope);
 			await pinRemoteChatAttachments(app.ms.storage, attachmentStorageIds, {
-				timeoutMs: app.config.chatConfig?.attachmentPinTimeoutMs
+				timeoutMs: app.config.chatConfig?.attachmentPinTimeoutMs,
+				...getAttachmentLimits(app)
 			});
 			const eventHash = getEventHash(envelope);
 			const existing = await models.ChatEvent.findOne({
@@ -1151,6 +1156,13 @@ function isSafeEnvelopeMetadata(metadata): boolean {
 
 function getAttachmentStorageIds(envelope): string[] {
 	return envelope.metadata?.attachmentStorageIds || [];
+}
+
+function getAttachmentLimits(app: IGeesomeApp) {
+	return {
+		maxAttachmentBytes: app.config?.chatConfig?.maxAttachmentBytes,
+		maxEventAttachmentBytes: app.config?.chatConfig?.maxEventAttachmentBytes
+	};
 }
 
 async function getOwnedAttachmentContents(

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -220,6 +220,10 @@ TODO.
   stores normalized event-to-storage references, and registers them with the
   shared deletion-safety scanner so queued events cannot be orphaned by content
   cleanup.
+- Configurable ciphertext admission limits reject oversized local attachments
+  before event persistence and resolve remote ciphertext sizes before pinning.
+  Defaults cap one attachment at 25 MiB and one event at 100 MiB; unavailable
+  ciphertext remains retryable while quota rejection is a permanent `413`.
 - Recipient nodes recursively fetch and pin every referenced attachment
   ciphertext DAG before committing the remote event and signing its delivery
   acknowledgement. Missing or unavailable objects return a retryable service
@@ -237,6 +241,7 @@ TODO.
   sequence/head reconciliation as the correctness boundary.
 
 This is a browser-first encrypted direct-message foundation, not completion of
-production-secure chat. Attachment deletion, quota, abandoned-upload cleanup,
-and retention policy, reviewed group membership/key rotation, and real two-node
-browser testing remain in the active TODO.
+production-secure chat. Attachment deletion, aggregate per-account lifecycle
+quota, abandoned-upload cleanup, and retention policy, reviewed group
+membership/key rotation, and real two-node browser testing remain in the active
+TODO.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -116,9 +116,11 @@ Remaining delivery order:
    implemented. Browsers now encrypt before upload, keep wrapped content-key
    descriptors inside the encrypted envelope, authenticate downloads, render
    safe raster previews, report corruption, and reuse successful uploads when
-   event submission is retried. Next, define deletion, quota, abandoned-upload
-   cleanup, and retention policy without exposing plaintext, original file
-   metadata, or keys to the node.
+   event submission is retried. Configurable byte admission now caps individual
+   ciphertext files and combined event attachments before local persistence or
+   remote pinning. Next, define deletion, aggregate per-account lifecycle quota,
+   abandoned-upload cleanup, and retention policy without exposing plaintext,
+   original file metadata, or keys to the node.
 2. Select and review the group protocol before extending pairwise envelopes.
    Define membership epochs and rotate future-message keys when members/devices
    are added, removed, replaced, or revoked. Evaluate MLS, Matrix-style

--- a/test/chatAttachmentStorage.test.ts
+++ b/test/chatAttachmentStorage.test.ts
@@ -1,10 +1,16 @@
 import assert from 'node:assert';
-import {pinRemoteChatAttachments} from '../app/modules/chat/attachmentStorage.js';
+import {
+	assertOwnedChatAttachmentQuota,
+	pinRemoteChatAttachments
+} from '../app/modules/chat/attachmentStorage.js';
 
 describe('chat attachment storage', () => {
 	it('awaits every remote ciphertext pin before returning', async () => {
 		const pinned = [];
 		const storage: any = {
+			getFileStat: async storageId => ({
+				size: storageId === 'first-cid' ? 10 : 20
+			}),
 			addPin: async storageId => {
 				pinned.push(storageId);
 			}
@@ -17,6 +23,7 @@ describe('chat attachment storage', () => {
 
 	it('returns a retryable service error when a ciphertext cannot be pinned', async () => {
 		const storage: any = {
+			getFileStat: async () => ({size: 10}),
 			addPin: async () => {
 				throw new Error('ipfs object unavailable');
 			}
@@ -36,6 +43,7 @@ describe('chat attachment storage', () => {
 
 	it('bounds the whole attachment batch below the delivery request timeout', async () => {
 		const storage: any = {
+			getFileStat: async () => new Promise(() => {}),
 			addPin: async () => new Promise(() => {})
 		};
 		const startedAt = Date.now();
@@ -46,5 +54,62 @@ describe('chat attachment storage', () => {
 		);
 
 		assert.ok(Date.now() - startedAt < 1000);
+	});
+
+	it('rejects oversized remote ciphertext before pinning it', async () => {
+		const pinned = [];
+		const storage: any = {
+			getFileStat: async () => ({size: 11}),
+			addPin: async storageId => pinned.push(storageId)
+		};
+
+		await assert.rejects(
+			() => pinRemoteChatAttachments(storage, ['large-cid'], {
+				maxAttachmentBytes: 10,
+				maxEventAttachmentBytes: 20
+			}),
+			(error: any) => {
+				assert.equal(error.message, 'chat_attachment_too_large');
+				assert.equal(error.code, 413);
+				assert.equal(error.retryable, false);
+				assert.equal(error.storageId, 'large-cid');
+				return true;
+			}
+		);
+		assert.deepEqual(pinned, []);
+	});
+
+	it('preflights the combined remote quota before pinning any ciphertext', async () => {
+		const pinned = [];
+		const storage: any = {
+			getFileStat: async () => ({size: 7}),
+			addPin: async storageId => pinned.push(storageId)
+		};
+
+		await assert.rejects(
+			() => pinRemoteChatAttachments(storage, ['first-cid', 'second-cid'], {
+				maxAttachmentBytes: 10,
+				maxEventAttachmentBytes: 12
+			}),
+			/chat_attachment_quota_exceeded/
+		);
+		assert.deepEqual(pinned, []);
+	});
+
+	it('enforces the combined ciphertext quota for local attachments', () => {
+		assert.throws(
+			() => assertOwnedChatAttachmentQuota([
+				{storageId: 'first-cid', size: '7'},
+				{storageId: 'second-cid', size: 6}
+			], {
+				maxAttachmentBytes: 10,
+				maxEventAttachmentBytes: 12
+			}),
+			(error: any) => {
+				assert.equal(error.message, 'chat_attachment_quota_exceeded');
+				assert.equal(error.storageId, 'second-cid');
+				return true;
+			}
+		);
 	});
 });

--- a/test/chatIntegration.test.ts
+++ b/test/chatIntegration.test.ts
@@ -197,7 +197,12 @@ describe('chat persistence', function () {
 			sign: async data => Buffer.from(await aliceTransportKey.privKey.sign(data))
 		});
 		const pinnedAttachmentStorageIds = [];
+		const getFileStat = app.ms.storage.getFileStat.bind(app.ms.storage);
 		const addPin = app.ms.storage.addPin.bind(app.ms.storage);
+		app.ms.storage.getFileStat = async storageId => {
+			assert.equal(storageId, testAttachmentStorageId);
+			return {size: 32};
+		};
 		app.ms.storage.addPin = async storageId => {
 			pinnedAttachmentStorageIds.push(storageId);
 		};
@@ -205,6 +210,7 @@ describe('chat persistence', function () {
 		try {
 			acknowledgement = await app.ms.chat.acceptRemoteDelivery(delivery);
 		} finally {
+			app.ms.storage.getFileStat = getFileStat;
 			app.ms.storage.addPin = addPin;
 		}
 		const remoteEventHash = getEnvelopeHash(remoteEnvelope);

--- a/test/chatModule.test.ts
+++ b/test/chatModule.test.ts
@@ -69,7 +69,7 @@ describe('chat module', () => {
 
 	it('retains only attachment ciphertext owned by the authenticated sender', async () => {
 		const {chat, rows} = createChatHarness({
-			contents: [{id: 7, userId: 1, storageId: testAttachmentStorageId}]
+			contents: [{id: 7, userId: 1, storageId: testAttachmentStorageId, size: 32}]
 		});
 		const alice = await createDevice('owner-alice', 'alice-browser');
 		const bob = await createDevice('owner-bob', 'bob-browser');
@@ -117,6 +117,34 @@ describe('chat module', () => {
 			/encrypted_envelope_fields_invalid/
 		);
 		assert.equal(rows.events.length, 1);
+	});
+
+	it('rejects sender-owned ciphertext that exceeds configured chat limits', async () => {
+		const {chat, rows} = createChatHarness({
+			contents: [{id: 7, userId: 1, storageId: testAttachmentStorageId, size: 33}],
+			chatConfig: {
+				maxAttachmentBytes: 32,
+				maxEventAttachmentBytes: 64
+			}
+		});
+		const alice = await createDevice('owner-alice', 'alice-browser');
+		const bob = await createDevice('owner-bob', 'bob-browser');
+		await chat.registerDevice(1, alice.publicBundle);
+		await chat.registerDevice(2, bob.publicBundle);
+		const envelope = await createEnvelope(
+			'encrypted attachment descriptor',
+			alice,
+			bob,
+			'message-oversized-attachment',
+			{attachmentStorageIds: [testAttachmentStorageId]}
+		);
+
+		await assert.rejects(
+			() => chat.acceptEncryptedEvent(1, envelope),
+			/chat_attachment_too_large/
+		);
+		assert.equal(rows.events.length, 0);
+		assert.equal(rows.attachments.length, 0);
 	});
 
 	it('rejects revoked sender and locally known recipient devices', async () => {
@@ -224,6 +252,9 @@ function createChatHarness(options: any = {}) {
 	};
 	const models = createModels(rows);
 	const app: any = {
+		config: {
+			chatConfig: options.chatConfig || {}
+		},
 		checkUserCan: async () => true,
 		ms: {
 			database: {


### PR DESCRIPTION
## Summary

- enforce configurable ciphertext limits before local chat event persistence
- preflight every remote attachment size before pinning any object in the event
- preserve retryable `503` behavior for unavailable ciphertext while returning permanent `413` quota errors
- document the 25 MiB per-file and 100 MiB per-event defaults and narrow the remaining lifecycle TODO

## Validation

- focused chat protocol suite: 16 passing
- `npm run generate-docs`
- `npm run security:route-inventory:update`
- `npm run security:route-inventory`
- `npm run todo:sections`
- `npm run todo:context -- browser-first-chat-e2ee`
- `npm run test:docker`: 596 passing, 11 pending

The first Docker run exposed a synthetic attachment fixture that mocked pinning but not the new stat preflight. The fixture now mocks the full storage boundary, and the complete Docker suite passes.