### PR TITLE
Prove encrypted chat delivery survives restart

### DIFF
--- a/docs/chat-group-e2ee-protocol-decision.md
+++ b/docs/chat-group-e2ee-protocol-decision.md
@@ -1,7 +1,7 @@
 # Group Chat E2EE Protocol Decision
 
-Status: accepted architecture; browser implementation library remains gated by
-the compatibility spike below.
+Status: accepted architecture; no reviewed browser implementation currently
+passes the compatibility gate below.
 
 ## Decision
 
@@ -86,6 +86,15 @@ The spike may add a thin maintained GeeSome binding around OpenMLS. It must not
 reimplement MLS cryptography. If OpenMLS cannot satisfy these requirements,
 evaluate another RFC 9420 implementation against the same fixture before
 changing the protocol decision.
+
+The July 2026 compatibility pass did not select a production dependency. The
+reviewed browser packages did not provide the complete persistence, device
+lifecycle, pending-commit recovery, and maintained interoperability surface
+required by this gate. Experimental dependencies and fixtures were therefore
+discarded rather than added to the runtime. Group MLS implementation remains
+paused until a maintained browser implementation can pass this gate as a
+dependency; GeeSome will not fill missing protocol behavior with custom
+cryptographic code.
 
 ## Identity And Device Rules
 
@@ -185,10 +194,10 @@ retroactively re-encrypt old attachment objects.
 
 ## Rollout And Compatibility
 
-1. Land the browser compatibility spike and shared fixtures without changing
-   production chat behavior.
-2. Add opaque node contracts for KeyPackages and MLS event kinds only after the
-   spike selects a pinned library/binding.
+1. Re-run the browser compatibility gate when a maintained candidate exposes
+   the required lifecycle and persistence surface.
+2. Add shared fixtures and opaque node contracts for KeyPackages and MLS event
+   kinds only after the spike selects a pinned library/binding.
 3. Implement new MLS group conversations behind an explicit capability flag.
 4. Exercise add/remove/revoke, concurrent commits, restart, and delivery repair
    in real two-browser/two-node tests.

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -254,6 +254,9 @@ TODO.
 - Authenticated HTTPS delivery has durable retry leases, bounded backoff,
   recipient-signed acknowledgements, source-head comparison, signed missing-range
   repair, and an opt-in bounded reconciliation worker.
+- A PostgreSQL-backed restart regression proves a failed opaque delivery remains
+  queued across sender shutdown, resumes after app restart, records the signed
+  acknowledgement, and does not duplicate the encrypted event.
 - Configured nodes advertise canonical delivery, sync, and device-discovery
   endpoints in signed user manifests. Older profiles omit this additive field
   and remain valid.
@@ -266,9 +269,11 @@ TODO.
   signed GeeSome credential binding, explicit Add/Remove epoch changes,
   application-level admin authorization, canonical compare-and-set commit
   ordering, no automatic history sharing, opaque node transport, and a required
-  OpenMLS/WASM browser compatibility gate before implementation.
+  browser compatibility gate before implementation. The July 2026 dependency
+  pass selected no production browser implementation, so no experimental
+  dependency or partial MLS node contract was retained.
 
 This is a browser-first encrypted direct-message foundation, not completion of
-production-secure group chat. The browser MLS compatibility spike, real
-two-node browser testing, explicit operator policy, and legacy-path retirement
+production-secure group chat. Real two-node browser testing, explicit operator
+policy, legacy-path retirement, and a future successful MLS dependency gate
 remain in the active TODO.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -114,17 +114,16 @@ Current safety boundary:
 
 Remaining delivery order:
 
-1. Run the browser MLS compatibility spike defined by the protocol decision.
-   Prove OpenMLS/WASM persistence, restart, add/remove/revoke, concurrent-commit
-   recovery, shared fixture interoperability, and acceptable bundle/runtime
-   cost before adding node schemas or routes.
-2. Run real two-node browser tests across restart, temporary unreachability,
+1. Run real two-node browser tests across restart, temporary unreachability,
    duplicate/out-of-order delivery, bounded repair, revoked devices, and
    NAT/bootstrap/reciprocal-peering conditions.
-3. Define operator-visible queue/reconciliation metrics and explicit encrypted
+2. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old
    conversations as E2EE.
+3. Re-run the MLS browser compatibility gate only when a maintained dependency
+   exposes the required persistence, device lifecycle, and commit-recovery
+   surface. Do not add MLS node schemas or routes before a dependency passes.
 
 Transport requirements:
 
@@ -159,13 +158,13 @@ Verification:
   between otherwise running nodes.
 - A test that drops 100% of PubSub/communicator notifications and still
   recovers every locally accepted event through sequence/head reconciliation.
-- Node restart immediately before and after acknowledgement, browser
+- Recipient restart after persistence but before acknowledgement, browser
   resubmission after a rejected local save, brief network partition,
   reciprocal-peering reconnect, remote fetch/pin failure, and database/storage
   failure scenarios.
-- Recipient-node downtime followed by queued delivery, sender-node restart with
-  queue recovery, concurrent worker lease recovery, quota/expiry, permanent
-  rejection, and membership-removal cancellation.
+- Recipient-node downtime followed by queued delivery, concurrent worker lease
+  recovery, quota/expiry, permanent rejection, and membership-removal
+  cancellation.
 - Membership removal and key rotation proving removed devices cannot decrypt new
   messages.
 - Encrypted attachment upload/download and corruption/tamper failure tests.

--- a/test/chatIntegration.test.ts
+++ b/test/chatIntegration.test.ts
@@ -20,16 +20,7 @@ describe('chat persistence', function () {
 	let bob;
 
 	beforeEach(async () => {
-		const appConfig: any = (await import('../app/config.js')).default;
-		appConfig.storageConfig.jsNode.pass = 'test test test test test test test test test test';
-		appConfig.chatConfig.deliveryWorker = false;
-		appConfig.chatConfig.reconciliationWorker = false;
-		appConfig.chatConfig.attachmentCleanupWorker = false;
-		appConfig.chatConfig.autoProcessDeliveries = false;
-		app = await (await import('../app/index.js')).default({
-			storageConfig: appConfig.storageConfig,
-			port: 7771
-		});
+		app = await startChatTestApp();
 		await app.flushDatabase();
 		alice = await app.setup({
 			email: 'alice@example.com',
@@ -45,7 +36,7 @@ describe('chat persistence', function () {
 	});
 
 	afterEach(async () => {
-		await app.stop();
+		await app?.stop();
 	});
 
 	it('persists encrypted events, sequences, recipient reads, and receipts in PostgreSQL', async () => {
@@ -446,6 +437,80 @@ describe('chat persistence', function () {
 			new Set(quotaClaims.map(job => job.recipientOwnerId)).size,
 			2
 		);
+	});
+
+	it('resumes a pending encrypted delivery after restart without duplicating it', async () => {
+		const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: alice.storageAccountId,
+			deviceId: 'alice-restart-browser'
+		});
+		const bobDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: bob.storageAccountId,
+			deviceId: 'bob-restart-browser'
+		});
+		await app.ms.chat.registerDevice(alice.id, aliceDevice.publicBundle);
+		await app.ms.chat.registerDevice(bob.id, bobDevice.publicBundle);
+		const recipientPublicKey = await app.ms.accountStorage
+			.getStaticIdPublicKeyByOr(bob.storageAccountId);
+		const envelope = await browserE2eeHelper.encryptEnvelope(
+			'restart queue secret',
+			[bobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'postgres-restart-message-1',
+				conversationId: 'postgres-restart-conversation-1'
+			}
+		);
+		await app.ms.chat.acceptEncryptedEvent(alice.id, envelope, {
+			recipientEndpoints: [{
+				ownerId: bob.storageAccountId,
+				publicKey: recipientPublicKey,
+				inboxUrl: 'https://recipient.example/v1/chat/inbox'
+			}]
+		});
+		const failedAt = new Date();
+		const failedAttempt = await app.ms.chat.processDeliveryQueue({
+			now: failedAt,
+			deliverChatRequest: async () => {
+				throw new Error('recipient_temporarily_unreachable');
+			}
+		});
+		assert.deepEqual(failedAttempt, {
+			processed: 1,
+			delivered: 0,
+			failed: 0,
+			pending: 1
+		});
+
+		await app.stop();
+		app = await startChatTestApp();
+		const retryResult = await app.ms.chat.processDeliveryQueue({
+			now: new Date(failedAt.getTime() + 6000),
+			deliverChatRequest: (_inboxUrl, delivery) =>
+				app.ms.chat.acceptRemoteDelivery(delivery)
+		});
+		assert.deepEqual(retryResult, {
+			processed: 1,
+			delivered: 1,
+			failed: 0,
+			pending: 0
+		});
+		const deliveries = await app.ms.chat.getEventDeliveries(
+			alice.id,
+			envelope.messageId
+		);
+		assert.equal(deliveries.length, 1);
+		assert.equal(deliveries[0].state, 'delivered');
+		assert.equal(deliveries[0].attempts, 2);
+		assert.equal(deliveries[0].lastError, null);
+		assert.ok(deliveries[0].acknowledgedSequence);
+		const receivedEvents = await app.ms.chat.getEncryptedEvents(
+			bob.id,
+			envelope.conversationId
+		);
+		assert.equal(receivedEvents.total, 1);
+		assert.equal(receivedEvents.list[0].envelope.messageId, envelope.messageId);
+		assert.equal(JSON.stringify(receivedEvents.list[0]).includes('restart queue secret'), false);
 	});
 
 	it('protects sender-owned attachment ciphertext from content cleanup', async () => {
@@ -933,6 +998,19 @@ describe('chat persistence', function () {
 });
 
 const testAttachmentStorageId = 'QmYwAPJzv5CZsnAzt8auVZRnGi9iS3hBghG9V1sA9j3z2H';
+
+async function startChatTestApp(): Promise<IGeesomeApp> {
+	const appConfig: any = (await import('../app/config.js')).default;
+	appConfig.storageConfig.jsNode.pass = 'test test test test test test test test test test';
+	appConfig.chatConfig.deliveryWorker = false;
+	appConfig.chatConfig.reconciliationWorker = false;
+	appConfig.chatConfig.attachmentCleanupWorker = false;
+	appConfig.chatConfig.autoProcessDeliveries = false;
+	return (await import('../app/index.js')).default({
+		storageConfig: appConfig.storageConfig,
+		port: 7771
+	});
+}
 
 function getEnvelopeHash(envelope): string {
 	return createHash('sha256').update([


### PR DESCRIPTION
## Summary
- add a PostgreSQL-backed regression for failed encrypted delivery resuming after app restart
- verify the retry records one acknowledgement and does not duplicate the encrypted event
- record that no reviewed browser MLS dependency passed the compatibility gate and prioritize two-node reliability work

## Validation
- `npm run test:docker` (609 passing, 11 pending)