### PR TITLE
Run two-node chat reliability tests on separate Kubo peers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,4 +23,6 @@ test/.geesome-frontend
 test/.geesome-test-output
 test/.ipfs
 test/.ipfs-data
+test/.chat-ipfs
+test/.chat-ipfs-data
 test/.postgres-data

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ test/.geesome-data
 test/.geesome-frontend
 test/.ipfs
 test/.ipfs-data
+test/.chat-ipfs
+test/.chat-ipfs-data
 test/.postgres-data
 test/.geesome-test-output

--- a/README.MD
+++ b/README.MD
@@ -362,7 +362,14 @@ When a Docker image has already been built and you need to rerun the exact same 
 npm run test:docker:no-build
 ```
 
-The Docker test flow builds a Node 22 test image with `ffmpeg`, starts PostgreSQL and IPFS through `test/docker-compose.yml`, waits for those services, generates deterministic media/archive fixtures under `test/resources`, then runs `yarn test` inside the test container. A Kubo RPC storage service is treated as externally owned and is not stopped during app teardown. Set `STORAGE_STOP_REMOTE_NODE=1` only when the GeeSome process intentionally owns that Kubo daemon and should stop it with the app.
+The Docker test flow builds a Node 22 test image with `ffmpeg`, starts PostgreSQL
+and two isolated Kubo daemons through `test/docker-compose.yml`, waits for those
+services, generates deterministic media/archive fixtures under `test/resources`,
+then runs the test suite inside the test container. The second Kubo daemon gives
+the independent chat-node harness a distinct storage peer. Kubo RPC storage
+services are treated as externally owned and are not stopped during app
+teardown. Set `STORAGE_STOP_REMOTE_NODE=1` only when the GeeSome process
+intentionally owns that Kubo daemon and should stop it with the app.
 
 ## Links
 - [Manifests example](./docs/manifests-example.md)

--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -83,16 +83,17 @@ regress repair work. The following environment variables tune the bounded worker
 - `CHAT_ATTACHMENT_CLEANUP_RECORD_RETENTION_MS`
 
 The process-level reliability harness runs two independent GeeSome app
-processes with separate PostgreSQL databases and account-data directories. It
-proves that recipient downtime and both-node restart do not lose or duplicate a
-queued event when delivery resumes through the real HTTP inbox. A second
-scenario delivers source event three before events one and two, then proves the
-real signed HTTP sync path repairs the missing range, revalidates the already
-stored event without duplicating it, and makes a repeated repair a no-op. The
-revoked-device scenario proves the recipient stores no event and the sender
-records one visible failed delivery without retrying a permanent HTTP response.
-This is the durable HTTP baseline; separate IPFS-node, browser, and network-shape
-scenarios remain in the active TODO.
+processes with separate PostgreSQL databases, account-data directories, and
+Kubo storage daemons. The harness verifies the Kubo peer identities differ
+before running delivery scenarios. It proves that recipient downtime and
+both-node restart do not lose or duplicate a queued event when delivery resumes
+through the real HTTP inbox. A second scenario delivers source event three
+before events one and two, then proves the real signed HTTP sync path repairs
+the missing range, revalidates the already stored event without duplicating it,
+and makes a repeated repair a no-op. The revoked-device scenario proves the
+recipient stores no event and the sender records one visible failed delivery
+without retrying a permanent HTTP response. This is the durable HTTP baseline;
+browser and network-shape scenarios remain in the active TODO.
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
 direct-message send/read UX and explicit device trust verification are present

--- a/bash/docker-test
+++ b/bash/docker-test
@@ -50,6 +50,8 @@ if [[ "$cold" -eq 1 ]]; then
 		test/.geesome-data \
 		test/.geesome-frontend \
 		test/.geesome-test-output \
+		test/.chat-ipfs \
+		test/.chat-ipfs-data \
 		test/.ipfs \
 		test/.ipfs-data \
 		test/.postgres-data

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -258,15 +258,16 @@ TODO.
   queued across sender shutdown, resumes after app restart, records the signed
   acknowledgement, and does not duplicate the encrypted event.
 - An independent-process reliability harness starts two GeeSome apps with
-  separate PostgreSQL databases and account-data directories. Its first real
-  HTTP scenario stops the recipient, records a failed delivery, restarts both
-  nodes, and proves the persisted sender queue delivers exactly one opaque event
-  to the recipient database. Its reordered-delivery scenario sends source event
-  three first, repairs events one and two through the signed HTTP sync endpoint,
+  separate PostgreSQL databases, account-data directories, and Kubo daemons
+  whose peer identities are verified as distinct. Its first real HTTP scenario
+  stops the recipient, records a failed delivery, restarts both nodes, and
+  proves the persisted sender queue delivers exactly one opaque event to the
+  recipient database. Its reordered-delivery scenario sends source event three
+  first, repairs events one and two through the signed HTTP sync endpoint,
   revalidates event three without duplicating it, and proves a repeated repair
   imports nothing. Its revoked-device scenario proves the recipient stores no
-  event and the sender records one visible failed delivery instead of retrying a
-  permanent HTTP rejection.
+  event and the sender records one visible failed delivery instead of retrying
+  a permanent HTTP rejection.
 - Configured nodes advertise canonical delivery, sync, and device-discovery
   endpoints in signed user manifests. Older profiles omit this additive field
   and remain valid.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -115,8 +115,9 @@ Current safety boundary:
 Remaining delivery order:
 
 1. Promote the independent-process restart and reordered-repair scenarios into
-   real two-browser/two-node tests. Add separate-IPFS-node and
-   NAT/bootstrap/reciprocal-peering conditions.
+   real two-browser/two-node tests. Add NAT/bootstrap/reciprocal-peering
+   conditions and encrypted attachment transfer between the separate IPFS
+   nodes.
 2. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old

--- a/test/chatTwoNodeReliability.test.ts
+++ b/test/chatTwoNodeReliability.test.ts
@@ -33,6 +33,10 @@ describe('two-node chat reliability', function () {
 	let dataDirB: string;
 	let portA: number;
 	let portB: number;
+	let storageNodeIdA: string;
+	let storageNodeIdB: string;
+	let storageUrlA: string;
+	let storageUrlB: string;
 
 	beforeEach(async () => {
 		const suffix = `${process.pid}_${Date.now()}`;
@@ -40,11 +44,27 @@ describe('two-node chat reliability', function () {
 		databaseB = `geesome_chat_b_${suffix}`;
 		dataDirA = path.join(os.tmpdir(), databaseA);
 		dataDirB = path.join(os.tmpdir(), databaseB);
+		storageUrlA = process.env.STORAGE_URL || 'http://127.0.0.1:5001';
+		storageUrlB = process.env.CHAT_TEST_STORAGE_URL_B || storageUrlA;
 		[portA, portB] = await Promise.all([findFreePort(), findFreePort()]);
 		await createTestDatabase(databaseA);
 		await createTestDatabase(databaseB);
-		nodeA = await ChatNodeProcess.start(createNodeConfig(databaseA, dataDirA, portA));
-		nodeB = await ChatNodeProcess.start(createNodeConfig(databaseB, dataDirB, portB));
+		nodeA = await ChatNodeProcess.start(createNodeConfig(
+			databaseA,
+			dataDirA,
+			portA,
+			storageUrlA
+		));
+		nodeB = await ChatNodeProcess.start(createNodeConfig(
+			databaseB,
+			dataDirB,
+			portB,
+			storageUrlB
+		));
+		[storageNodeIdA, storageNodeIdB] = await Promise.all([
+			nodeA.request('get-storage-node-id'),
+			nodeB.request('get-storage-node-id')
+		]);
 	});
 
 	afterEach(async () => {
@@ -57,6 +77,13 @@ describe('two-node chat reliability', function () {
 			fs.rm(dataDirA, {recursive: true, force: true}),
 			fs.rm(dataDirB, {recursive: true, force: true})
 		]);
+	});
+
+	it('runs each GeeSome process against a distinct IPFS node', function () {
+		if (!process.env.CHAT_TEST_STORAGE_URL_B) {
+			this.skip();
+		}
+		assert.notEqual(storageNodeIdA, storageNodeIdB);
 	});
 
 	it('delivers one queued event after both independent nodes restart', async () => {
@@ -129,8 +156,18 @@ describe('two-node chat reliability', function () {
 		await nodeA.stop();
 		nodeA = null;
 
-		nodeB = await ChatNodeProcess.start(createNodeConfig(databaseB, dataDirB, portB));
-		nodeA = await ChatNodeProcess.start(createNodeConfig(databaseA, dataDirA, portA));
+		nodeB = await ChatNodeProcess.start(createNodeConfig(
+			databaseB,
+			dataDirB,
+			portB,
+			storageUrlB
+		));
+		nodeA = await ChatNodeProcess.start(createNodeConfig(
+			databaseA,
+			dataDirA,
+			portA,
+			storageUrlA
+		));
 		const delivered = await nodeA.request('process-deliveries', {
 			options: {now: new Date(Date.now() + 6000).toISOString()}
 		});
@@ -371,6 +408,7 @@ type ChatNodeConfig = {
 	databaseName: string;
 	dataDir: string;
 	port: number;
+	storageUrl: string;
 };
 
 class ChatNodeProcess {
@@ -419,6 +457,7 @@ class ChatNodeProcess {
 				DATABASE_APPLICATION_NAME: `geesome-chat-test-${config.databaseName}`,
 				DATA_DIR: config.dataDir,
 				PORT: String(config.port),
+				STORAGE_URL: config.storageUrl,
 				MODULES: requiredModules,
 				STORAGE_MODULE: 'ipfs-http-client',
 				CHAT_AUTO_PROCESS_DELIVERIES: '0',
@@ -509,9 +548,10 @@ class ChatNodeProcess {
 function createNodeConfig(
 	databaseName: string,
 	dataDir: string,
-	port: number
+	port: number,
+	storageUrl: string
 ): ChatNodeConfig {
-	return {databaseName, dataDir, port};
+	return {databaseName, dataDir, port, storageUrl};
 }
 
 async function setupChatParticipants(

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -13,6 +13,8 @@ services:
         condition: service_healthy
       ipfs:
         condition: service_started
+      chat_ipfs_b:
+        condition: service_started
     volumes:
       - "${GEESOME_DATA:-./.geesome-data}:/geesome-node/data"
       - "${GEESOME_FRONTEND_DIST:-./.geesome-frontend}:/geesome-node/frontend/docker-dist"
@@ -28,6 +30,7 @@ services:
       - DATABASE_PORT=5432
       - STORAGE_MODULE=ipfs-http-client
       - STORAGE_URL=http://go_ipfs:5001
+      - CHAT_TEST_STORAGE_URL_B=http://geesome_chat_ipfs_b:5001
       - NPM_CONFIG_UPDATE_NOTIFIER=false
 
   postgres:
@@ -60,3 +63,14 @@ services:
     volumes:
       - "${STORAGE_STAGING:-./.ipfs}:/export"
       - "${STORAGE_DATA:-./.ipfs-data}:/data/ipfs"
+
+  chat_ipfs_b:
+    container_name: geesome_chat_ipfs_b
+    image: "ipfs/kubo:v0.31.0"
+    environment:
+      - IPFS_PROFILE
+    expose:
+      - 5001
+    volumes:
+      - "${CHAT_STORAGE_STAGING:-./.chat-ipfs}:/export"
+      - "${CHAT_STORAGE_DATA:-./.chat-ipfs-data}:/data/ipfs"

--- a/test/fixtures/chatNodeChild.ts
+++ b/test/fixtures/chatNodeChild.ts
@@ -73,6 +73,10 @@ async function runCommand(command: string, payload: any) {
 	if (command === 'get-transport-public-key') {
 		return app.ms.accountStorage.getStaticIdPublicKeyByOr(payload.ownerId);
 	}
+	if (command === 'get-storage-node-id') {
+		const nodeInfo = await app.ms.storage.node.id();
+		return String(nodeInfo.id);
+	}
 	if (command === 'accept-event') {
 		return app.ms.chat.acceptEncryptedEvent(
 			payload.userId,


### PR DESCRIPTION
## Summary

- add an isolated second Kubo daemon to the Docker test topology
- pass distinct storage URLs to the two independent GeeSome child processes and preserve them across restart
- verify the connected Kubo peer identities differ before delivery scenarios run
- keep generated chat Kubo repositories out of Git and Docker build contexts
- update the README and chat implementation/TODO documentation

## Validation

- focused two-node Docker test: 4 passing
- full Docker suite: 614 passing, 11 pending
- Docker Compose configuration validation passed