### PR TITLE
Gate encrypted attachment cleanup on release and delivery

### DIFF
--- a/app/modules/chat/api.ts
+++ b/app/modules/chat/api.ts
@@ -182,20 +182,23 @@ export default function registerChatApi(app: IGeesomeApp, chat: IGeesomeChatModu
 	);
 
 	/**
-	 * @api {post} /v1/admin/chat/attachments/cleanup Clean abandoned encrypted chat uploads
+	 * @api {post} /v1/admin/chat/attachments/cleanup Clean retained encrypted chat attachments
 	 * @apiName CleanupEncryptedChatAttachments
 	 * @apiGroup Chat
 	 * @apiUse ApiKey
 	 * @apiUse AuthErrors
 	 * @apiPermission AdminAll
 	 * @apiBody {Number} [limit=25] Maximum lifecycle rows to process, capped at 100.
+	 * @apiBody {Number} [attachmentReleasedRetentionMs=604800000] Minimum time after release before committed ciphertext becomes cleanup-eligible.
 	 * @apiSuccess {Number} processed Lifecycle rows processed.
-	 * @apiSuccess {Number} cleaned Uploads tombstoned and queued for reference-safe storage removal.
-	 * @apiSuccess {Number} blocked Uploads retained because another content reference still exists.
+	 * @apiSuccess {Number} cleaned Uploads or fully released event attachments tombstoned and queued for reference-safe storage removal.
+	 * @apiSuccess {Number} blocked Rows retained because a participant has not released or delivery is not acknowledged.
+	 * @apiSuccess {Number} releasedCleaned Fully released event attachments detached and queued for reference-safe storage removal.
+	 * @apiSuccess {Number} releasedBlocked Released event attachments retained by participant or delivery gates.
 	 * @apiSuccess {Number} reconciled Uploads repaired to attached state from an accepted event reference.
 	 * @apiSuccess {Number} pruned Expired cleanup audit rows removed.
 	 * @apiSuccess {Number} failed Rows left retryable after a cleanup failure.
-	 * @apiDescription Uses configured retention windows unless explicit operator overrides are supplied. Plaintext names, MIME types, attachment keys, and message bodies are never read.
+	 * @apiDescription Uses configured retention windows unless explicit operator overrides are supplied. Committed ciphertext is detached only after every local participant releases it and every required outbound delivery has a signed acknowledgement. Plaintext names, MIME types, attachment keys, and message bodies are never read.
 	 */
 	app.ms.api.onAuthorizedPost(
 		'admin/chat/attachments/cleanup',

--- a/app/modules/chat/attachmentCleanup.ts
+++ b/app/modules/chat/attachmentCleanup.ts
@@ -1,6 +1,8 @@
 import {Op} from 'sequelize';
 import type {IGeesomeApp} from '../../interface.js';
 import {ChatAttachmentUploadState} from './attachmentLifecycle.js';
+import {cleanupReleasedChatEventAttachments} from './releasedAttachmentCleanup.js';
+import {queueChatAttachmentStorageRemoval} from './attachmentStorageRemoval.js';
 
 const defaultAbandonedRetentionMs = 7 * 24 * 60 * 60 * 1000;
 const defaultCancelledRetentionMs = 60 * 60 * 1000;
@@ -57,6 +59,22 @@ export async function cleanupChatAttachmentUploads(
 			result.failed += 1;
 		}
 	}
+	const releasedCleanup = await cleanupReleasedChatEventAttachments(
+		app,
+		models,
+		{
+			...options,
+			limit: Math.max(0, limit - result.processed)
+		}
+	);
+	result.processed += releasedCleanup.processed;
+	result.cleaned += releasedCleanup.cleaned;
+	result.blocked += releasedCleanup.blocked;
+	result.failed += releasedCleanup.failed;
+	Object.assign(result, {
+		releasedCleaned: releasedCleanup.cleaned,
+		releasedBlocked: releasedCleanup.blocked
+	});
 	return result;
 }
 
@@ -270,30 +288,6 @@ function getChatAttachmentCleanupCutoffs(now: Date, policy) {
 		claim: new Date(now.getTime() - policy.cleanupClaimTtlMs),
 		record: new Date(now.getTime() - policy.cleanupRecordRetentionMs)
 	};
-}
-
-async function queueChatAttachmentStorageRemoval(
-	app: IGeesomeApp,
-	userId: number,
-	storageId,
-	options
-) {
-	if (!storageId) {
-		return;
-	}
-	const storageSpace = app.ms['storageSpace'];
-	if (storageSpace?.queueStorageObjectRemoval) {
-		await storageSpace.queueStorageObjectRemoval(userId, null, storageId, {
-			process: options.processStorageRemoval !== false
-		});
-		return;
-	}
-	const deleteSafety = await app.ms.database.getStorageObjectDeleteSafety(storageId);
-	if (!deleteSafety.safeToRemovePhysical) {
-		return;
-	}
-	await app.ms.storage.unPin(storageId).catch(() => null);
-	await app.ms.storage.remove(storageId).catch(() => null);
 }
 
 function getDate(value): Date {

--- a/app/modules/chat/attachmentRetention.ts
+++ b/app/modules/chat/attachmentRetention.ts
@@ -3,8 +3,14 @@ import type {IGeesomeApp} from '../../interface.js';
 import {CorePermissionName} from '../database/interface.js';
 
 export enum ChatEventAttachmentRetentionState {
-	Released = 'released'
+	Released = 'released',
+	CleanupPending = 'cleanup_pending',
+	CleanupQueued = 'cleanup_queued'
 }
+
+export const chatEventAttachmentReleasedStates = Object.values(
+	ChatEventAttachmentRetentionState
+);
 
 export async function releaseChatEventAttachment(
 	app: IGeesomeApp,
@@ -36,6 +42,18 @@ export async function releaseChatEventAttachment(
 			!await canUserAccessChatEvent(models, event, userId, transaction)
 		) {
 			throw retentionError('event_not_found', 404);
+		}
+		const existingRelease = await models.ChatEventAttachmentRetention.findOne({
+			where: {
+				chatEventId: event.id,
+				storageId: normalizedStorageId,
+				userId
+			},
+			transaction,
+			lock: transaction.LOCK.UPDATE
+		});
+		if (existingRelease) {
+			return serializeChatEventAttachmentRelease(event, existingRelease);
 		}
 		const attachment = await models.ChatEventAttachment.findOne({
 			where: {
@@ -81,7 +99,7 @@ export async function getReleasedChatEventAttachments(
 		where: {
 			userId,
 			chatEventId: {[Op.in]: chatEventIds},
-			state: ChatEventAttachmentRetentionState.Released
+			state: {[Op.in]: chatEventAttachmentReleasedStates}
 		},
 		order: [['id', 'ASC']]
 	});
@@ -111,7 +129,7 @@ function serializeChatEventAttachmentRelease(event, release) {
 	return {
 		messageId: event.messageId,
 		storageId: release.storageId,
-		state: release.state,
+		state: ChatEventAttachmentRetentionState.Released,
 		releasedAt: release.releasedAt
 	};
 }

--- a/app/modules/chat/attachmentStorageRemoval.ts
+++ b/app/modules/chat/attachmentStorageRemoval.ts
@@ -1,0 +1,25 @@
+import type {IGeesomeApp} from '../../interface.js';
+
+export async function queueChatAttachmentStorageRemoval(
+	app: IGeesomeApp,
+	userId: number,
+	storageId,
+	options: any = {}
+) {
+	if (!storageId) {
+		return;
+	}
+	const storageSpace = app.ms['storageSpace'];
+	if (storageSpace?.queueStorageObjectRemoval) {
+		await storageSpace.queueStorageObjectRemoval(userId, null, storageId, {
+			process: options.processStorageRemoval !== false
+		});
+		return;
+	}
+	const deleteSafety = await app.ms.database.getStorageObjectDeleteSafety(storageId);
+	if (!deleteSafety.safeToRemovePhysical) {
+		return;
+	}
+	await app.ms.storage.unPin(storageId).catch(() => null);
+	await app.ms.storage.remove(storageId).catch(() => null);
+}

--- a/app/modules/chat/releasedAttachmentCleanup.ts
+++ b/app/modules/chat/releasedAttachmentCleanup.ts
@@ -1,0 +1,306 @@
+import {Op} from 'sequelize';
+import type {IGeesomeApp} from '../../interface.js';
+import {ChatDeliveryState} from './interface.js';
+import {
+	ChatEventAttachmentRetentionState,
+	chatEventAttachmentReleasedStates
+} from './attachmentRetention.js';
+import {queueChatAttachmentStorageRemoval} from './attachmentStorageRemoval.js';
+
+const defaultReleasedRetentionMs = 7 * 24 * 60 * 60 * 1000;
+
+export async function cleanupReleasedChatEventAttachments(
+	app: IGeesomeApp,
+	models,
+	options: any = {}
+) {
+	const limit = Number(options.limit || 0);
+	if (!Number.isSafeInteger(limit) || limit <= 0) {
+		return {processed: 0, cleaned: 0, blocked: 0, failed: 0};
+	}
+	const now = getDate(options.now);
+	const cleanupOptions = {
+		...app.config?.chatConfig,
+		...options
+	};
+	const releasedRetentionMs = parseNonNegativeInteger(
+		cleanupOptions.attachmentReleasedRetentionMs,
+		defaultReleasedRetentionMs
+	);
+	const candidates = await getReleasedAttachmentCleanupCandidates(
+		models,
+		new Date(now.getTime() - releasedRetentionMs),
+		limit
+	);
+	const result = {processed: 0, cleaned: 0, blocked: 0, failed: 0};
+	for (const candidate of candidates) {
+		try {
+			const outcome = await cleanupReleasedAttachmentCandidate(
+				app,
+				models,
+				candidate,
+				now,
+				cleanupOptions
+			);
+			if (outcome === 'skipped') {
+				continue;
+			}
+			result.processed += 1;
+			result[outcome] += 1;
+		} catch (_error) {
+			result.processed += 1;
+			result.failed += 1;
+		}
+	}
+	return result;
+}
+
+async function getReleasedAttachmentCleanupCandidates(
+	models,
+	releasedBefore: Date,
+	limit: number
+) {
+	const retentions = await models.ChatEventAttachmentRetention.findAll({
+		where: {
+			[Op.or]: [
+				{
+					state: ChatEventAttachmentRetentionState.Released,
+					releasedAt: {[Op.lte]: releasedBefore}
+				},
+				{state: ChatEventAttachmentRetentionState.CleanupPending}
+			]
+		},
+		order: [['updatedAt', 'ASC'], ['id', 'ASC']],
+		limit
+	});
+	const candidates = new Map<string, {chatEventId: number; storageId: string}>();
+	for (const retention of retentions) {
+		const key = `${retention.chatEventId}\0${retention.storageId}`;
+		if (!candidates.has(key)) {
+			candidates.set(key, {
+				chatEventId: retention.chatEventId,
+				storageId: retention.storageId
+			});
+		}
+	}
+	return [...candidates.values()];
+}
+
+async function cleanupReleasedAttachmentCandidate(
+	app: IGeesomeApp,
+	models,
+	candidate,
+	now: Date,
+	options
+) {
+	const claim = await app.ms.database.sequelize.transaction(async transaction => {
+		const event = await models.ChatEvent.findByPk(candidate.chatEventId, {
+			transaction,
+			lock: transaction.LOCK.UPDATE
+		});
+		if (!event) {
+			return {outcome: 'skipped'};
+		}
+		const retentions = await models.ChatEventAttachmentRetention.findAll({
+			where: {
+				chatEventId: candidate.chatEventId,
+				storageId: candidate.storageId,
+				state: {[Op.in]: chatEventAttachmentReleasedStates}
+			},
+			transaction,
+			lock: transaction.LOCK.UPDATE
+		});
+		const participantUserIds = await getLocalParticipantUserIds(
+			models,
+			event,
+			transaction
+		);
+		if (!hasEveryParticipantReleased(participantUserIds, retentions)) {
+			await deferRetentionCleanup(models, candidate, now, transaction);
+			return {outcome: 'blocked'};
+		}
+		if (!await areRequiredDeliveriesAcknowledged(
+			models,
+			event,
+			transaction
+		)) {
+			await deferRetentionCleanup(models, candidate, now, transaction);
+			return {outcome: 'blocked'};
+		}
+		const attachment = await models.ChatEventAttachment.findOne({
+			where: {
+				chatEventId: event.id,
+				storageId: candidate.storageId
+			},
+			transaction,
+			lock: transaction.LOCK.UPDATE
+		});
+		const contentId = attachment?.contentId || retentions[0]?.contentId || null;
+		const content = contentId
+			? await app.ms.database.models.Content.findByPk(contentId, {
+				transaction,
+				lock: transaction.LOCK.UPDATE
+			})
+			: null;
+		if (content && content.isDeleted !== true) {
+			const [otherEventAttachments, deleteSafety] = await Promise.all([
+				countOtherEventAttachmentContentReferences(
+					models,
+					attachment,
+					content.id,
+					transaction
+				),
+				app.ms.database.getContentDeleteSafety(content)
+			]);
+			if (
+				otherEventAttachments === 0 &&
+				deleteSafety?.safeToDestroyContent
+			) {
+				await content.update({
+					isDeleted: true,
+					deletedAt: now
+				}, {transaction});
+			}
+		}
+		await models.ChatEventAttachmentRetention.update({
+			state: ChatEventAttachmentRetentionState.CleanupPending
+		}, {
+			where: {
+				chatEventId: event.id,
+				storageId: candidate.storageId,
+				state: {[Op.in]: chatEventAttachmentReleasedStates}
+			},
+			transaction
+		});
+		if (attachment) {
+			await attachment.destroy({transaction});
+		}
+		return {
+			outcome: 'claimed',
+			userId: Number(content?.userId || participantUserIds[0]),
+			storageId: candidate.storageId
+		};
+	});
+	if (claim.outcome !== 'claimed') {
+		return claim.outcome;
+	}
+	await queueChatAttachmentStorageRemoval(
+		app,
+		claim.userId,
+		claim.storageId,
+		options
+	);
+	await models.ChatEventAttachmentRetention.update({
+		state: ChatEventAttachmentRetentionState.CleanupQueued
+	}, {
+		where: {
+			chatEventId: candidate.chatEventId,
+			storageId: candidate.storageId,
+			state: ChatEventAttachmentRetentionState.CleanupPending
+		}
+	});
+	return 'cleaned';
+}
+
+function countOtherEventAttachmentContentReferences(
+	models,
+	attachment,
+	contentId: number,
+	transaction
+) {
+	const where: any = {contentId};
+	if (attachment?.id) {
+		where.id = {[Op.ne]: attachment.id};
+	}
+	return models.ChatEventAttachment.count({where, transaction});
+}
+
+async function getLocalParticipantUserIds(models, event, transaction) {
+	const recipients = await models.ChatEventRecipient.findAll({
+		attributes: ['userId'],
+		where: {
+			chatEventId: event.id,
+			userId: {[Op.ne]: null}
+		},
+		transaction,
+		lock: transaction.LOCK.UPDATE
+	});
+	return [...new Set([
+		event.senderUserId,
+		...recipients.map(recipient => recipient.userId)
+	]
+		.filter(userId => userId !== null && userId !== undefined)
+		.map(Number)
+	)].sort((left, right) => left - right);
+}
+
+function hasEveryParticipantReleased(participantUserIds, retentions) {
+	if (!participantUserIds.length) {
+		return false;
+	}
+	const releasedUserIds = new Set(retentions.map(retention =>
+		Number(retention.userId)
+	));
+	return participantUserIds.every(userId => releasedUserIds.has(userId));
+}
+
+async function areRequiredDeliveriesAcknowledged(models, event, transaction) {
+	const remoteRecipients = await models.ChatEventRecipient.findAll({
+		attributes: ['ownerId'],
+		where: {
+			chatEventId: event.id,
+			userId: null
+		},
+		transaction,
+		lock: transaction.LOCK.UPDATE
+	});
+	const deliveries = await models.ChatDelivery.findAll({
+		where: {chatEventId: event.id},
+		transaction,
+		lock: transaction.LOCK.UPDATE
+	});
+	const acknowledgedOwnerIds = new Set(deliveries
+		.filter(delivery =>
+			delivery.state === ChatDeliveryState.Delivered &&
+			Boolean(delivery.deliveredAt) &&
+			delivery.acknowledgedSequence !== null &&
+			delivery.acknowledgedSequence !== undefined
+		)
+		.map(delivery => delivery.recipientOwnerId)
+	);
+	return deliveries.every(delivery =>
+		delivery.state === ChatDeliveryState.Delivered &&
+		Boolean(delivery.deliveredAt) &&
+		delivery.acknowledgedSequence !== null &&
+		delivery.acknowledgedSequence !== undefined
+	) && remoteRecipients.every(recipient =>
+		acknowledgedOwnerIds.has(recipient.ownerId)
+	);
+}
+
+function deferRetentionCleanup(models, candidate, now: Date, transaction) {
+	return models.ChatEventAttachmentRetention.update({
+		updatedAt: now
+	}, {
+		where: {
+			chatEventId: candidate.chatEventId,
+			storageId: candidate.storageId,
+			state: {[Op.in]: chatEventAttachmentReleasedStates}
+		},
+		transaction,
+		silent: true
+	});
+}
+
+function getDate(value): Date {
+	const date = value instanceof Date ? value : new Date(value || Date.now());
+	if (!Number.isFinite(date.getTime())) {
+		throw new Error('chat_attachment_cleanup_time_invalid');
+	}
+	return date;
+}
+
+function parseNonNegativeInteger(value, fallback: number): number {
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -10,7 +10,7 @@ Current unfinished work lives in [todo.md](./todo.md). Detailed design and
 operational notes remain in their dedicated documents and module-local `docs`
 directories.
 
-Last consolidated: 2026-07-29.
+Last consolidated: 2026-07-30.
 
 ## Runtime And Test Foundation
 
@@ -240,6 +240,12 @@ TODO.
   participant and overlays released ciphertext IDs on that user's encrypted
   event reads. Release does not rewrite the signed event or prematurely remove
   the shared reference needed by another participant, retry, or repair.
+- The browser exposes confirmed per-attachment release without removing the
+  signed message event. A recoverable node lifecycle waits for every distinct
+  local participant, every required signed delivery acknowledgement, and a
+  configurable retention window before tombstoning dedicated ciphertext
+  content, detaching the event reference, and delegating physical removal to the
+  shared reference-safe queue.
 - Recipient nodes recursively fetch and pin every referenced attachment
   ciphertext DAG before committing the remote event and signing its delivery
   acknowledgement. Missing or unavailable objects return a retryable service
@@ -257,6 +263,6 @@ TODO.
   sequence/head reconciliation as the correctness boundary.
 
 This is a browser-first encrypted direct-message foundation, not completion of
-production-secure chat. Browser attachment-release controls, delivery-gated
-physical retention cleanup, reviewed group membership/key rotation, and real
-two-node browser testing remain in the active TODO.
+production-secure chat. Reviewed group membership/key rotation, real two-node
+browser testing, explicit operator policy, and legacy-path retirement remain in
+the active TODO.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -111,35 +111,14 @@ Current safety boundary:
 
 Remaining delivery order:
 
-1. Complete encrypted attachments. Sender-side ownership and retention checks,
-   durable event-to-storage references, and recipient fetch/pin-before-ack are
-   implemented. Browsers now encrypt before upload, keep wrapped content-key
-   descriptors inside the encrypted envelope, authenticate downloads, render
-   safe raster previews, report corruption, and reuse successful uploads when
-   event submission is retried. Configurable byte admission now caps individual
-   ciphertext files and combined event attachments before local persistence or
-   remote pinning. The node now has expiring, count/byte-bounded upload
-   reservations that bind ciphertext content through the existing upload hook
-   and transition to attached state with event acceptance. Browsers now reserve
-   exact ciphertext bytes and reuse successful uploads across event retries.
-   Bounded cleanup expires unbound reservations, tombstones cancelled and
-   abandoned uploads after explicit retention windows, reconciles event-linked
-   rows, and delegates physical deletion to the reference-safe storage queue.
-   The node now records idempotent committed-attachment release intent per
-   participant and overlays released ciphertext IDs on that user's event reads
-   without changing the signed envelope or shared reference. Next, expose that
-   release action in the browser, then add bounded physical cleanup only after
-   every local participant released the attachment and every required outbound
-   delivery was acknowledged. Neither step may expose plaintext, original file
-   metadata, or keys to the node.
-2. Select and review the group protocol before extending pairwise envelopes.
+1. Select and review the group protocol before extending pairwise envelopes.
    Define membership epochs and rotate future-message keys when members/devices
    are added, removed, replaced, or revoked. Evaluate MLS, Matrix-style
    device/session handling, or another maintained browser-capable protocol.
-3. Run real two-node browser tests across restart, temporary unreachability,
+2. Run real two-node browser tests across restart, temporary unreachability,
    duplicate/out-of-order delivery, bounded repair, revoked devices, and
    NAT/bootstrap/reciprocal-peering conditions.
-4. Define operator-visible queue/reconciliation metrics and explicit encrypted
+3. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old
    conversations as E2EE.

--- a/test/chatIntegration.test.ts
+++ b/test/chatIntegration.test.ts
@@ -567,6 +567,310 @@ describe('chat persistence', function () {
 		);
 	});
 
+	it('cleans committed ciphertext only after local releases and delivery acknowledgement', async () => {
+		const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: alice.storageAccountId,
+			deviceId: 'alice-cleanup-browser'
+		});
+		const bobDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: bob.storageAccountId,
+			deviceId: 'bob-cleanup-browser'
+		});
+		await app.ms.chat.registerDevice(alice.id, aliceDevice.publicBundle);
+		await app.ms.chat.registerDevice(bob.id, bobDevice.publicBundle);
+		const attachment = await app.ms.database.addContent({
+			userId: alice.id,
+			storageType: ContentStorageType.IPFS,
+			mimeType: 'application/octet-stream',
+			storageId: testAttachmentStorageId,
+			size: 32,
+			name: 'delivery-gated-encrypted-chat-attachment'
+		} as any);
+		const envelope = await browserE2eeHelper.encryptEnvelope(
+			JSON.stringify({text: '', attachments: [{storageId: testAttachmentStorageId}]}),
+			[bobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'postgres-attachment-cleanup-1',
+				conversationId: 'postgres-attachment-cleanup-conversation',
+				metadata: {attachmentStorageIds: [testAttachmentStorageId]}
+			}
+		);
+		const bobTransportPublicKey = await app.ms.accountStorage
+			.getStaticIdPublicKeyByOr(bob.storageAccountId);
+		await app.ms.chat.acceptEncryptedEvent(alice.id, envelope, {
+			recipientEndpoints: [{
+				ownerId: bob.storageAccountId,
+				publicKey: bobTransportPublicKey,
+				inboxUrl: 'https://recipient.example/v1/chat/inbox'
+			}]
+		});
+
+		await app.ms.chat.releaseEventAttachment(
+			alice.id,
+			envelope.messageId,
+			testAttachmentStorageId
+		);
+		const participantBlocked = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(participantBlocked.releasedBlocked, 1);
+		assert.equal(
+			await app.ms.database.sequelize.models.chatEventAttachment.count(),
+			1
+		);
+
+		await app.ms.chat.releaseEventAttachment(
+			bob.id,
+			envelope.messageId,
+			testAttachmentStorageId
+		);
+		const deliveryBlocked = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(deliveryBlocked.releasedBlocked, 1);
+		assert.equal(
+			await app.ms.database.sequelize.models.chatEventAttachment.count(),
+			1
+		);
+
+		await app.ms.database.sequelize.models.chatDelivery.update({
+			state: 'delivered',
+			deliveredAt: new Date(),
+			acknowledgedSequence: 1,
+			acknowledgedHeadSequence: 1
+		}, {
+			where: {recipientOwnerId: bob.storageAccountId}
+		});
+		const cleaned = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(cleaned.releasedCleaned, 1);
+		assert.equal(
+			await app.ms.database.sequelize.models.chatEventAttachment.count(),
+			0
+		);
+		assert.equal(
+			(await app.ms.database.getContent(attachment.id, {includeDeleted: true}))
+				.isDeleted,
+			true
+		);
+		const retentionStates = await app.ms.database.sequelize.models
+			.chatEventAttachmentRetention.findAll({
+				attributes: ['state'],
+				order: [['id', 'ASC']]
+			});
+		assert.deepEqual(
+			retentionStates.map(retention => retention.state),
+			['cleanup_queued', 'cleanup_queued']
+		);
+		const queue = await app.ms.database.sequelize.models.userOperationQueue.findOne({
+			where: {module: 'storage-space-storage-removal'}
+		});
+		assert.ok(queue);
+		assert.equal(
+			JSON.parse(queue.inputJson).storageId,
+			testAttachmentStorageId
+		);
+		const aliceEvents = await app.ms.chat.getEncryptedEvents(
+			alice.id,
+			envelope.conversationId
+		);
+		const bobEvents = await app.ms.chat.getEncryptedEvents(
+			bob.id,
+			envelope.conversationId
+		);
+		assert.deepEqual(
+			aliceEvents.list[0].releasedAttachmentStorageIds,
+			[testAttachmentStorageId]
+		);
+		assert.deepEqual(
+			bobEvents.list[0].releasedAttachmentStorageIds,
+			[testAttachmentStorageId]
+		);
+		const replay = await app.ms.chat.releaseEventAttachment(
+			alice.id,
+			envelope.messageId,
+			testAttachmentStorageId
+		);
+		assert.equal(replay.state, 'released');
+	});
+
+	it('keeps released ciphertext until every remote recipient has a delivery row', async () => {
+		const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: alice.storageAccountId,
+			deviceId: 'alice-remote-cleanup-browser'
+		});
+		const remoteBobDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: bob.storageAccountId,
+			deviceId: 'bob-remote-cleanup-browser'
+		});
+		await app.ms.chat.registerDevice(alice.id, aliceDevice.publicBundle);
+		const attachment = await app.ms.database.addContent({
+			userId: alice.id,
+			storageType: ContentStorageType.IPFS,
+			mimeType: 'application/octet-stream',
+			storageId: testAttachmentStorageId,
+			size: 32,
+			name: 'remote-delivery-gated-chat-attachment'
+		} as any);
+		const envelope = await browserE2eeHelper.encryptEnvelope(
+			JSON.stringify({text: '', attachments: [{storageId: testAttachmentStorageId}]}),
+			[remoteBobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'postgres-remote-attachment-cleanup-1',
+				conversationId: 'postgres-remote-attachment-cleanup-conversation',
+				metadata: {attachmentStorageIds: [testAttachmentStorageId]}
+			}
+		);
+		await app.ms.chat.acceptEncryptedEvent(alice.id, envelope);
+		await app.ms.chat.releaseEventAttachment(
+			alice.id,
+			envelope.messageId,
+			testAttachmentStorageId
+		);
+
+		const missingDelivery = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(missingDelivery.releasedBlocked, 1);
+		assert.equal(
+			await app.ms.database.sequelize.models.chatEventAttachment.count(),
+			1
+		);
+
+		const bobTransportPublicKey = await app.ms.accountStorage
+			.getStaticIdPublicKeyByOr(bob.storageAccountId);
+		await app.ms.chat.acceptEncryptedEvent(alice.id, envelope, {
+			recipientEndpoints: [{
+				ownerId: bob.storageAccountId,
+				publicKey: bobTransportPublicKey,
+				inboxUrl: 'https://recipient.example/v1/chat/inbox'
+			}]
+		});
+		const pendingDelivery = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(pendingDelivery.releasedBlocked, 1);
+
+		await app.ms.database.sequelize.models.chatDelivery.update({
+			state: 'delivered',
+			deliveredAt: new Date(),
+			acknowledgedSequence: 1,
+			acknowledgedHeadSequence: 1
+		}, {
+			where: {recipientOwnerId: bob.storageAccountId}
+		});
+		const cleaned = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(cleaned.releasedCleaned, 1);
+		assert.equal(
+			await app.ms.database.sequelize.models.chatEventAttachment.count(),
+			0
+		);
+		assert.equal(
+			(await app.ms.database.getContent(attachment.id, {includeDeleted: true}))
+				.isDeleted,
+			true
+		);
+	});
+
+	it('keeps ciphertext content active while another event still references it', async () => {
+		const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: alice.storageAccountId,
+			deviceId: 'alice-shared-cleanup-browser'
+		});
+		const bobDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: bob.storageAccountId,
+			deviceId: 'bob-shared-cleanup-browser'
+		});
+		await app.ms.chat.registerDevice(alice.id, aliceDevice.publicBundle);
+		await app.ms.chat.registerDevice(bob.id, bobDevice.publicBundle);
+		const attachment = await app.ms.database.addContent({
+			userId: alice.id,
+			storageType: ContentStorageType.IPFS,
+			mimeType: 'application/octet-stream',
+			storageId: testAttachmentStorageId,
+			size: 32,
+			name: 'shared-event-encrypted-chat-attachment'
+		} as any);
+		const envelopes = await Promise.all([1, 2].map(index =>
+			browserE2eeHelper.encryptEnvelope(
+				JSON.stringify({
+					text: '',
+					attachments: [{storageId: testAttachmentStorageId}]
+				}),
+				[bobDevice.publicBundle],
+				aliceDevice,
+				{
+					messageId: `postgres-shared-attachment-cleanup-${index}`,
+					conversationId: 'postgres-shared-attachment-cleanup-conversation',
+					metadata: {attachmentStorageIds: [testAttachmentStorageId]}
+				}
+			)
+		));
+		for (const envelope of envelopes) {
+			await app.ms.chat.acceptEncryptedEvent(alice.id, envelope);
+		}
+		await app.ms.chat.releaseEventAttachment(
+			alice.id,
+			envelopes[0].messageId,
+			testAttachmentStorageId
+		);
+		await app.ms.chat.releaseEventAttachment(
+			bob.id,
+			envelopes[0].messageId,
+			testAttachmentStorageId
+		);
+		const firstCleanup = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(firstCleanup.releasedCleaned, 1);
+		assert.equal(
+			await app.ms.database.sequelize.models.chatEventAttachment.count(),
+			1
+		);
+		assert.equal(
+			(await app.ms.database.getContent(attachment.id, {includeDeleted: true}))
+				.isDeleted,
+			false
+		);
+
+		await app.ms.chat.releaseEventAttachment(
+			alice.id,
+			envelopes[1].messageId,
+			testAttachmentStorageId
+		);
+		await app.ms.chat.releaseEventAttachment(
+			bob.id,
+			envelopes[1].messageId,
+			testAttachmentStorageId
+		);
+		const finalCleanup = await app.ms.chat.processAttachmentCleanup({
+			attachmentReleasedRetentionMs: 0,
+			processStorageRemoval: false
+		});
+		assert.equal(finalCleanup.releasedCleaned, 1);
+		assert.equal(
+			await app.ms.database.sequelize.models.chatEventAttachment.count(),
+			0
+		);
+		assert.equal(
+			(await app.ms.database.getContent(attachment.id, {includeDeleted: true}))
+				.isDeleted,
+			true
+		);
+	});
+
 	it('tombstones cancelled ciphertext and queues reference-safe physical cleanup', async () => {
 		const reservation = await app.ms.chat.createAttachmentUploadReservation(
 			alice.id,

--- a/test/chatModule.test.ts
+++ b/test/chatModule.test.ts
@@ -640,6 +640,9 @@ function createModels(rows) {
 			destroy: async () => clearRows(rows.attachments)
 		},
 		ChatEventAttachmentRetention: {
+			findOne: async ({where}) => rows.attachmentRetentions.find(
+				row => matchesWhere(row, where)
+			) || null,
 			findOrCreate: async ({where, defaults}) => {
 				let retention = rows.attachmentRetentions.find(
 					row => matchesWhere(row, where)


### PR DESCRIPTION
## Summary

- keep committed encrypted attachments until every local participant releases them and every remote recipient has a signed delivery acknowledgement
- add a recoverable `released` to `cleanup_pending` to `cleanup_queued` lifecycle before reference-safe physical removal
- preserve release overlays and idempotent release replay after the event attachment reference is detached
- rotate blocked candidates to avoid cleanup starvation and preserve ciphertext content reused by another event
- move the completed attachment lifecycle out of the active TODO and record it in implemented work

## Safety

The node never reads attachment plaintext, original names, MIME metadata, content keys, or message bodies. The existing storage-removal queue still performs final shared-reference checks before unpinning or deleting bytes.

## Validation

- `npm run test:docker` — 606 passing, 11 pending on the main implementation snapshot
- latest Docker image: `test/chatIntegration.test.ts` — 7 passing, including local release, missing/pending remote delivery, replay-after-cleanup, and shared-event ciphertext cases
- `test/chatModule.test.ts` — 12 passing
- `npm run generate-docs`
- `npm run security:route-inventory`
- `npm run todo:sections`