### PR TITLE
Verify chat attachment recovery after storage becomes reachable

### DIFF
--- a/app/modules/chat/docs/overview.md
+++ b/app/modules/chat/docs/overview.md
@@ -89,16 +89,20 @@ before running delivery scenarios. With an explicit direct peer connection, an
 attachment scenario encrypts bytes in the test client, stores only ciphertext
 on the sender Kubo daemon, and proves the recipient Kubo daemon fetches and pins
 that CID before the HTTP acknowledgement. The test client then retrieves and
-decrypts the recipient copy. The harness also proves that recipient downtime
-and both-node restart do not lose or duplicate a queued event when delivery
-resumes through the real HTTP inbox. A reordered scenario delivers source event
-three before events one and two, then proves the real signed HTTP sync path
-repairs the missing range, revalidates the already stored event without
-duplicating it, and makes a repeated repair a no-op. The revoked-device scenario
-proves the recipient stores no event and the sender records one visible failed
-delivery without retrying a permanent HTTP response. This is the durable HTTP
-and separate-storage baseline; browser and network-shape scenarios remain in
-the active TODO.
+decrypts the recipient copy. A retry scenario reserves the real ciphertext CID
+before those bytes are available, proves the recipient rejects the event with a
+retryable response, then materializes the same CID and makes the sender peer
+reachable. The queued delivery succeeds on its second attempt without creating
+an event during the failed attempt. The harness also proves that recipient
+downtime and both-node restart do not lose or duplicate a queued event when
+delivery resumes through the real HTTP inbox. A reordered scenario delivers
+source event three before events one and two, then proves the real signed HTTP
+sync path repairs the missing range, revalidates the already stored event
+without duplicating it, and makes a repeated repair a no-op. The revoked-device
+scenario proves the recipient stores no event and the sender records one visible
+failed delivery without retrying a permanent HTTP response. This is the durable
+HTTP and separate-storage baseline; browser and broader network-shape scenarios
+remain in the active TODO.
 
 Browser device creation, encrypted recovery/restore, revocation, and encrypted
 direct-message send/read UX and explicit device trust verification are present

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -265,7 +265,10 @@ TODO.
   recipient database. Its encrypted-attachment scenario directly peers the two
   Kubo daemons, uploads browser-produced ciphertext to the sender only, proves
   the recipient fetches and pins the CID before acknowledgement, and decrypts
-  the recipient copy only in the test client. Its reordered-delivery scenario
+  the recipient copy only in the test client. Its unavailable-attachment
+  scenario proves the recipient commits no event after a retryable fetch
+  failure, then materializes the same CID, connects the sender storage peer, and
+  delivers once on the second queued attempt. Its reordered-delivery scenario
   sends source event three first, repairs events one and two through the signed
   HTTP sync endpoint, revalidates event three without duplicating it, and proves
   a repeated repair imports nothing. Its revoked-device scenario proves the

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -116,8 +116,9 @@ Remaining delivery order:
 
 1. Promote the independent-process restart and reordered-repair scenarios into
    real two-browser/two-node tests. Add NAT, bootstrap discovery, peer
-   reconnection, and reciprocal-peering conditions around the now-covered
-   encrypted attachment transfer between separate IPFS nodes.
+   reconnection after daemon restart, and reciprocal-peering persistence around
+   the now-covered encrypted attachment transfer and retryable fetch recovery
+   between separate IPFS nodes.
 2. Define operator-visible queue/reconciliation metrics and explicit encrypted
    event retention, retry deadline, quota, and cleanup policy. Migrate or
    explicitly retire the legacy server-encrypted path without relabelling old
@@ -209,8 +210,7 @@ Verification:
   recovers every locally accepted event through sequence/head reconciliation.
 - Recipient restart after persistence but before acknowledgement, browser
   resubmission after a rejected local save, brief network partition,
-  reciprocal-peering reconnect, remote fetch/pin failure, and database/storage
-  failure scenarios.
+  reciprocal-peering reconnect, and database/storage failure scenarios.
 - Concurrent worker lease recovery, quota/expiry, permanent rejection, and
   membership-removal cancellation.
 - Membership removal and key rotation proving removed devices cannot decrypt new

--- a/test/chatTwoNodeReliability.test.ts
+++ b/test/chatTwoNodeReliability.test.ts
@@ -99,44 +99,16 @@ describe('two-node chat reliability', function () {
 		await nodeB.request('connect-storage-peer', {
 			address: createStoragePeerAddress(storageUrlA, storageNodeIdA)
 		});
-		const plaintext = Buffer.from('two-node encrypted attachment');
-		const encryptedAttachment = await browserE2eeHelper.encryptAttachment(
-			plaintext,
-			{
-				name: 'attachment.txt',
-				mimeType: 'text/plain'
-			}
+		const attachment = await prepareEncryptedAttachment(
+			nodeA,
+			alice.id,
+			'save-owned-attachment'
 		);
-		const uploaded = await nodeA.request('save-owned-attachment', {
-			userId: alice.id,
-			dataBase64: Buffer.from(
-				encryptedAttachment.attachment.ciphertext
-			).toString('base64')
-		});
-		const attachmentReference = {
-			storageId: uploaded.storageId,
-			encryption: {
-				version: encryptedAttachment.attachment.version,
-				algorithm: encryptedAttachment.attachment.algorithm,
-				mimeType: encryptedAttachment.attachment.mimeType,
-				name: encryptedAttachment.attachment.name,
-				size: encryptedAttachment.attachment.size,
-				iv: encryptedAttachment.attachment.iv,
-				key: browserE2eeHelper.encodeBase64Url(encryptedAttachment.key)
-			}
-		};
-		const envelope = await browserE2eeHelper.encryptEnvelope(
-			{
-				text: '',
-				attachments: [attachmentReference]
-			},
-			[bobDevice.publicBundle],
+		const envelope = await createAttachmentEnvelope(
+			attachment.reference,
 			aliceDevice,
-			{
-				messageId: 'two-node-attachment-message-1',
-				conversationId: 'two-node-attachment-conversation-1',
-				metadata: {attachmentStorageIds: [uploaded.storageId]}
-			}
+			bobDevice,
+			'two-node-attachment'
 		);
 		const bobTransportPublicKey = await nodeB.request(
 			'get-transport-public-key',
@@ -166,39 +138,108 @@ describe('two-node chat reliability', function () {
 			conversationId: envelope.conversationId
 		});
 		assert.equal(received.total, 1);
-		const message = await browserE2eeHelper.decryptEnvelopeJson(
+		await assertReceivedAttachment(
+			nodeB,
 			received.list[0].envelope,
+			attachment,
+			aliceDevice,
+			bobDevice
+		);
+	});
+
+	it('retries an unavailable attachment after the storage peer becomes reachable', async function () {
+		if (!process.env.CHAT_TEST_STORAGE_URL_B) {
+			this.skip();
+		}
+		const {
+			alice,
+			bob,
+			aliceDevice,
+			bobDevice
+		} = await setupChatParticipants(nodeA, nodeB, 'attachment-retry');
+		const attachment = await prepareEncryptedAttachment(
+			nodeA,
+			alice.id,
+			'reserve-missing-owned-attachment'
+		);
+		const envelope = await createAttachmentEnvelope(
+			attachment.reference,
+			aliceDevice,
 			bobDevice,
-			aliceDevice.publicBundle
+			'two-node-attachment-retry'
 		);
-		const fetched = await nodeB.request('get-storage-data', {
-			storageId: message.attachments[0].storageId
+		const bobTransportPublicKey = await nodeB.request(
+			'get-transport-public-key',
+			{ownerId: bob.storageAccountId}
+		);
+		await nodeA.request('accept-event', {
+			userId: alice.id,
+			envelope,
+			options: {
+				recipientEndpoints: [{
+					ownerId: bob.storageAccountId,
+					publicKey: bobTransportPublicKey,
+					inboxUrl: `http://127.0.0.1:${portB}/v1/chat/inbox`
+				}]
+			}
 		});
-		assert.equal(await nodeB.request('is-storage-pinned', {
-			storageId: message.attachments[0].storageId
-		}), true);
-		const expectedCiphertext = Buffer.from(
-			encryptedAttachment.attachment.ciphertext
+
+		const unavailable = await nodeA.request('process-deliveries');
+		assert.deepEqual(unavailable, {
+			processed: 1,
+			delivered: 0,
+			failed: 0,
+			pending: 1
+		});
+		const pendingDeliveries = await nodeA.request('get-deliveries', {
+			userId: alice.id,
+			messageId: envelope.messageId
+		});
+		assert.equal(pendingDeliveries.length, 1);
+		assert.equal(pendingDeliveries[0].state, 'pending');
+		assert.equal(pendingDeliveries[0].attempts, 1);
+		assert.equal(pendingDeliveries[0].lastError, 'chat_delivery_http_503');
+		const missingEvents = await nodeB.request('get-events', {
+			userId: bob.id,
+			conversationId: envelope.conversationId
+		});
+		assert.equal(missingEvents.total, 0);
+
+		const stored = await nodeA.request('save-storage-data', {
+			dataBase64: attachment.ciphertextBase64
+		});
+		assert.equal(stored.storageId, attachment.reference.storageId);
+		await nodeB.request('connect-storage-peer', {
+			address: createStoragePeerAddress(storageUrlA, storageNodeIdA)
+		});
+		const delivered = await nodeA.request('process-deliveries', {
+			options: {now: new Date(Date.now() + 6000).toISOString()}
+		});
+		assert.deepEqual(delivered, {
+			processed: 1,
+			delivered: 1,
+			failed: 0,
+			pending: 0
+		});
+		const deliveries = await nodeA.request('get-deliveries', {
+			userId: alice.id,
+			messageId: envelope.messageId
+		});
+		assert.equal(deliveries.length, 1);
+		assert.equal(deliveries[0].state, 'delivered');
+		assert.equal(deliveries[0].attempts, 2);
+		const received = await nodeB.request('get-events', {
+			userId: bob.id,
+			conversationId: envelope.conversationId
+		});
+		assert.equal(received.total, 1);
+		await assertReceivedAttachment(
+			nodeB,
+			received.list[0].envelope,
+			attachment,
+			aliceDevice,
+			bobDevice
 		);
-		assert.equal(
-			fetched.dataBase64,
-			expectedCiphertext.toString('base64')
-		);
-		assert.equal(
-			message.attachments[0].encryption.key,
-			browserE2eeHelper.encodeBase64Url(encryptedAttachment.key)
-		);
-		const decrypted = await browserE2eeHelper.decryptAttachment(
-			{
-				...message.attachments[0].encryption,
-				key: undefined,
-				ciphertext: Buffer.from(fetched.dataBase64, 'base64')
-			},
-			browserE2eeHelper.decodeBase64Url(
-				message.attachments[0].encryption.key
-			)
-		);
-		assert.deepEqual(Buffer.from(decrypted), plaintext);
 	});
 
 	it('delivers one queued event after both independent nodes restart', async () => {
@@ -672,6 +713,95 @@ function createNodeConfig(
 function createStoragePeerAddress(storageUrl: string, peerId: string): string {
 	const hostname = new URL(storageUrl).hostname;
 	return `/dns4/${hostname}/tcp/4001/p2p/${peerId}`;
+}
+
+async function prepareEncryptedAttachment(
+	node: ChatNodeProcess,
+	userId: number,
+	command: string
+) {
+	const plaintext = Buffer.from('two-node encrypted attachment');
+	const encrypted = await browserE2eeHelper.encryptAttachment(plaintext, {
+		name: 'attachment.txt',
+		mimeType: 'text/plain'
+	});
+	const ciphertextBase64 = Buffer.from(
+		encrypted.attachment.ciphertext
+	).toString('base64');
+	const uploaded = await node.request(command, {
+		userId,
+		dataBase64: ciphertextBase64
+	});
+	return {
+		plaintext,
+		encrypted,
+		ciphertextBase64,
+		reference: {
+			storageId: uploaded.storageId,
+			encryption: {
+				version: encrypted.attachment.version,
+				algorithm: encrypted.attachment.algorithm,
+				mimeType: encrypted.attachment.mimeType,
+				name: encrypted.attachment.name,
+				size: encrypted.attachment.size,
+				iv: encrypted.attachment.iv,
+				key: browserE2eeHelper.encodeBase64Url(encrypted.key)
+			}
+		}
+	};
+}
+
+function createAttachmentEnvelope(
+	reference: any,
+	senderDevice: any,
+	recipientDevice: any,
+	idPrefix: string
+) {
+	return browserE2eeHelper.encryptEnvelope(
+		{text: '', attachments: [reference]},
+		[recipientDevice.publicBundle],
+		senderDevice,
+		{
+			messageId: `${idPrefix}-message-1`,
+			conversationId: `${idPrefix}-conversation-1`,
+			metadata: {attachmentStorageIds: [reference.storageId]}
+		}
+	);
+}
+
+async function assertReceivedAttachment(
+	node: ChatNodeProcess,
+	envelope: any,
+	attachment: any,
+	senderDevice: any,
+	recipientDevice: any
+) {
+	const message = await browserE2eeHelper.decryptEnvelopeJson(
+		envelope,
+		recipientDevice,
+		senderDevice.publicBundle
+	);
+	const reference = message.attachments[0];
+	const fetched = await node.request('get-storage-data', {
+		storageId: reference.storageId
+	});
+	assert.equal(await node.request('is-storage-pinned', {
+		storageId: reference.storageId
+	}), true);
+	assert.equal(fetched.dataBase64, attachment.ciphertextBase64);
+	assert.equal(
+		reference.encryption.key,
+		browserE2eeHelper.encodeBase64Url(attachment.encrypted.key)
+	);
+	const decrypted = await browserE2eeHelper.decryptAttachment(
+		{
+			...reference.encryption,
+			key: undefined,
+			ciphertext: Buffer.from(fetched.dataBase64, 'base64')
+		},
+		browserE2eeHelper.decodeBase64Url(reference.encryption.key)
+	);
+	assert.deepEqual(Buffer.from(decrypted), attachment.plaintext);
 }
 
 async function setupChatParticipants(

--- a/test/fixtures/chatNodeChild.ts
+++ b/test/fixtures/chatNodeChild.ts
@@ -84,6 +84,12 @@ async function runCommand(command: string, payload: any) {
 	if (command === 'save-owned-attachment') {
 		return saveOwnedAttachment(payload);
 	}
+	if (command === 'reserve-missing-owned-attachment') {
+		return reserveMissingOwnedAttachment(payload);
+	}
+	if (command === 'save-storage-data') {
+		return saveStorageData(payload.dataBase64);
+	}
 	if (command === 'get-storage-data') {
 		return getStorageData(payload.storageId);
 	}
@@ -136,26 +142,54 @@ function toPlainValue(value) {
 
 async function saveOwnedAttachment(payload: any) {
 	const data = Buffer.from(payload.dataBase64, 'base64');
-	const reservation = await app.ms.chat.createAttachmentUploadReservation(
-		payload.userId,
-		data.length
-	);
 	const storageFile = await app.ms.storage.saveFileByData(data);
 	await app.ms.storage.addPin(storageFile.id);
+	return registerOwnedAttachment(payload, storageFile.id, data.length);
+}
+
+async function reserveMissingOwnedAttachment(payload: any) {
+	const data = Buffer.from(payload.dataBase64, 'base64');
+	const storageFile = await app.ms.storage.node.add(
+		{content: data},
+		{onlyHash: true, pin: false, cidVersion: 1}
+	);
+	return registerOwnedAttachment(
+		payload,
+		String(storageFile.cid),
+		data.length
+	);
+}
+
+async function saveStorageData(dataBase64: string) {
+	const data = Buffer.from(dataBase64, 'base64');
+	const storageFile = await app.ms.storage.saveFileByData(data);
+	await app.ms.storage.addPin(storageFile.id);
+	return {storageId: storageFile.id, size: data.length};
+}
+
+async function registerOwnedAttachment(
+	payload: any,
+	storageId: string,
+	size: number
+) {
+	const reservation = await app.ms.chat.createAttachmentUploadReservation(
+		payload.userId,
+		size
+	);
 	const content = await app.ms.database.addContent({
 		userId: payload.userId,
 		storageType: 'ipfs',
 		mimeType: 'application/octet-stream',
-		storageId: storageFile.id,
-		size: data.length,
+		storageId,
+		size,
 		name: payload.name || 'encrypted-chat-attachment'
 	});
 	await app.ms.chat.afterContentAdding(payload.userId, content, {
 		chatAttachmentReservationId: reservation.reservationId
 	});
 	return {
-		storageId: storageFile.id,
-		size: data.length,
+		storageId,
+		size,
 		reservationId: reservation.reservationId
 	};
 }


### PR DESCRIPTION
## Summary

- add a deterministic two-node case where an attachment CID is accepted before its ciphertext bytes are available
- verify the recipient returns a retryable response, commits no event, and leaves one pending delivery attempt
- materialize the same CID, connect the separate Kubo peers, and prove the queued delivery succeeds exactly once on attempt two
- factor shared attachment setup and client-only decryption assertions into named test helpers
- move the completed remote fetch recovery item from the active TODO into implemented documentation

## Verification

- attachment-focused Docker scenarios: 2 passing
- full independent-process Docker file: 6 passing
- final focused retry scenario: 1 passing
- full Docker suite: 616 passing, 11 pending
- Docker Compose configuration, TODO context, and diff checks passed