### PR TITLE
Stop retrying chat delivery after permanent recipient rejection

### DIFF
--- a/app/modules/chat/delivery.ts
+++ b/app/modules/chat/delivery.ts
@@ -141,7 +141,7 @@ async function recordChatDeliveryFailure(
 		options.maximumAttempts,
 		defaultMaximumAttempts
 	);
-	const failed = attempts >= maximumAttempts;
+	const failed = error?.retryable === false || attempts >= maximumAttempts;
 	await delivery.update({
 		state: failed ? ChatDeliveryState.Failed : ChatDeliveryState.Pending,
 		attempts,

--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -88,9 +88,11 @@ proves that recipient downtime and both-node restart do not lose or duplicate a
 queued event when delivery resumes through the real HTTP inbox. A second
 scenario delivers source event three before events one and two, then proves the
 real signed HTTP sync path repairs the missing range, revalidates the already
-stored event without duplicating it, and makes a repeated repair a no-op. This
-is the durable HTTP baseline; separate IPFS-node, browser, revoked-device, and
-network-shape scenarios remain in the active TODO.
+stored event without duplicating it, and makes a repeated repair a no-op. The
+revoked-device scenario proves the recipient stores no event and the sender
+records one visible failed delivery without retrying a permanent HTTP response.
+This is the durable HTTP baseline; separate IPFS-node, browser, and network-shape
+scenarios remain in the active TODO.
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
 direct-message send/read UX and explicit device trust verification are present

--- a/app/modules/chat/transport.ts
+++ b/app/modules/chat/transport.ts
@@ -234,7 +234,10 @@ export async function postChatTransportJson(
 		return response.data as IChatDeliveryAcknowledgement;
 	} catch (error) {
 		if (error?.response?.status) {
-			throw new Error(`${options.errorPrefix || 'chat_delivery'}_http_${error.response.status}`);
+			throw createChatTransportHttpError(
+				options.errorPrefix || 'chat_delivery',
+				error.response.status
+			);
 		}
 		throw error;
 	} finally {
@@ -367,4 +370,15 @@ function parsePositiveInteger(value, fallback: number): number {
 		return parsed;
 	}
 	return fallback;
+}
+
+function createChatTransportHttpError(prefix: string, statusValue): Error {
+	const status = Number(statusValue);
+	const error: any = new Error(`${prefix}_http_${status}`);
+	error.statusCode = status;
+	error.retryable = status === 408 ||
+		status === 425 ||
+		status === 429 ||
+		status >= 500;
+	return error;
 }

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -264,7 +264,9 @@ TODO.
   to the recipient database. Its reordered-delivery scenario sends source event
   three first, repairs events one and two through the signed HTTP sync endpoint,
   revalidates event three without duplicating it, and proves a repeated repair
-  imports nothing.
+  imports nothing. Its revoked-device scenario proves the recipient stores no
+  event and the sender records one visible failed delivery instead of retrying a
+  permanent HTTP rejection.
 - Configured nodes advertise canonical delivery, sync, and device-discovery
   endpoints in signed user manifests. Older profiles omit this additive field
   and remain valid.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -115,7 +115,7 @@ Current safety boundary:
 Remaining delivery order:
 
 1. Promote the independent-process restart and reordered-repair scenarios into
-   real two-browser/two-node tests. Add revoked-device, separate-IPFS-node, and
+   real two-browser/two-node tests. Add separate-IPFS-node and
    NAT/bootstrap/reciprocal-peering conditions.
 2. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or

--- a/test/chatDelivery.test.ts
+++ b/test/chatDelivery.test.ts
@@ -9,9 +9,17 @@ import {
 
 describe('chat delivery queue', function () {
 	this.timeout(10000);
+	let sender;
+	let recipient;
+
+	before(async () => {
+		[sender, recipient] = await Promise.all([
+			createTransportIdentity(),
+			createTransportIdentity()
+		]);
+	});
+
 	it('records a recipient-signed acknowledgement', async () => {
-		const sender = await createTransportIdentity();
-		const recipient = await createTransportIdentity();
 		const row = createDeliveryRow(sender, recipient);
 		const models = {
 			ChatDelivery: {
@@ -47,8 +55,6 @@ describe('chat delivery queue', function () {
 	});
 
 	it('releases a failed claim for bounded retry', async () => {
-		const sender = await createTransportIdentity();
-		const recipient = await createTransportIdentity();
 		const row = createDeliveryRow(sender, recipient);
 		const result = await processChatDeliveryQueue({
 			ChatDelivery: {
@@ -69,6 +75,34 @@ describe('chat delivery queue', function () {
 		assert.equal(row.deliveryClaimedAt, null);
 		assert.equal(row.deliveryClaimExpiresAt, null);
 		assert.ok(row.nextAttemptAt > new Date('2026-07-28T12:00:00.000Z'));
+	});
+
+	it('stops retrying a permanent recipient rejection immediately', async () => {
+		const row = createDeliveryRow(sender, recipient);
+		const result = await processChatDeliveryQueue({
+			ChatDelivery: {
+				claimDue: async () => [row]
+			}
+		}, {
+			getSigner: async () => sender,
+			deliverChatRequest: async () => {
+				const error: any = new Error('chat_delivery_http_404');
+				error.retryable = false;
+				throw error;
+			}
+		});
+
+		assert.deepEqual(result, {
+			processed: 1,
+			delivered: 0,
+			failed: 1,
+			pending: 0
+		});
+		assert.equal(row.state, ChatDeliveryState.Failed);
+		assert.equal(row.attempts, 1);
+		assert.equal(row.lastError, 'chat_delivery_http_404');
+		assert.equal(row.deliveryClaimedAt, null);
+		assert.equal(row.deliveryClaimExpiresAt, null);
 	});
 });
 

--- a/test/chatTwoNodeReliability.test.ts
+++ b/test/chatTwoNodeReliability.test.ts
@@ -297,6 +297,74 @@ describe('two-node chat reliability', function () {
 		assert.equal(repeatedReconciliation.replayed, 0);
 		assert.equal(repeatedReconciliation.verifiedSourceSequence, '3');
 	});
+
+	it('stops retrying after the recipient device is revoked', async () => {
+		const {
+			alice,
+			bob,
+			aliceDevice,
+			bobDevice
+		} = await setupChatParticipants(nodeA, nodeB, 'revoked');
+		const bobTransportPublicKey = await nodeB.request(
+			'get-transport-public-key',
+			{ownerId: bob.storageAccountId}
+		);
+		const envelope = await browserE2eeHelper.encryptEnvelope(
+			'two-node revoked device message',
+			[bobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'two-node-revoked-message-1',
+				conversationId: 'two-node-revoked-conversation-1'
+			}
+		);
+		await nodeB.request('revoke-device', {
+			userId: bob.id,
+			deviceId: bobDevice.publicBundle.deviceId
+		});
+		await nodeA.request('accept-event', {
+			userId: alice.id,
+			envelope,
+			options: {
+				recipientEndpoints: [{
+					ownerId: bob.storageAccountId,
+					publicKey: bobTransportPublicKey,
+					inboxUrl: `http://127.0.0.1:${portB}/v1/chat/inbox`
+				}]
+			}
+		});
+
+		const rejected = await nodeA.request('process-deliveries');
+		assert.deepEqual(rejected, {
+			processed: 1,
+			delivered: 0,
+			failed: 1,
+			pending: 0
+		});
+		const deliveries = await nodeA.request('get-deliveries', {
+			userId: alice.id,
+			messageId: envelope.messageId
+		});
+		assert.equal(deliveries.length, 1);
+		assert.equal(deliveries[0].state, 'failed');
+		assert.equal(deliveries[0].attempts, 1);
+		assert.equal(deliveries[0].lastError, 'chat_delivery_http_404');
+		const received = await nodeB.request('get-events', {
+			userId: bob.id,
+			conversationId: envelope.conversationId
+		});
+		assert.equal(received.total, 0);
+
+		const repeated = await nodeA.request('process-deliveries', {
+			options: {now: new Date(Date.now() + 6000).toISOString()}
+		});
+		assert.deepEqual(repeated, {
+			processed: 0,
+			delivered: 0,
+			failed: 0,
+			pending: 0
+		});
+	});
 });
 
 type ChatNodeConfig = {
@@ -444,6 +512,46 @@ function createNodeConfig(
 	port: number
 ): ChatNodeConfig {
 	return {databaseName, dataDir, port};
+}
+
+async function setupChatParticipants(
+	nodeA: ChatNodeProcess,
+	nodeB: ChatNodeProcess,
+	name: string
+) {
+	const aliceSetup = await nodeA.request('setup', {
+		user: {
+			email: `alice-${name}@example.com`,
+			name: `alice_${name}`,
+			password: 'alice'
+		}
+	});
+	const bobSetup = await nodeB.request('setup', {
+		user: {
+			email: `bob-${name}@example.com`,
+			name: `bob_${name}`,
+			password: 'bob'
+		}
+	});
+	const alice = aliceSetup.user;
+	const bob = bobSetup.user;
+	const aliceDevice = await browserE2eeHelper.generateDeviceKeys({
+		ownerId: alice.storageAccountId,
+		deviceId: `alice-${name}-browser`
+	});
+	const bobDevice = await browserE2eeHelper.generateDeviceKeys({
+		ownerId: bob.storageAccountId,
+		deviceId: `bob-${name}-browser`
+	});
+	await nodeA.request('register-device', {
+		userId: alice.id,
+		publicBundle: aliceDevice.publicBundle
+	});
+	await nodeB.request('register-device', {
+		userId: bob.id,
+		publicBundle: bobDevice.publicBundle
+	});
+	return {alice, bob, aliceDevice, bobDevice};
 }
 
 async function createTestDatabase(databaseName: string): Promise<void> {

--- a/test/fixtures/chatNodeChild.ts
+++ b/test/fixtures/chatNodeChild.ts
@@ -67,6 +67,9 @@ async function runCommand(command: string, payload: any) {
 	if (command === 'register-device') {
 		return app.ms.chat.registerDevice(payload.userId, payload.publicBundle);
 	}
+	if (command === 'revoke-device') {
+		return app.ms.chat.revokeDevice(payload.userId, payload.deviceId);
+	}
 	if (command === 'get-transport-public-key') {
 		return app.ms.accountStorage.getStaticIdPublicKeyByOr(payload.ownerId);
 	}


### PR DESCRIPTION
## Summary

- preserve HTTP retryability metadata from the chat transport
- mark permanent recipient responses failed after one visible delivery attempt
- keep timeout, rate-limit, and server responses on bounded retry
- add an independent two-node revoked-device scenario proving the recipient stores no event and the sender does not retry
- update chat implementation and remaining-work documentation

## Validation

- focused Docker tests: 6 passing
- full Docker suite: 613 passing, 11 pending