### PR TITLE
Add independent two-node chat delivery harness

### DIFF
--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -82,6 +82,13 @@ regress repair work. The following environment variables tune the bounded worker
 - `CHAT_ATTACHMENT_CLEANUP_CLAIM_TTL_MS`
 - `CHAT_ATTACHMENT_CLEANUP_RECORD_RETENTION_MS`
 
+The process-level reliability harness runs two independent GeeSome app
+processes with separate PostgreSQL databases and account-data directories. It
+proves that recipient downtime and both-node restart do not lose or duplicate a
+queued event when delivery resumes through the real HTTP inbox. This is the
+durable HTTP baseline; separate IPFS-node, browser, reordered-event, and
+network-shape scenarios remain in the active TODO.
+
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
 direct-message send/read UX and explicit device trust verification are present
 in `geesome-ui`. The browser also encrypts attachment bytes before upload, keeps

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -257,6 +257,11 @@ TODO.
 - A PostgreSQL-backed restart regression proves a failed opaque delivery remains
   queued across sender shutdown, resumes after app restart, records the signed
   acknowledgement, and does not duplicate the encrypted event.
+- An independent-process reliability harness starts two GeeSome apps with
+  separate PostgreSQL databases and account-data directories. Its first real
+  HTTP scenario stops the recipient, records a failed delivery, restarts both
+  nodes, and proves the persisted sender queue delivers exactly one opaque event
+  to the recipient database.
 - Configured nodes advertise canonical delivery, sync, and device-discovery
   endpoints in signed user manifests. Older profiles omit this additive field
   and remain valid.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -114,9 +114,9 @@ Current safety boundary:
 
 Remaining delivery order:
 
-1. Run real two-node browser tests across restart, temporary unreachability,
-   duplicate/out-of-order delivery, bounded repair, revoked devices, and
-   NAT/bootstrap/reciprocal-peering conditions.
+1. Extend the independent-process HTTP harness into real two-browser/two-node
+   tests for duplicate/out-of-order delivery, bounded repair, revoked devices,
+   separate IPFS nodes, and NAT/bootstrap/reciprocal-peering conditions.
 2. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old
@@ -210,9 +210,8 @@ Verification:
   resubmission after a rejected local save, brief network partition,
   reciprocal-peering reconnect, remote fetch/pin failure, and database/storage
   failure scenarios.
-- Recipient-node downtime followed by queued delivery, concurrent worker lease
-  recovery, quota/expiry, permanent rejection, and membership-removal
-  cancellation.
+- Concurrent worker lease recovery, quota/expiry, permanent rejection, and
+  membership-removal cancellation.
 - Membership removal and key rotation proving removed devices cannot decrypt new
   messages.
 - Encrypted attachment upload/download and corruption/tamper failure tests.

--- a/test/chatTwoNodeReliability.test.ts
+++ b/test/chatTwoNodeReliability.test.ts
@@ -1,0 +1,392 @@
+import assert from 'node:assert';
+import {spawn, ChildProcess} from 'node:child_process';
+import fs from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import {Client} from 'pg';
+import browserE2eeHelper from 'geesome-libs/src/browserE2eeHelper.js';
+
+const requiredModules = [
+	'drivers',
+	'database',
+	'api',
+	'accountStorage',
+	'communicator',
+	'storage',
+	'content',
+	'staticId',
+	'asyncOperation',
+	'group',
+	'chat',
+	'entityJsonManifest'
+].join(',');
+
+describe('two-node chat reliability', function () {
+	this.timeout(120000);
+
+	let nodeA: ChatNodeProcess | null;
+	let nodeB: ChatNodeProcess | null;
+	let databaseA: string;
+	let databaseB: string;
+	let dataDirA: string;
+	let dataDirB: string;
+	let portA: number;
+	let portB: number;
+
+	beforeEach(async () => {
+		const suffix = `${process.pid}_${Date.now()}`;
+		databaseA = `geesome_chat_a_${suffix}`;
+		databaseB = `geesome_chat_b_${suffix}`;
+		dataDirA = path.join(os.tmpdir(), databaseA);
+		dataDirB = path.join(os.tmpdir(), databaseB);
+		[portA, portB] = await Promise.all([findFreePort(), findFreePort()]);
+		await createTestDatabase(databaseA);
+		await createTestDatabase(databaseB);
+		nodeA = await ChatNodeProcess.start(createNodeConfig(databaseA, dataDirA, portA));
+		nodeB = await ChatNodeProcess.start(createNodeConfig(databaseB, dataDirB, portB));
+	});
+
+	afterEach(async () => {
+		await Promise.allSettled([nodeA?.stop(), nodeB?.stop()]);
+		await Promise.allSettled([
+			dropTestDatabase(databaseA),
+			dropTestDatabase(databaseB)
+		]);
+		await Promise.allSettled([
+			fs.rm(dataDirA, {recursive: true, force: true}),
+			fs.rm(dataDirB, {recursive: true, force: true})
+		]);
+	});
+
+	it('delivers one queued event after both independent nodes restart', async () => {
+		const aliceSetup = await nodeA.request('setup', {
+			user: {
+				email: 'alice-two-node@example.com',
+				name: 'alice_two_node',
+				password: 'alice'
+			}
+		});
+		const bobSetup = await nodeB.request('setup', {
+			user: {
+				email: 'bob-two-node@example.com',
+				name: 'bob_two_node',
+				password: 'bob'
+			}
+		});
+		const alice = aliceSetup.user;
+		const bob = bobSetup.user;
+		const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: alice.storageAccountId,
+			deviceId: 'alice-two-node-browser'
+		});
+		const bobDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: bob.storageAccountId,
+			deviceId: 'bob-two-node-browser'
+		});
+		await nodeA.request('register-device', {
+			userId: alice.id,
+			publicBundle: aliceDevice.publicBundle
+		});
+		await nodeB.request('register-device', {
+			userId: bob.id,
+			publicBundle: bobDevice.publicBundle
+		});
+		const bobTransportPublicKey = await nodeB.request(
+			'get-transport-public-key',
+			{ownerId: bob.storageAccountId}
+		);
+		const envelope = await browserE2eeHelper.encryptEnvelope(
+			'two-node restart message',
+			[bobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'two-node-restart-message-1',
+				conversationId: 'two-node-restart-conversation-1'
+			}
+		);
+		await nodeA.request('accept-event', {
+			userId: alice.id,
+			envelope,
+			options: {
+				recipientEndpoints: [{
+					ownerId: bob.storageAccountId,
+					publicKey: bobTransportPublicKey,
+					inboxUrl: `http://127.0.0.1:${portB}/v1/chat/inbox`
+				}]
+			}
+		});
+
+		await nodeB.stop();
+		nodeB = null;
+		const failed = await nodeA.request('process-deliveries');
+		assert.deepEqual(failed, {
+			processed: 1,
+			delivered: 0,
+			failed: 0,
+			pending: 1
+		});
+		await nodeA.stop();
+		nodeA = null;
+
+		nodeB = await ChatNodeProcess.start(createNodeConfig(databaseB, dataDirB, portB));
+		nodeA = await ChatNodeProcess.start(createNodeConfig(databaseA, dataDirA, portA));
+		const delivered = await nodeA.request('process-deliveries', {
+			options: {now: new Date(Date.now() + 6000).toISOString()}
+		});
+		assert.deepEqual(delivered, {
+			processed: 1,
+			delivered: 1,
+			failed: 0,
+			pending: 0
+		});
+		const deliveries = await nodeA.request('get-deliveries', {
+			userId: alice.id,
+			messageId: envelope.messageId
+		});
+		assert.equal(deliveries.length, 1);
+		assert.equal(deliveries[0].state, 'delivered');
+		assert.equal(deliveries[0].attempts, 2);
+		const received = await nodeB.request('get-events', {
+			userId: bob.id,
+			conversationId: envelope.conversationId
+		});
+		assert.equal(received.total, 1);
+		assert.equal(received.list[0].envelope.messageId, envelope.messageId);
+		assert.equal(
+			JSON.stringify(received.list[0]).includes('two-node restart message'),
+			false
+		);
+	});
+});
+
+type ChatNodeConfig = {
+	databaseName: string;
+	dataDir: string;
+	port: number;
+};
+
+class ChatNodeProcess {
+	child: ChildProcess;
+	nextRequestId = 1;
+	pending = new Map<number, {
+		resolve(value): void;
+		reject(error): void;
+		timeout: NodeJS.Timeout;
+	}>();
+	readyPromise: Promise<void>;
+	resolveReady;
+	rejectReady;
+	stdout = '';
+	stderr = '';
+	stopped = false;
+
+	constructor(child: ChildProcess) {
+		this.child = child;
+		this.readyPromise = new Promise((resolve, reject) => {
+			this.resolveReady = resolve;
+			this.rejectReady = reject;
+		});
+		child.stdout?.setEncoding('utf8');
+		child.stderr?.setEncoding('utf8');
+		child.stdout?.on('data', chunk => {
+			this.stdout += chunk;
+		});
+		child.stderr?.on('data', chunk => {
+			this.stderr += chunk;
+		});
+		child.on('message', message => this.onMessage(message));
+		child.on('exit', (code, signal) => this.onExit(code, signal));
+	}
+
+	static async start(config: ChatNodeConfig): Promise<ChatNodeProcess> {
+		const child = spawn(process.execPath, [
+			'--import',
+			'tsx',
+			'test/fixtures/chatNodeChild.ts'
+		], {
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				DATABASE_NAME: config.databaseName,
+				DATABASE_APPLICATION_NAME: `geesome-chat-test-${config.databaseName}`,
+				DATA_DIR: config.dataDir,
+				PORT: String(config.port),
+				MODULES: requiredModules,
+				STORAGE_MODULE: 'ipfs-http-client',
+				CHAT_AUTO_PROCESS_DELIVERIES: '0',
+				CHAT_DELIVERY_WORKER: '0',
+				CHAT_RECONCILIATION_WORKER: '0',
+				CHAT_ATTACHMENT_CLEANUP_WORKER: '0'
+			},
+			stdio: ['ignore', 'pipe', 'pipe', 'ipc']
+		});
+		const node = new ChatNodeProcess(child);
+		try {
+			await withTimeout(
+				node.readyPromise,
+				60000,
+				() => node.createError('chat_node_startup_timeout')
+			);
+		} catch (error) {
+			child.kill('SIGKILL');
+			throw error;
+		}
+		return node;
+	}
+
+	request(command: string, payload: any = {}): Promise<any> {
+		const id = this.nextRequestId++;
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.pending.delete(id);
+				reject(this.createError(`chat_node_request_timeout:${command}`));
+			}, 30000);
+			this.pending.set(id, {resolve, reject, timeout});
+			this.child.send({id, command, payload});
+		});
+	}
+
+	async stop(): Promise<void> {
+		if (this.stopped) {
+			return;
+		}
+		this.stopped = true;
+		if (this.child.exitCode === null && this.child.signalCode === null) {
+			await this.request('stop');
+			await waitForExit(this.child);
+		}
+	}
+
+	onMessage(message: any) {
+		if (message?.type === 'ready') {
+			this.resolveReady();
+			return;
+		}
+		if (message?.type === 'startup-error') {
+			this.rejectReady(this.createError(message.error));
+			return;
+		}
+		const request = this.pending.get(message?.id);
+		if (!request) {
+			return;
+		}
+		this.pending.delete(message.id);
+		clearTimeout(request.timeout);
+		if (message.error) {
+			request.reject(this.createError(message.error));
+			return;
+		}
+		request.resolve(message.result);
+	}
+
+	onExit(code, signal) {
+		const error = this.createError(`child_exit:${code}:${signal || ''}`);
+		this.rejectReady(error);
+		for (const request of this.pending.values()) {
+			clearTimeout(request.timeout);
+			request.reject(error);
+		}
+		this.pending.clear();
+	}
+
+	createError(message: string): Error {
+		return new Error([
+			message,
+			this.stdout && `stdout:\n${this.stdout}`,
+			this.stderr && `stderr:\n${this.stderr}`
+		].filter(Boolean).join('\n'));
+	}
+}
+
+function createNodeConfig(
+	databaseName: string,
+	dataDir: string,
+	port: number
+): ChatNodeConfig {
+	return {databaseName, dataDir, port};
+}
+
+async function createTestDatabase(databaseName: string): Promise<void> {
+	const client = createDatabaseClient();
+	await client.connect();
+	try {
+		await client.query(`CREATE DATABASE "${databaseName}"`);
+	} finally {
+		await client.end();
+	}
+}
+
+async function dropTestDatabase(databaseName: string): Promise<void> {
+	if (!databaseName) {
+		return;
+	}
+	const client = createDatabaseClient();
+	await client.connect();
+	try {
+		await client.query(
+			'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()',
+			[databaseName]
+		);
+		await client.query(`DROP DATABASE IF EXISTS "${databaseName}"`);
+	} finally {
+		await client.end();
+	}
+}
+
+function createDatabaseClient(): Client {
+	return new Client({
+		host: process.env.DATABASE_HOST || 'localhost',
+		port: Number(process.env.DATABASE_PORT || 5432),
+		user: process.env.DATABASE_USER || 'geesome',
+		password: process.env.DATABASE_PASSWORD || 'geesome',
+		database: process.env.DATABASE_NAME || 'geesome_node'
+	});
+}
+
+function findFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			if (!address || typeof address === 'string') {
+				server.close();
+				reject(new Error('chat_test_port_unavailable'));
+				return;
+			}
+			const port = address.port;
+			server.close(() => resolve(port));
+		});
+	});
+}
+
+function waitForExit(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return Promise.resolve();
+	}
+	return new Promise((resolve, reject) => {
+		child.once('error', reject);
+		child.once('exit', () => resolve());
+	});
+}
+
+function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	getError: () => Error
+): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => reject(getError()), timeoutMs);
+		promise.then(
+			value => {
+				clearTimeout(timeout);
+				resolve(value);
+			},
+			error => {
+				clearTimeout(timeout);
+				reject(error);
+			}
+		);
+	});
+}

--- a/test/fixtures/chatNodeChild.ts
+++ b/test/fixtures/chatNodeChild.ts
@@ -1,0 +1,108 @@
+import initializeApp from '../../app/index.js';
+
+let app;
+
+process.on('message', async (message: any) => {
+	const {id, command, payload} = message || {};
+	try {
+		const result = await runCommand(command, payload || {});
+		process.send?.({id, result: toPlainValue(result)});
+		if (command === 'stop') {
+			setImmediate(() => process.exit(0));
+		}
+	} catch (error) {
+		process.send?.({
+			id,
+			error: error?.message || String(error)
+		});
+	}
+});
+
+start().catch(error => {
+	process.send?.({
+		type: 'startup-error',
+		error: error?.message || String(error)
+	});
+	process.exitCode = 1;
+});
+
+async function start() {
+	const appConfig: any = (await import('../../app/config.js')).default;
+	app = await initializeApp({
+		...appConfig,
+		port: Number(process.env.PORT),
+		skipFrontendStorage: true,
+		storageConfig: {
+			...appConfig.storageConfig,
+			jsNode: {
+				...appConfig.storageConfig.jsNode,
+				pass: 'test test test test test test test test test test'
+			}
+		},
+		chatConfig: {
+			...appConfig.chatConfig,
+			autoProcessDeliveries: false,
+			deliveryWorker: false,
+			reconciliationWorker: false,
+			attachmentCleanupWorker: false
+		}
+	}, {
+		loadModule: async (moduleName, childApp) => {
+			const initializeModule = (await import(
+				`../../app/modules/${moduleName}/index.js`
+			)).default;
+			if (moduleName === 'chat') {
+				return initializeModule(childApp, {allowHttp: true});
+			}
+			return initializeModule(childApp);
+		}
+	});
+	process.send?.({type: 'ready'});
+}
+
+async function runCommand(command: string, payload: any) {
+	if (command === 'setup') {
+		return app.setup(payload.user);
+	}
+	if (command === 'register-device') {
+		return app.ms.chat.registerDevice(payload.userId, payload.publicBundle);
+	}
+	if (command === 'get-transport-public-key') {
+		return app.ms.accountStorage.getStaticIdPublicKeyByOr(payload.ownerId);
+	}
+	if (command === 'accept-event') {
+		return app.ms.chat.acceptEncryptedEvent(
+			payload.userId,
+			payload.envelope,
+			payload.options
+		);
+	}
+	if (command === 'process-deliveries') {
+		const options = {...payload.options};
+		if (options.now) {
+			options.now = new Date(options.now);
+		}
+		return app.ms.chat.processDeliveryQueue(options);
+	}
+	if (command === 'get-deliveries') {
+		return app.ms.chat.getEventDeliveries(payload.userId, payload.messageId);
+	}
+	if (command === 'get-events') {
+		return app.ms.chat.getEncryptedEvents(
+			payload.userId,
+			payload.conversationId
+		);
+	}
+	if (command === 'stop') {
+		await app?.stop();
+		return {stopped: true};
+	}
+	throw new Error(`unknown_chat_node_command:${command}`);
+}
+
+function toPlainValue(value) {
+	if (value === undefined) {
+		return null;
+	}
+	return JSON.parse(JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary
- run two GeeSome apps in separate child processes with separate PostgreSQL databases and account-data directories
- exercise the real HTTP inbox after recipient downtime and both-node restart
- prove the durable sender queue delivers exactly one opaque event after recovery
- keep child startup and RPC waits bounded and update the chat plan with the remaining browser/IPFS/network cases

## Validation
- `npm run test:docker` (610 passing, 11 pending)
- focused final harness run in Docker (1 passing)
- `npm run todo:context -- browser-first-chat-e2ee`
- `git diff --check`