### PR TITLE
Select MLS for group chat E2EE

### DIFF
--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -87,8 +87,9 @@ direct-message send/read UX and explicit device trust verification are present
 in `geesome-ui`. The browser also encrypts attachment bytes before upload, keeps
 private attachment descriptors inside the encrypted envelope, authenticates
 downloaded ciphertext before preview/download, and preserves the text-only
-envelope for rolling compatibility. Remaining chat work includes attachment
-deletion, aggregate quota, abandoned-upload cleanup, and retention policy, group
+envelope for rolling compatibility. The node and browser implement reservation,
+release, abandoned-upload cleanup, and gated ciphertext deletion. Remaining
+chat work includes aggregate event quota and retention policy, MLS group
 membership and key rotation, and real multi-node browser e2e coverage.
 
 Attachment admission is bounded without inspecting plaintext. Local events use
@@ -137,4 +138,7 @@ and repair no longer depend on the ciphertext. A later bounded reconciliation
 step must enforce those gates before physical unpinning.
 
 See [Reliable IPFS Chat Research](../../../../docs/ipfs-chat-reliability-research.md)
-for the transport and delivery analysis behind these boundaries.
+for the transport and delivery analysis behind these boundaries. Group chat
+uses the separate
+[MLS protocol decision](../../../../docs/chat-group-e2ee-protocol-decision.md);
+the node remains an opaque delivery service and does not own MLS private state.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,4 +45,5 @@ can be used for the generated API page, this portal, and module docs.
 - [Database scalability review](./database-scalability-review.md)
 - [Group manifest IPLD scalability](./group-manifest-ipld-scalability.md)
 - [Reliable IPFS chat research](./ipfs-chat-reliability-research.md)
+- [Group chat E2EE protocol decision](./chat-group-e2ee-protocol-decision.md)
 - [Manifest examples](./manifests-example.md)

--- a/docs/agent-map.md
+++ b/docs/agent-map.md
@@ -51,6 +51,9 @@ Useful live endpoints:
   completion of production-secure group chat.
 - Read [Reliable IPFS Chat Research](./ipfs-chat-reliability-research.md) before
   changing chat storage, delivery, PubSub, peering, or browser transport.
+- Read [Group Chat E2EE Protocol Decision](./chat-group-e2ee-protocol-decision.md)
+  before changing group membership, device leaves, epoch ordering, MLS browser
+  state, KeyPackages, Welcome messages, or group-chat wire contracts.
 - Read `app/modules/chat/docs/overview.md` before changing device, envelope,
   delivery, acknowledgement, or reconciliation contracts.
 - Load the `browser-first-chat-e2ee` TODO section before chat implementation.

--- a/docs/chat-group-e2ee-protocol-decision.md
+++ b/docs/chat-group-e2ee-protocol-decision.md
@@ -1,0 +1,222 @@
+# Group Chat E2EE Protocol Decision
+
+Status: accepted architecture; browser implementation library remains gated by
+the compatibility spike below.
+
+## Decision
+
+GeeSome group chat will use Messaging Layer Security 1.0 (MLS), defined by
+[RFC 9420](https://www.rfc-editor.org/rfc/rfc9420.html), with the service split
+described by the
+[MLS architecture](https://www.rfc-editor.org/rfc/rfc9750.html).
+
+The initial interoperable profile is:
+
+- MLS protocol version 1.0;
+- `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (`0x0001`);
+- encrypted handshake messages after group creation;
+- BasicCredential values carrying the versioned GeeSome device binding;
+- external joins, pre-shared keys, group reinitialization, and custom MLS
+  extensions disabled until separately reviewed.
+
+Each browser device is a separate MLS client and group leaf. GeeSome account
+identity groups those devices for product UX and authorization, but devices do
+not share one MLS leaf or private state.
+
+GeeSome nodes provide the MLS Authentication Service and Delivery Service
+boundaries:
+
+- The Authentication Service validates the existing signed GeeSome device
+  bundle and binds its account ID, device ID, signing key, and bundle version to
+  an MLS credential.
+- The Delivery Service stores and routes opaque MLS messages, KeyPackages, and
+  recipient-specific Welcome messages. It sequences membership commits but
+  cannot decrypt application data or manufacture a valid browser credential.
+
+The existing signed append-only chat event log remains the durable transport.
+MLS replaces neither persistence nor delivery repair. PubSub, WebSockets, and
+communicator events remain optional wake-up hints.
+
+## Why MLS
+
+MLS provides the missing group primitive instead of extending direct-message
+recipient key wrapping into a custom group protocol:
+
+- membership changes advance an explicit cryptographic epoch;
+- adding and removing clients rotates future group secrets;
+- each device has independent credentials and state;
+- TreeKEM scales group updates without encrypting every message separately for
+  every recipient;
+- forward secrecy and post-compromise security have specified update behavior;
+- proposals, commits, Welcome messages, and application messages are typed
+  protocol objects that can remain opaque to the node.
+
+Matrix is an important operational reference for device verification,
+cross-device UX, durable synchronization, and withheld-key behavior. Embedding
+Matrix Olm/Megolm directly would also import Matrix room state, device-list,
+cross-signing, key-backup, and homeserver contracts that duplicate GeeSome's
+existing identity and event log. It is therefore not the selected wire protocol.
+
+A hand-built sender-key or pairwise-fanout group scheme is rejected. It would
+make GeeSome responsible for defining and reviewing membership agreement,
+concurrent updates, skipped-key handling, forward secrecy, and recovery.
+
+## Browser Implementation Gate
+
+[OpenMLS](https://openmls.tech/) is the provisional implementation candidate.
+It is maintained, implements MLS 1.0, supports WebAssembly, and exposes
+application-provided cryptography and storage boundaries. It is not accepted as
+a production dependency until a small browser spike proves all of the following:
+
+1. A pinned release builds for the browsers supported by `geesome-ui` without
+   Node cryptography or filesystem APIs.
+2. Two independent browser contexts can create a group, exchange application
+   messages, add a device, remove it, and process Welcome and Commit messages.
+3. Browser persistence can reload group state after a tab close and browser
+   restart, while old epoch secrets are deleted through the storage provider.
+4. The binding exposes the proposal, commit, pending-commit discard, export,
+   import, and error information needed by the ordering rules below.
+5. Serialized protocol values round-trip through a fixture shared by
+   `geesome-libs`, `geesome-ui`, and a node-side opaque framing validator. The
+   node verifies the outer device signature and public bounds, not MLS secrets.
+6. Bundle size, initialization latency, and message/update cost are recorded for
+   a direct chat, a small group, and a representative larger group.
+
+The spike may add a thin maintained GeeSome binding around OpenMLS. It must not
+reimplement MLS cryptography. If OpenMLS cannot satisfy these requirements,
+evaluate another RFC 9420 implementation against the same fixture before
+changing the protocol decision.
+
+## Identity And Device Rules
+
+- An MLS leaf represents exactly one registered, non-revoked GeeSome device.
+- The credential binds the canonical GeeSome account ID and device ID to the
+  device signing key. Clients verify this binding against the signed device
+  bundle, not against display names or node-provided labels.
+- Adding another device for the same account is a normal MLS Add operation and
+  advances the epoch.
+- Device replacement or revocation removes that device's leaf and commits a new
+  epoch. Removing an account removes every active leaf belonging to it.
+- A removed device can retain plaintext and old epoch secrets it already had.
+  It must not receive secrets for later epochs. The UI must not describe removal
+  as erasing previously delivered history.
+- A newly added device receives no earlier conversation history by default.
+  Historical transfer requires a later, explicit client-to-client encrypted
+  export design; the node must not reconstruct or escrow it.
+- Restoring an account creates a new device identity. Active MLS state is not
+  copied through server-readable recovery data. An authorized current member
+  must add the restored device.
+
+Browser storage contains sensitive MLS state. The implementation must use a
+dedicated local storage provider, avoid logs and exports of secret state, delete
+obsolete values when requested by the MLS library, and clear state on device
+removal/logout. Browser and storage-device behavior means physical secure
+erasure cannot be promised; the UI and security documentation must state the
+resulting forward-secrecy limitation accurately.
+
+## Membership Authorization
+
+MLS authenticates protocol participants but deliberately does not define who is
+allowed to change product membership. GeeSome therefore applies both checks:
+
+1. the MLS proposal/commit is cryptographically valid for the current epoch;
+2. the committing account/device is authorized by the signed GeeSome group
+   policy to perform every included Add, Remove, or Update.
+
+Only an authorized browser device creates and signs a membership commit. The
+node may reject unauthorized or stale commits, but it never rewrites a commit,
+adds a member automatically from a mutable database row, or creates MLS secrets.
+Database membership and MLS membership are reconciled as explicit, visible
+operations rather than silently forced into agreement.
+
+The first version uses the existing group owner/admin policy. More complex
+quorum or role rules require a versioned policy change before they affect MLS
+commit authorization.
+
+## Epoch And Ordering Rules
+
+- A group has one opaque MLS `group_id`, the selected profile above, and one
+  monotonically increasing epoch.
+- The canonical group node advertised by the signed group manifest serializes
+  membership commits with compare-and-set semantics on the expected epoch.
+- Exactly one valid commit can advance a given epoch. A competing commit receives
+  a conflict response; its browser discards pending state, synchronizes the
+  accepted commit, and rebuilds the intended change if it is still authorized.
+- Proposal events must be available before a commit that references them.
+  Recipient-specific Welcome messages are accepted only for the commit selected
+  for that epoch.
+- Application messages may arrive out of order within a bounded window. A
+  client buffers recoverable gaps and asks the existing durable sync path for
+  missing events. It does not advance through a missing membership commit.
+- Stale-epoch application messages are never re-encrypted by the node. Clients
+  may decrypt retained old-epoch messages only when their local MLS state allows
+  it; otherwise they expose a recoverable or permanently unavailable state.
+- Canonical-node failover and multi-writer commit consensus are deferred. An
+  unavailable canonical node delays membership changes instead of allowing
+  divergent epoch histories. Application events remain queued for durable
+  delivery.
+
+The canonical node is trusted for availability and commit ordering, not message
+confidentiality or authorship. Clients detect invalid commits and signed event
+gaps through normal MLS validation and GeeSome head reconciliation.
+
+## Opaque Event Contract
+
+The existing chat log will gain a versioned `geesome-mls-v1` payload family:
+
+- MLS application message;
+- proposal;
+- commit;
+- Welcome message addressed to one device;
+- KeyPackage publication/consumption metadata;
+- bounded synchronization checkpoint.
+
+Routing metadata is limited to what delivery requires: conversation and opaque
+group IDs, epoch, protocol object type, sender device, intended recipient for a
+Welcome message, sequence/head data, and ciphertext identity. Sensitive
+application metadata stays inside MLS application data. Metadata that must be
+visible and integrity-protected belongs in MLS authenticated data.
+
+GeeSome application data remains independently versioned and carries message
+ID, event type, body, reply/reaction relation, and encrypted attachment
+descriptors. Attachment bytes remain client-encrypted; their content keys are
+carried inside MLS-protected application data. A membership change does not
+retroactively re-encrypt old attachment objects.
+
+## Rollout And Compatibility
+
+1. Land the browser compatibility spike and shared fixtures without changing
+   production chat behavior.
+2. Add opaque node contracts for KeyPackages and MLS event kinds only after the
+   spike selects a pinned library/binding.
+3. Implement new MLS group conversations behind an explicit capability flag.
+4. Exercise add/remove/revoke, concurrent commits, restart, and delivery repair
+   in real two-browser/two-node tests.
+5. Enable MLS only for newly created group conversations at first.
+
+Direct-message `geesome-e2ee-v2` conversations are not silently converted.
+Legacy server-encrypted chats remain visibly legacy until explicitly retired.
+There is no plaintext or pairwise-envelope fallback when an MLS participant is
+unsupported or out of date.
+
+## Security Review Triggers
+
+Review this decision before enabling production group chat if any of these
+change:
+
+- MLS protocol version, cipher suite, implementation, or WASM binding;
+- device credential format or account recovery behavior;
+- group authorization or canonical commit-ordering policy;
+- browser persistence or secret-state export;
+- historical-message sharing;
+- server-visible routing metadata;
+- attachment key transport;
+- canonical-node failover or federated multi-writer membership.
+
+## Primary References
+
+- [RFC 9420: The Messaging Layer Security Protocol](https://www.rfc-editor.org/rfc/rfc9420.html)
+- [RFC 9750: The Messaging Layer Security Architecture](https://www.rfc-editor.org/rfc/rfc9750.html)
+- [OpenMLS WebAssembly guidance](https://book.openmls.tech/user_manual/wasm.html)
+- [OpenMLS persistence and forward-secrecy guidance](https://book.openmls.tech/user_manual/persistence.html)
+- [Matrix client-server and E2EE specification](https://spec.matrix.org/latest/client-server-api/)

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -261,8 +261,14 @@ TODO.
   guarantee delivery, recommends reciprocal peering only as a live connectivity
   aid, and defines persist-before-publish, remote acknowledgement, retry, and
   sequence/head reconciliation as the correctness boundary.
+- The group E2EE protocol review selects MLS 1.0 instead of extending pairwise
+  envelopes or embedding Matrix. It defines one MLS leaf per browser device,
+  signed GeeSome credential binding, explicit Add/Remove epoch changes,
+  application-level admin authorization, canonical compare-and-set commit
+  ordering, no automatic history sharing, opaque node transport, and a required
+  OpenMLS/WASM browser compatibility gate before implementation.
 
 This is a browser-first encrypted direct-message foundation, not completion of
-production-secure chat. Reviewed group membership/key rotation, real two-node
-browser testing, explicit operator policy, and legacy-path retirement remain in
-the active TODO.
+production-secure group chat. The browser MLS compatibility spike, real
+two-node browser testing, explicit operator policy, and legacy-path retirement
+remain in the active TODO.

--- a/docs/ipfs-chat-reliability-research.md
+++ b/docs/ipfs-chat-reliability-research.md
@@ -210,9 +210,10 @@ The direct-message foundation now follows the recommended correctness boundary:
 - Signed user manifests advertise canonical delivery, sync, and public-device
   discovery endpoints when configured.
 
-The remaining recommendations still apply to explicit device trust, encrypted
-attachments, retention and quota policy, a reviewed group membership/key-rotation
-protocol, and real multi-node browser/NAT/peering tests.
+The remaining recommendations now apply to the MLS browser compatibility gate,
+retention and aggregate quota policy, and real multi-node
+browser/NAT/peering tests. Device trust, encrypted attachment lifecycle, and the
+group protocol decision have moved into the implemented foundation.
 
 ## Recommended GeeSome Architecture
 
@@ -395,11 +396,11 @@ streams. Apply padding or batching only after measuring the threat and cost.
 ### Cryptographic protocol choice
 
 Do not turn the existing envelope experiment into a custom production group
-protocol without a focused review. Choose and document a maintained,
-browser-capable implementation of MLS, Matrix's established device/session
-model, or another reviewed protocol. The transport envelope should carry an
-opaque versioned protocol payload so the storage and sync layer does not depend
-on one cryptographic suite.
+protocol. The focused review selected MLS 1.0 and defined the browser, identity,
+membership, ordering, and rollout constraints in
+[Group Chat E2EE Protocol Decision](./chat-group-e2ee-protocol-decision.md).
+The transport envelope should carry an opaque versioned protocol payload so the
+storage and sync layer does not depend on one cryptographic suite.
 
 Required decisions include:
 

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -66,15 +66,17 @@ The same pattern should be kept for:
 
 The rule for API handlers should be: secrets may be accepted for creation/update and may be decrypted internally for outbound calls, but list/get responses should return only non-secret metadata plus explicit status fields.
 
-### Chat Encryption Is Not Real E2EE Yet
+### Direct Chat Is Browser-First E2EE; Group Chat Is Not Complete
 
-Backend encryption with app-held passphrases is useful only for at-rest protection against accidental database disclosure. It is not sufficient for confidential chat because the node can decrypt. The safe target remains:
+Legacy backend encryption with app-held passphrases remains only at-rest
+protection and must not be labelled E2EE. New direct conversations use
+browser-held device keys, signed opaque envelopes, encrypted attachment
+lifecycle, durable delivery, and repair without exposing plaintext to the node.
 
-- Frontend/device owns private keys.
-- Public/device keys are discoverable through user or group metadata.
-- Messages and attachments are encrypted client-side.
-- Node stores opaque encrypted envelopes and delivery metadata.
-- Removed group members cannot decrypt future messages after membership/key rotation.
+Production group chat remains gated by the
+[MLS protocol decision](./chat-group-e2ee-protocol-decision.md), its browser
+compatibility spike, epoch-based membership changes, and real multi-node tests.
+Removed devices must not decrypt messages from epochs committed after removal.
 
 ## Required Follow-Up Work
 
@@ -82,7 +84,8 @@ Backend encryption with app-held passphrases is useful only for at-rest protecti
 2. [#874](https://github.com/galtproject/geesome-node/issues/874): add focused tests for the highest-risk token-only handlers in `group`, `content`, `fileCatalog`, `staticSiteGenerator`, `pin`, and social import modules.
 3. [#876](https://github.com/galtproject/geesome-node/issues/876): add response-shape tests that prove current external-service secrets are not returned by list/get/login/update APIs.
 4. [#875](https://github.com/galtproject/geesome-node/issues/875): add public-route abuse tests for content/gateway range handling, storage misses, and webhook/auth-message replay behavior.
-5. Keep backend chat encryption documented as PoC/unsafe until frontend E2EE envelopes and client-held private keys land.
+5. Keep legacy backend-encrypted chat labelled as non-E2EE, and do not label
+   group chat production-secure until the active secure-chat release gates pass.
 
 ## Verification Checklist
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -91,6 +91,9 @@ Architecture decision:
 - Keep PostgreSQL as the operational authorization, head, acknowledgement, and
   retry index. Consider encrypted IPLD event batches or checkpoints for portable
   replication only after the operational path is proven.
+- Use MLS 1.0 for group membership and future-message key rotation according to
+  [Group Chat E2EE Protocol Decision](./chat-group-e2ee-protocol-decision.md).
+  Matrix remains an operational reference rather than the group wire protocol.
 
 Current safety boundary:
 
@@ -104,17 +107,17 @@ Current safety boundary:
 - Signed user manifests advertise canonical identity-bound chat transport when
   configured. Older profiles remain valid and produce an actionable unavailable
   state instead of falling back to plaintext.
-- Direct messages are the implemented E2EE foundation. Chat must not be
-  described as production-secure for attachments or groups until explicit
-  attachment lifecycle, membership/key rotation, retention, and real multi-node
+- Direct messages and encrypted attachment lifecycle are the implemented E2EE
+  foundation. Chat must not be described as production-secure for groups until
+  MLS membership/key rotation, explicit event retention, and real multi-node
   browser tests are complete.
 
 Remaining delivery order:
 
-1. Select and review the group protocol before extending pairwise envelopes.
-   Define membership epochs and rotate future-message keys when members/devices
-   are added, removed, replaced, or revoked. Evaluate MLS, Matrix-style
-   device/session handling, or another maintained browser-capable protocol.
+1. Run the browser MLS compatibility spike defined by the protocol decision.
+   Prove OpenMLS/WASM persistence, restart, add/remove/revoke, concurrent-commit
+   recovery, shared fixture interoperability, and acceptable bundle/runtime
+   cost before adding node schemas or routes.
 2. Run real two-node browser tests across restart, temporary unreachability,
    duplicate/out-of-order delivery, bounded repair, revoked devices, and
    NAT/bootstrap/reciprocal-peering conditions.


### PR DESCRIPTION
## Summary

- select MLS 1.0 as the group-chat protocol and define the initial interoperable profile
- define device identity, epoch, authorization, commit ordering, history, recovery, and opaque delivery rules
- gate runtime work on an OpenMLS/WASM browser persistence and interoperability spike
- align the active TODO, implemented status, security review, chat module docs, and docs discovery

## Why

The direct-message envelope should not grow into a custom group cryptographic protocol. This decision gives the next implementation PRs a reviewed contract while keeping GeeSome nodes outside plaintext and private-key handling.

## Verification

- `npm run todo:sections`
- `npm run todo:context -- browser-first-chat-e2ee`
- local Markdown link resolution check for changed docs
- `git diff --check`

Runtime tests were not run because this PR changes documentation and planning only.

Relates to #2.