### PR TITLE
Verify encrypted chat attachments across Kubo peers

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -48,7 +48,7 @@ GeeSome protocol created to provide communication tool between communities of pr
 
 Galt Project team is aware of many cases of censorship and blocking in different social networks. These cases forced us to develop a new decentralized protocol and node application that would allow anyone to upload any content to his personal node and to share this content with the whole world without the risk of being blocked.
 
-Using the GeeSome protocol, communities in the Galt Project should eventually be able to communicate in end-to-end encrypted chat groups, share images, video, text or any data. Browser-encrypted direct messages now keep device private keys and plaintext outside GeeSome nodes, which store and route opaque ciphertext. Production-secure group chat still requires explicit device trust, encrypted attachments, a reviewed membership/key-rotation protocol, and real multi-node browser verification.
+Using the GeeSome protocol, communities in the Galt Project should eventually be able to communicate in end-to-end encrypted chat groups, share images, video, text or any data. Browser-encrypted direct messages and attachments now keep device private keys, plaintext, and attachment keys outside GeeSome nodes, which store and route opaque ciphertext. Production-ready group chat still requires a maintained MLS implementation, membership/key-rotation flows, and real multi-node browser verification.
 
 We are sure that this tool should be used not only by the project's communities, but also by anyone who is concerned about the safety of their data, censorship and blocking in web.
 
@@ -272,7 +272,7 @@ geesomeClient.init().then(async () => {
 ```
 
 ## Current state and features:
-- Browser-first encrypted direct messages with client-held device keys, opaque node storage, authenticated delayed inter-node delivery, and signed history repair; production device trust, attachments, group key rotation, and multi-node browser testing remain
+- Browser-first encrypted direct messages and attachments with client-held device keys, opaque node storage, authenticated delayed inter-node delivery, and signed history repair; group key rotation and multi-node browser testing remain
 - Public channels and posts
 - Streamable media api(video and audio)
 - Basic file manager
@@ -292,7 +292,7 @@ geesomeClient.init().then(async () => {
 ## TODO:
 
 - Complete the remaining operator-run ActivityPub/Bluesky release gates: credentialed native Bluesky writes, public staging-node inbox/outbox exchange, and external signed-ownership proof compatibility.
-- Complete browser-first secure chat with explicit device trust, encrypted attachments, a reviewed group membership/key-rotation protocol, retention quotas, and real multi-node browser tests. Private keys and plaintext remain on user devices; nodes persist and route only opaque encrypted envelopes and delivery metadata.
+- Complete browser-first secure chat with a maintained group membership/key-rotation implementation, retention quotas, and real multi-node browser tests. Private keys and plaintext remain on user devices; nodes persist and route only opaque encrypted envelopes and delivery metadata.
 - Finish API route ownership and public-route abuse coverage before expanding federation and secure-chat surfaces.
 - Complete static-site settings validation and generated frontend delivery while preserving the stabilized renderer.
 - Attribute reported content-serving CPU saturation across GeeSome, Kubo, PostgreSQL, nginx, media conversion, and storage I/O before changing runtime behavior.

--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -85,15 +85,20 @@ regress repair work. The following environment variables tune the bounded worker
 The process-level reliability harness runs two independent GeeSome app
 processes with separate PostgreSQL databases, account-data directories, and
 Kubo storage daemons. The harness verifies the Kubo peer identities differ
-before running delivery scenarios. It proves that recipient downtime and
-both-node restart do not lose or duplicate a queued event when delivery resumes
-through the real HTTP inbox. A second scenario delivers source event three
-before events one and two, then proves the real signed HTTP sync path repairs
-the missing range, revalidates the already stored event without duplicating it,
-and makes a repeated repair a no-op. The revoked-device scenario proves the
-recipient stores no event and the sender records one visible failed delivery
-without retrying a permanent HTTP response. This is the durable HTTP baseline;
-browser and network-shape scenarios remain in the active TODO.
+before running delivery scenarios. With an explicit direct peer connection, an
+attachment scenario encrypts bytes in the test client, stores only ciphertext
+on the sender Kubo daemon, and proves the recipient Kubo daemon fetches and pins
+that CID before the HTTP acknowledgement. The test client then retrieves and
+decrypts the recipient copy. The harness also proves that recipient downtime
+and both-node restart do not lose or duplicate a queued event when delivery
+resumes through the real HTTP inbox. A reordered scenario delivers source event
+three before events one and two, then proves the real signed HTTP sync path
+repairs the missing range, revalidates the already stored event without
+duplicating it, and makes a repeated repair a no-op. The revoked-device scenario
+proves the recipient stores no event and the sender records one visible failed
+delivery without retrying a permanent HTTP response. This is the durable HTTP
+and separate-storage baseline; browser and network-shape scenarios remain in
+the active TODO.
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
 direct-message send/read UX and explicit device trust verification are present

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -262,12 +262,15 @@ TODO.
   whose peer identities are verified as distinct. Its first real HTTP scenario
   stops the recipient, records a failed delivery, restarts both nodes, and
   proves the persisted sender queue delivers exactly one opaque event to the
-  recipient database. Its reordered-delivery scenario sends source event three
-  first, repairs events one and two through the signed HTTP sync endpoint,
-  revalidates event three without duplicating it, and proves a repeated repair
-  imports nothing. Its revoked-device scenario proves the recipient stores no
-  event and the sender records one visible failed delivery instead of retrying
-  a permanent HTTP rejection.
+  recipient database. Its encrypted-attachment scenario directly peers the two
+  Kubo daemons, uploads browser-produced ciphertext to the sender only, proves
+  the recipient fetches and pins the CID before acknowledgement, and decrypts
+  the recipient copy only in the test client. Its reordered-delivery scenario
+  sends source event three first, repairs events one and two through the signed
+  HTTP sync endpoint, revalidates event three without duplicating it, and proves
+  a repeated repair imports nothing. Its revoked-device scenario proves the
+  recipient stores no event and the sender records one visible failed delivery
+  instead of retrying a permanent HTTP rejection.
 - Configured nodes advertise canonical delivery, sync, and device-discovery
   endpoints in signed user manifests. Older profiles omit this additive field
   and remain valid.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -115,9 +115,9 @@ Current safety boundary:
 Remaining delivery order:
 
 1. Promote the independent-process restart and reordered-repair scenarios into
-   real two-browser/two-node tests. Add NAT/bootstrap/reciprocal-peering
-   conditions and encrypted attachment transfer between the separate IPFS
-   nodes.
+   real two-browser/two-node tests. Add NAT, bootstrap discovery, peer
+   reconnection, and reciprocal-peering conditions around the now-covered
+   encrypted attachment transfer between separate IPFS nodes.
 2. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old

--- a/test/chatTwoNodeReliability.test.ts
+++ b/test/chatTwoNodeReliability.test.ts
@@ -86,6 +86,121 @@ describe('two-node chat reliability', function () {
 		assert.notEqual(storageNodeIdA, storageNodeIdB);
 	});
 
+	it('fetches and pins an encrypted attachment on the recipient IPFS node', async function () {
+		if (!process.env.CHAT_TEST_STORAGE_URL_B) {
+			this.skip();
+		}
+		const {
+			alice,
+			bob,
+			aliceDevice,
+			bobDevice
+		} = await setupChatParticipants(nodeA, nodeB, 'attachment');
+		await nodeB.request('connect-storage-peer', {
+			address: createStoragePeerAddress(storageUrlA, storageNodeIdA)
+		});
+		const plaintext = Buffer.from('two-node encrypted attachment');
+		const encryptedAttachment = await browserE2eeHelper.encryptAttachment(
+			plaintext,
+			{
+				name: 'attachment.txt',
+				mimeType: 'text/plain'
+			}
+		);
+		const uploaded = await nodeA.request('save-owned-attachment', {
+			userId: alice.id,
+			dataBase64: Buffer.from(
+				encryptedAttachment.attachment.ciphertext
+			).toString('base64')
+		});
+		const attachmentReference = {
+			storageId: uploaded.storageId,
+			encryption: {
+				version: encryptedAttachment.attachment.version,
+				algorithm: encryptedAttachment.attachment.algorithm,
+				mimeType: encryptedAttachment.attachment.mimeType,
+				name: encryptedAttachment.attachment.name,
+				size: encryptedAttachment.attachment.size,
+				iv: encryptedAttachment.attachment.iv,
+				key: browserE2eeHelper.encodeBase64Url(encryptedAttachment.key)
+			}
+		};
+		const envelope = await browserE2eeHelper.encryptEnvelope(
+			{
+				text: '',
+				attachments: [attachmentReference]
+			},
+			[bobDevice.publicBundle],
+			aliceDevice,
+			{
+				messageId: 'two-node-attachment-message-1',
+				conversationId: 'two-node-attachment-conversation-1',
+				metadata: {attachmentStorageIds: [uploaded.storageId]}
+			}
+		);
+		const bobTransportPublicKey = await nodeB.request(
+			'get-transport-public-key',
+			{ownerId: bob.storageAccountId}
+		);
+		await nodeA.request('accept-event', {
+			userId: alice.id,
+			envelope,
+			options: {
+				recipientEndpoints: [{
+					ownerId: bob.storageAccountId,
+					publicKey: bobTransportPublicKey,
+					inboxUrl: `http://127.0.0.1:${portB}/v1/chat/inbox`
+				}]
+			}
+		});
+
+		const delivery = await nodeA.request('process-deliveries');
+		assert.deepEqual(delivery, {
+			processed: 1,
+			delivered: 1,
+			failed: 0,
+			pending: 0
+		});
+		const received = await nodeB.request('get-events', {
+			userId: bob.id,
+			conversationId: envelope.conversationId
+		});
+		assert.equal(received.total, 1);
+		const message = await browserE2eeHelper.decryptEnvelopeJson(
+			received.list[0].envelope,
+			bobDevice,
+			aliceDevice.publicBundle
+		);
+		const fetched = await nodeB.request('get-storage-data', {
+			storageId: message.attachments[0].storageId
+		});
+		assert.equal(await nodeB.request('is-storage-pinned', {
+			storageId: message.attachments[0].storageId
+		}), true);
+		const expectedCiphertext = Buffer.from(
+			encryptedAttachment.attachment.ciphertext
+		);
+		assert.equal(
+			fetched.dataBase64,
+			expectedCiphertext.toString('base64')
+		);
+		assert.equal(
+			message.attachments[0].encryption.key,
+			browserE2eeHelper.encodeBase64Url(encryptedAttachment.key)
+		);
+		const decrypted = await browserE2eeHelper.decryptAttachment(
+			{
+				...message.attachments[0].encryption,
+				key: undefined,
+				ciphertext: Buffer.from(fetched.dataBase64, 'base64')
+			},
+			browserE2eeHelper.decodeBase64Url(
+				message.attachments[0].encryption.key
+			)
+		);
+		assert.deepEqual(Buffer.from(decrypted), plaintext);
+	});
+
 	it('delivers one queued event after both independent nodes restart', async () => {
 		const aliceSetup = await nodeA.request('setup', {
 			user: {
@@ -552,6 +667,11 @@ function createNodeConfig(
 	storageUrl: string
 ): ChatNodeConfig {
 	return {databaseName, dataDir, port, storageUrl};
+}
+
+function createStoragePeerAddress(storageUrl: string, peerId: string): string {
+	const hostname = new URL(storageUrl).hostname;
+	return `/dns4/${hostname}/tcp/4001/p2p/${peerId}`;
 }
 
 async function setupChatParticipants(

--- a/test/fixtures/chatNodeChild.ts
+++ b/test/fixtures/chatNodeChild.ts
@@ -77,6 +77,19 @@ async function runCommand(command: string, payload: any) {
 		const nodeInfo = await app.ms.storage.node.id();
 		return String(nodeInfo.id);
 	}
+	if (command === 'connect-storage-peer') {
+		await app.ms.storage.swarmConnect(payload.address);
+		return {connected: true};
+	}
+	if (command === 'save-owned-attachment') {
+		return saveOwnedAttachment(payload);
+	}
+	if (command === 'get-storage-data') {
+		return getStorageData(payload.storageId);
+	}
+	if (command === 'is-storage-pinned') {
+		return isStoragePinned(payload.storageId);
+	}
 	if (command === 'accept-event') {
 		return app.ms.chat.acceptEncryptedEvent(
 			payload.userId,
@@ -119,4 +132,47 @@ function toPlainValue(value) {
 		return null;
 	}
 	return JSON.parse(JSON.stringify(value));
+}
+
+async function saveOwnedAttachment(payload: any) {
+	const data = Buffer.from(payload.dataBase64, 'base64');
+	const reservation = await app.ms.chat.createAttachmentUploadReservation(
+		payload.userId,
+		data.length
+	);
+	const storageFile = await app.ms.storage.saveFileByData(data);
+	await app.ms.storage.addPin(storageFile.id);
+	const content = await app.ms.database.addContent({
+		userId: payload.userId,
+		storageType: 'ipfs',
+		mimeType: 'application/octet-stream',
+		storageId: storageFile.id,
+		size: data.length,
+		name: payload.name || 'encrypted-chat-attachment'
+	});
+	await app.ms.chat.afterContentAdding(payload.userId, content, {
+		chatAttachmentReservationId: reservation.reservationId
+	});
+	return {
+		storageId: storageFile.id,
+		size: data.length,
+		reservationId: reservation.reservationId
+	};
+}
+
+async function getStorageData(storageId: string) {
+	const data = await app.ms.storage.getFileData(storageId);
+	const bytes = typeof data?.slice === 'function'
+		? data.slice()
+		: data;
+	return {dataBase64: Buffer.from(bytes).toString('base64')};
+}
+
+async function isStoragePinned(storageId: string) {
+	for await (const pin of app.ms.storage.node.pin.ls({paths: [storageId]})) {
+		if (String(pin.cid) === storageId) {
+			return true;
+		}
+	}
+	return false;
 }


### PR DESCRIPTION
## Summary

- extend the independent-process chat harness with production-like ciphertext reservation, upload, peer connection, and recipient storage inspection
- prove a recipient on a separate Kubo daemon fetches and pins an encrypted attachment before acknowledging delivery
- decrypt the recipient copy only in the test client and update implemented/TODO documentation

## Verification

- focused two-node Docker file: 5 passing
- focused attachment scenario after readability cleanup: 1 passing
- full Docker suite: 615 passing, 11 pending
- Docker Compose configuration validation passed
- TODO section context and diff checks passed