### PR TITLE
Verify reordered chat repair across independent nodes

### DIFF
--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -85,8 +85,11 @@ regress repair work. The following environment variables tune the bounded worker
 The process-level reliability harness runs two independent GeeSome app
 processes with separate PostgreSQL databases and account-data directories. It
 proves that recipient downtime and both-node restart do not lose or duplicate a
-queued event when delivery resumes through the real HTTP inbox. This is the
-durable HTTP baseline; separate IPFS-node, browser, reordered-event, and
+queued event when delivery resumes through the real HTTP inbox. A second
+scenario delivers source event three before events one and two, then proves the
+real signed HTTP sync path repairs the missing range, revalidates the already
+stored event without duplicating it, and makes a repeated repair a no-op. This
+is the durable HTTP baseline; separate IPFS-node, browser, revoked-device, and
 network-shape scenarios remain in the active TODO.
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -261,7 +261,10 @@ TODO.
   separate PostgreSQL databases and account-data directories. Its first real
   HTTP scenario stops the recipient, records a failed delivery, restarts both
   nodes, and proves the persisted sender queue delivers exactly one opaque event
-  to the recipient database.
+  to the recipient database. Its reordered-delivery scenario sends source event
+  three first, repairs events one and two through the signed HTTP sync endpoint,
+  revalidates event three without duplicating it, and proves a repeated repair
+  imports nothing.
 - Configured nodes advertise canonical delivery, sync, and device-discovery
   endpoints in signed user manifests. Older profiles omit this additive field
   and remain valid.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -114,9 +114,9 @@ Current safety boundary:
 
 Remaining delivery order:
 
-1. Extend the independent-process HTTP harness into real two-browser/two-node
-   tests for duplicate/out-of-order delivery, bounded repair, revoked devices,
-   separate IPFS nodes, and NAT/bootstrap/reciprocal-peering conditions.
+1. Promote the independent-process restart and reordered-repair scenarios into
+   real two-browser/two-node tests. Add revoked-device, separate-IPFS-node, and
+   NAT/bootstrap/reciprocal-peering conditions.
 2. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old

--- a/test/chatTwoNodeReliability.test.ts
+++ b/test/chatTwoNodeReliability.test.ts
@@ -158,6 +158,145 @@ describe('two-node chat reliability', function () {
 			false
 		);
 	});
+
+	it('repairs earlier events after receiving a later event first', async () => {
+		const aliceSetup = await nodeA.request('setup', {
+			user: {
+				email: 'alice-repair@example.com',
+				name: 'alice_repair',
+				password: 'alice'
+			}
+		});
+		const bobSetup = await nodeB.request('setup', {
+			user: {
+				email: 'bob-repair@example.com',
+				name: 'bob_repair',
+				password: 'bob'
+			}
+		});
+		const alice = aliceSetup.user;
+		const bob = bobSetup.user;
+		const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: alice.storageAccountId,
+			deviceId: 'alice-repair-browser'
+		});
+		const bobDevice = await browserE2eeHelper.generateDeviceKeys({
+			ownerId: bob.storageAccountId,
+			deviceId: 'bob-repair-browser'
+		});
+		await nodeA.request('register-device', {
+			userId: alice.id,
+			publicBundle: aliceDevice.publicBundle
+		});
+		await nodeB.request('register-device', {
+			userId: bob.id,
+			publicBundle: bobDevice.publicBundle
+		});
+		const conversationId = 'two-node-repair-conversation-1';
+		const envelopes = [];
+		for (let sequence = 1; sequence <= 3; sequence += 1) {
+			envelopes.push(await browserE2eeHelper.encryptEnvelope(
+				`two-node repair message ${sequence}`,
+				[bobDevice.publicBundle],
+				aliceDevice,
+				{
+					messageId: `two-node-repair-message-${sequence}`,
+					conversationId
+				}
+			));
+		}
+		await nodeA.request('accept-event', {
+			userId: alice.id,
+			envelope: envelopes[0]
+		});
+		await nodeA.request('accept-event', {
+			userId: alice.id,
+			envelope: envelopes[1]
+		});
+		const bobTransportPublicKey = await nodeB.request(
+			'get-transport-public-key',
+			{ownerId: bob.storageAccountId}
+		);
+		await nodeA.request('accept-event', {
+			userId: alice.id,
+			envelope: envelopes[2],
+			options: {
+				recipientEndpoints: [{
+					ownerId: bob.storageAccountId,
+					publicKey: bobTransportPublicKey,
+					inboxUrl: `http://127.0.0.1:${portB}/v1/chat/inbox`
+				}]
+			}
+		});
+
+		const delivered = await nodeA.request('process-deliveries');
+		assert.deepEqual(delivered, {
+			processed: 1,
+			delivered: 1,
+			failed: 0,
+			pending: 0
+		});
+		const receivedOutOfOrder = await nodeB.request('get-events', {
+			userId: bob.id,
+			conversationId
+		});
+		assert.equal(receivedOutOfOrder.total, 1);
+		assert.equal(
+			receivedOutOfOrder.list[0].envelope.messageId,
+			envelopes[2].messageId
+		);
+		assert.equal(receivedOutOfOrder.list[0].sourceSequence, '3');
+
+		const aliceTransportPublicKey = await nodeA.request(
+			'get-transport-public-key',
+			{ownerId: alice.storageAccountId}
+		);
+		const reconciliation = await nodeB.request('reconcile-conversation', {
+			userId: bob.id,
+			conversationId,
+			options: {
+				sourceOwnerId: alice.storageAccountId,
+				sourcePublicKey: aliceTransportPublicKey,
+				syncUrl: `http://127.0.0.1:${portA}/v1/chat/sync`,
+				limit: 2,
+				maxPages: 2
+			}
+		});
+		assert.equal(reconciliation.complete, true);
+		assert.equal(reconciliation.imported, 2);
+		assert.equal(reconciliation.replayed, 1);
+		assert.equal(reconciliation.pages, 2);
+		assert.equal(reconciliation.verifiedSourceSequence, '3');
+
+		const receivedAfterRepair = await nodeB.request('get-events', {
+			userId: bob.id,
+			conversationId
+		});
+		assert.equal(receivedAfterRepair.total, 3);
+		assert.deepEqual(
+			receivedAfterRepair.list
+				.map(event => event.envelope.messageId)
+				.sort(),
+			envelopes.map(envelope => envelope.messageId).sort()
+		);
+		assert.equal(
+			JSON.stringify(receivedAfterRepair).includes('two-node repair message'),
+			false
+		);
+
+		const repeatedReconciliation = await nodeB.request(
+			'reconcile-conversation',
+			{
+				userId: bob.id,
+				conversationId,
+				options: {sourceOwnerId: alice.storageAccountId}
+			}
+		);
+		assert.equal(repeatedReconciliation.complete, true);
+		assert.equal(repeatedReconciliation.imported, 0);
+		assert.equal(repeatedReconciliation.replayed, 0);
+		assert.equal(repeatedReconciliation.verifiedSourceSequence, '3');
+	});
 });
 
 type ChatNodeConfig = {

--- a/test/fixtures/chatNodeChild.ts
+++ b/test/fixtures/chatNodeChild.ts
@@ -84,6 +84,13 @@ async function runCommand(command: string, payload: any) {
 		}
 		return app.ms.chat.processDeliveryQueue(options);
 	}
+	if (command === 'reconcile-conversation') {
+		return app.ms.chat.reconcileConversation(
+			payload.userId,
+			payload.conversationId,
+			payload.options
+		);
+	}
 	if (command === 'get-deliveries') {
 		return app.ms.chat.getEventDeliveries(payload.userId, payload.messageId);
 	}


### PR DESCRIPTION
## Summary

- extend the independent two-node harness with a real HTTP missing-range repair scenario
- deliver source event 3 first, then recover events 1 and 2 through the signed sync endpoint
- verify replay and repeated reconciliation do not duplicate encrypted events
- move the completed process-level coverage from the active TODO into implemented docs

## Validation

- focused Docker test: 2 passing
- full Docker suite: 611 passing, 11 pending