### PR TITLE
Isolate private group publishing policy

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -9,7 +9,7 @@
 
 //TODO: move communicator and fileCatalog to improve
 const modulePacks = {
-  'main': ['drivers', 'database', 'api', 'accountStorage', 'communicator', 'storage', 'content', 'staticId', 'asyncOperation', 'group', 'chat', 'fileCatalog', 'entityJsonManifest', 'imageComposition', 'remoteGroup'],
+  'main': ['drivers', 'database', 'api', 'accountStorage', 'communicator', 'storage', 'content', 'staticId', 'asyncOperation', 'privateGroup', 'group', 'chat', 'fileCatalog', 'entityJsonManifest', 'imageComposition', 'remoteGroup'],
   'improve': ['groupCategory', 'invite', 'staticSiteGenerator', 'rss', 'activityPub', 'autoActions', 'pin', 'foreignAccounts', 'ethereumAuthorization', 'storageSpace', 'gateway'],
   'socNet': ['socNetAccount', 'socNetImport', 'bluesky', 'telegramClient', 'twitterClient', 'tgContentBot']
 };
@@ -59,6 +59,9 @@ export default {
     reconciliationContinuationDelayMs: process.env.CHAT_RECONCILIATION_CONTINUATION_DELAY_MS,
     reconciliationPageLimit: process.env.CHAT_RECONCILIATION_PAGE_LIMIT,
     reconciliationMaxPages: process.env.CHAT_RECONCILIATION_MAX_PAGES
+  },
+  privateGroupConfig: {
+    enabled: process.env.PRIVATE_GROUP_ENABLED === '1'
   },
   activityPubConfig: {
     enabled: process.env.ACTIVITYPUB_ENABLED === '1',

--- a/app/index.ts
+++ b/app/index.ts
@@ -28,6 +28,7 @@ import IGeesomeDriversModule from "./modules/drivers/interface.js";
 import IGeesomeContentModule from "./modules/content/interface.js";
 import IGeesomeInviteModule from "./modules/invite/interface.js";
 import IGeesomeGroupModule from "./modules/group/interface.js";
+import IGeesomePrivateGroupModule from "./modules/privateGroup/interface.js";
 import IGeesomeChatModule from "./modules/chat/interface.js";
 import IGeesomeImageCompositionModule from "./modules/imageComposition/interface.js";
 import IGeesomeApiModule from "./modules/api/interface.js";
@@ -139,6 +140,7 @@ function getModule(config, appPass) {
       staticId: IGeesomeStaticIdModule,
       invite: IGeesomeInviteModule,
       group: IGeesomeGroupModule,
+      privateGroup?: IGeesomePrivateGroupModule,
       chat: IGeesomeChatModule,
       imageComposition: IGeesomeImageCompositionModule,
       accountStorage: IGeesomeAccountStorageModule,

--- a/app/interface.ts
+++ b/app/interface.ts
@@ -20,6 +20,7 @@ import IGeesomeDriversModule from "./modules/drivers/interface.js";
 import IGeesomeContentModule from "./modules/content/interface.js";
 import IGeesomeInviteModule from "./modules/invite/interface.js";
 import IGeesomeGroupModule from "./modules/group/interface.js";
+import IGeesomePrivateGroupModule from "./modules/privateGroup/interface.js";
 import IGeesomeChatModule from "./modules/chat/interface.js";
 import IGeesomeImageCompositionModule from "./modules/imageComposition/interface.js";
 import IGeesomeApiModule from "./modules/api/interface.js";
@@ -49,6 +50,7 @@ export interface IGeesomeApp {
     staticId: IGeesomeStaticIdModule;
     invite: IGeesomeInviteModule;
     group: IGeesomeGroupModule;
+    privateGroup?: IGeesomePrivateGroupModule;
     chat: IGeesomeChatModule;
     imageComposition: IGeesomeImageCompositionModule;
     accountStorage: IGeesomeAccountStorageModule;

--- a/app/modules/group/index.ts
+++ b/app/modules/group/index.ts
@@ -242,6 +242,7 @@ function getModule(app: IGeesomeApp, models) {
 
 	class GroupModule implements IGeesomeGroupModule {
 		async createGroup(userId, groupData) {
+			groupData = normalizePrivateGroupData(app, groupData);
 			log('groupData', groupData);
 			await app.checkUserCan(userId, CorePermissionName.UserGroupManagement);
 
@@ -266,6 +267,9 @@ function getModule(app: IGeesomeApp, models) {
 
 			if (groupData.type !== GroupType.PersonalChat) {
 				await this.addAdminToGroupPure(userId, group.id);
+			}
+			if (isPrivateGroup(group)) {
+				await this.addMemberToGroupPure(userId, group.id);
 			}
 
 			await this.updateGroupManifest(userId, group.id);
@@ -416,6 +420,7 @@ function getModule(app: IGeesomeApp, models) {
 				throw new Error("incorrect_name");
 			}
 			const group = await this.getGroup(groupId);
+			updateData = normalizePrivateGroupUpdateData(app, group, updateData);
 			if (updateData['name'] && updateData['name'] !== group.name) {
 				await app.ms.staticId.renameGroupStaticAccountId(userId, groupId, group.name, updateData['name']);
 			}
@@ -530,9 +535,10 @@ function getModule(app: IGeesomeApp, models) {
 
 		async callAfterPostManifestUpdateHooks(userId, post) {
 			try {
-				await app.callHook('group', 'afterPostManifestUpdate', [userId, post.id]);
+				const hookName = getPostManifestHook(app, post.group);
+				await app.callHook('group', hookName, [userId, post.id]);
 			} catch (e) {
-				log('afterPostManifestUpdate hook error', e);
+				log('post manifest hook error', e);
 			}
 		}
 
@@ -1040,6 +1046,16 @@ function getModule(app: IGeesomeApp, models) {
 			groupId = await this.checkGroupId(groupId);
 			const group = await this.getLocalGroup(userId, groupId);
 			const post = await this.getPostPure(postId);
+			const privateGroupModule = getPrivateGroupModule(app);
+			if (isPrivateGroup(group)) {
+				if (!privateGroupModule) {
+					throw new Error('private_group_module_required');
+				}
+				const isGroupParticipant = (await this.isAdminInGroupPure(userId, groupId))
+					|| (await this.isMemberInGroupPure(userId, groupId));
+				return isGroupParticipant
+					&& privateGroupModule.canMutateSharedPost(userId, post);
+			}
 			let canEdit = (await this.isAdminInGroupPure(userId, groupId))
 				|| (!group.isOpen && await this.isMemberInGroupPure(userId, groupId) && post.userId === userId);
 			if(canEdit) {
@@ -1788,7 +1804,7 @@ function getModule(app: IGeesomeApp, models) {
 		}
 
 		async addGroup(group) {
-			return models.Group.create(group);
+			return models.Group.create(normalizePrivateGroupData(app, group));
 		}
 
 		async updateGroupPure(id, updateData) {
@@ -2271,4 +2287,49 @@ function getModule(app: IGeesomeApp, models) {
 	}
 
 	return new GroupModule();
+}
+
+function getPrivateGroupModule(app: IGeesomeApp) {
+	return app.ms.privateGroup || null;
+}
+
+function isPrivateGroup(group) {
+	return group?.type === GroupType.PrivateGroup;
+}
+
+function normalizePrivateGroupData(app: IGeesomeApp, groupData) {
+	const privateGroupModule = getPrivateGroupModule(app);
+	if (privateGroupModule) {
+		return privateGroupModule.normalizeGroupData(groupData);
+	}
+	if (isPrivateGroup(groupData)) {
+		throw new Error('private_group_module_required');
+	}
+	return groupData;
+}
+
+function normalizePrivateGroupUpdateData(app: IGeesomeApp, group, updateData) {
+	const currentIsPrivate = isPrivateGroup(group);
+	const nextType = updateData?.type === undefined ? group.type : updateData.type;
+	if (currentIsPrivate !== (nextType === GroupType.PrivateGroup)) {
+		throw new Error('group_type_change_not_supported');
+	}
+	if (!currentIsPrivate) {
+		return updateData;
+	}
+	return normalizePrivateGroupData(app, {
+		...updateData,
+		type: GroupType.PrivateGroup
+	});
+}
+
+function getPostManifestHook(app: IGeesomeApp, group) {
+	const privateGroupModule = getPrivateGroupModule(app);
+	if (privateGroupModule) {
+		return privateGroupModule.getPostManifestHook(group);
+	}
+	if (isPrivateGroup(group)) {
+		throw new Error('private_group_module_required');
+	}
+	return 'afterPostManifestUpdate';
 }

--- a/app/modules/group/interface.ts
+++ b/app/modules/group/interface.ts
@@ -310,6 +310,7 @@ export interface IGroup {
 export enum GroupType {
 	Channel = 'channel',
 	Chat = 'chat',
+	PrivateGroup = 'private_group',
 	PersonalChat = 'personal_chat'
 }
 

--- a/app/modules/privateGroup/docs/overview.md
+++ b/app/modules/privateGroup/docs/overview.md
@@ -1,0 +1,39 @@
+# Private Group Module
+
+## Purpose
+
+The `privateGroup` module owns policy that distinguishes browser-encrypted
+private groups from public publishing groups while reusing the group, post,
+post-content, post-event, and reconciliation foundations.
+
+The initial capability:
+
+- identifies new private groups with `GroupType.PrivateGroup`;
+- keeps creation disabled by default until `PRIVATE_GROUP_ENABLED=1` is set;
+- normalizes them to non-public, closed, encrypted groups;
+- routes completed private post manifests through
+  `afterPrivatePostManifestUpdate` instead of public post hooks;
+- keeps shared post mutation under the original author's control;
+- leaves legacy `GroupType.PersonalChat` and browser-first direct `ChatEvent`
+  behavior unchanged.
+
+## Boundary
+
+This module is the integration point for later versioned member-device keys,
+membership/key epochs, private delivery policy, and encrypted-post callbacks.
+It must not receive plaintext messages, plaintext attachments, attachment keys,
+or browser private keys.
+
+Modules that intentionally process private posts must implement the private hook
+explicitly. Public integrations must continue to use
+`afterPostManifestUpdate`; they are not called for private-group posts.
+
+## Current Limitations
+
+The module does not yet create browser-facing private groups, store device-key
+membership, run membership/key transitions, or migrate legacy chat events.
+Those capabilities remain gated by the secure-chat implementation plan and
+multi-node browser verification.
+
+Enabling the initial capability is intended for development and compatibility
+testing. It does not make private group chat ready for users.

--- a/app/modules/privateGroup/index.ts
+++ b/app/modules/privateGroup/index.ts
@@ -1,0 +1,63 @@
+import type {IGeesomeApp} from '../../interface.js';
+import {GroupType, IGroup, IPost} from '../group/interface.js';
+import IGeesomePrivateGroupModule, {
+	privateGroupPostManifestHook,
+	publicPostManifestHook
+} from './interface.js';
+
+export default async function (app: IGeesomeApp): Promise<IGeesomePrivateGroupModule> {
+	return getModule(app);
+}
+
+export function getModule(app: IGeesomeApp): IGeesomePrivateGroupModule {
+	return {
+		isEnabled(): boolean {
+			return app.config?.privateGroupConfig?.enabled === true;
+		},
+
+		isPrivateGroup(group: Partial<IGroup> | null | undefined): boolean {
+			return group?.type === GroupType.PrivateGroup;
+		},
+
+		normalizeGroupData(groupData: Partial<IGroup>): Partial<IGroup> {
+			if (!this.isPrivateGroup(groupData)) {
+				return {...groupData};
+			}
+			if (!this.isEnabled()) {
+				throw new Error('private_group_disabled');
+			}
+			return {
+				...groupData,
+				isPublic: false,
+				isOpen: false,
+				isEncrypted: true
+			};
+		},
+
+		getPostManifestHook(group: Partial<IGroup> | null | undefined): string {
+			if (this.isPrivateGroup(group)) {
+				return privateGroupPostManifestHook;
+			}
+			return publicPostManifestHook;
+		},
+
+		canMutateSharedPost(userId: number, post: Partial<IPost>): boolean {
+			return Number(post?.userId) === Number(userId);
+		},
+
+		async afterPrivatePostManifestUpdate(
+			_userId: number,
+			postId: number
+		) {
+			const post = await app.ms.group.getPostPure(postId);
+			if (!post || !this.isPrivateGroup(post.group)) {
+				throw new Error('private_group_post_required');
+			}
+			return {
+				groupId: Number(post.groupId),
+				postId: Number(post.id),
+				private: true
+			};
+		}
+	};
+}

--- a/app/modules/privateGroup/interface.ts
+++ b/app/modules/privateGroup/interface.ts
@@ -1,0 +1,22 @@
+import type {IGroup, IPost} from '../group/interface.js';
+
+export const privateGroupPostManifestHook = 'afterPrivatePostManifestUpdate';
+export const publicPostManifestHook = 'afterPostManifestUpdate';
+
+export interface IPrivateGroupPostManifestResult {
+	groupId: number;
+	postId: number;
+	private: true;
+}
+
+export default interface IGeesomePrivateGroupModule {
+	isEnabled(): boolean;
+	isPrivateGroup(group: Partial<IGroup> | null | undefined): boolean;
+	normalizeGroupData(groupData: Partial<IGroup>): Partial<IGroup>;
+	getPostManifestHook(group: Partial<IGroup> | null | undefined): string;
+	canMutateSharedPost(userId: number, post: Partial<IPost>): boolean;
+	afterPrivatePostManifestUpdate(
+		userId: number,
+		postId: number
+	): Promise<IPrivateGroupPostManifestResult>;
+}

--- a/docs/agent-map.md
+++ b/docs/agent-map.md
@@ -56,6 +56,8 @@ Useful live endpoints:
   state, KeyPackages, Welcome messages, or group-chat wire contracts.
 - Read `app/modules/chat/docs/overview.md` before changing device, envelope,
   delivery, acknowledgement, or reconciliation contracts.
+- Read `app/modules/privateGroup/docs/overview.md` before changing encrypted
+  group/post policy, private post callbacks, or author-controlled mutation.
 - Load the `browser-first-chat-e2ee` TODO section before chat implementation.
 - Coordinate protocol/envelope changes through `geesome-libs`, browser/device
   key handling through `geesome-ui`, and opaque storage/delivery through

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -27,6 +27,7 @@ and implementation notes belong under `app/modules/<module>/docs/`.
 - `imageComposition`: [overview](../app/modules/imageComposition/docs/overview.md)
 - `invite`: [overview](../app/modules/invite/docs/overview.md)
 - `pin`: [overview](../app/modules/pin/docs/overview.md)
+- `privateGroup`: [overview](../app/modules/privateGroup/docs/overview.md)
 - `remoteContentModeration`: [overview](../app/modules/remoteContentModeration/docs/overview.md)
 - `remoteGroup`: [overview](../app/modules/remoteGroup/docs/overview.md)
 - `rss`: [overview](../app/modules/rss/docs/overview.md)
@@ -65,6 +66,7 @@ and implementation notes belong under `app/modules/<module>/docs/`.
 | `imageComposition` | Owns semantic SVG overlays, composition persistence, idempotency, optimistic revisions, and the compatible group-scoped composition API facade. | [Overview](../app/modules/imageComposition/docs/overview.md) |
 | `invite` | Manages invite-code status, rate-limited public join/register flows, invite-derived permissions/limits, optional group joins, and invite lifecycle. | [Overview](../app/modules/invite/docs/overview.md) |
 | `pin` | Stores pinning accounts and sends storage pin requests. | [Overview](../app/modules/pin/docs/overview.md) |
+| `privateGroup` | Applies encrypted private-group publication and author-control policy while reusing group/post storage. | [Overview](../app/modules/privateGroup/docs/overview.md) |
 | `remoteContentModeration` | Provides reusable policy helpers for review-first/auto-import decisions and bounded keyword/regex/source/group filters before remote content becomes visible posts. | [Overview](../app/modules/remoteContentModeration/docs/overview.md) |
 | `remoteGroup` | Imports or refreshes GeeSome groups/posts from remote manifest storage IDs or static IDs, and backs local-or-remote group lookup. | [Overview](../app/modules/remoteGroup/docs/overview.md) |
 | `rss` | Generates bounded public RSS XML feeds for group posts. | [Overview](../app/modules/rss/docs/overview.md) |

--- a/test/group.test.ts
+++ b/test/group.test.ts
@@ -11,7 +11,13 @@ import assert from 'assert';
 import commonHelper from "geesome-libs/src/common.js";
 import trieHelper from "geesome-libs/src/base36Trie.js";
 import {ContentStorageType, ContentView, CorePermissionName} from "../app/modules/database/interface.js";
-import {PostContentAttachmentReason, PostEventAction, PostEventType, PostStatus} from "../app/modules/group/interface.js";
+import {
+	GroupType,
+	PostContentAttachmentReason,
+	PostEventAction,
+	PostEventType,
+	PostStatus
+} from "../app/modules/group/interface.js";
 import {IGeesomeApp} from "../app/interface.js";
 import {RICH_TEXT_MIME_TYPE, createRichTextDocument} from "../app/richText.js";
 import {
@@ -61,6 +67,82 @@ describe("group", function () {
 
 	afterEach(async () => {
 		await app.stop();
+	});
+
+	it('routes private-group posts through private policy and keeps author mutation control', async () => {
+		app.config.privateGroupConfig.enabled = true;
+		const testUser = (await app.ms.database.getAllUserList('user'))[0];
+		const secondUser = await app.registerUser({
+			email: 'private-group-member@user.com',
+			name: 'private-group-member',
+			password: 'private-group-member',
+			permissions: [CorePermissionName.UserAll]
+		});
+		const privateGroup = await app.ms.group.createGroup(testUser.id, {
+			name: 'private-group',
+			title: 'Private group',
+			type: GroupType.PrivateGroup,
+			isPublic: true,
+			isOpen: true,
+			isEncrypted: false
+		});
+		await app.ms.group.addMemberToGroup(testUser.id, privateGroup.id, secondUser.id);
+		await app.ms.group.addAdminToGroup(testUser.id, privateGroup.id, secondUser.id);
+
+		let privateHookCalls = 0;
+		let publicHookCalls = 0;
+		const privateManifestHook = app.ms.privateGroup.afterPrivatePostManifestUpdate;
+		const activityPubManifestHook = app.ms.activityPub.afterPostManifestUpdate;
+		app.ms.privateGroup.afterPrivatePostManifestUpdate = async (_userId, postId) => {
+			privateHookCalls += 1;
+			return privateManifestHook.call(app.ms.privateGroup, testUser.id, postId);
+		};
+		app.ms.activityPub.afterPostManifestUpdate = async () => {
+			publicHookCalls += 1;
+			return {queued: 0, deliveryIds: []};
+		};
+
+		const post = await app.ms.group.createPost(testUser.id, {
+			groupId: privateGroup.id,
+			status: PostStatus.Published
+		}, {asyncDerivedState: false});
+
+		assert.equal(privateGroup.isPublic, false);
+		assert.equal(privateGroup.isOpen, false);
+		assert.equal(privateGroup.isEncrypted, true);
+		assert.equal(await app.ms.group.isMemberInGroup(testUser.id, privateGroup.id), true);
+		assert.equal(privateHookCalls, 1);
+		assert.equal(publicHookCalls, 0);
+		await app.ms.group.updateGroup(testUser.id, privateGroup.id, {
+			isPublic: true,
+			isOpen: true,
+			isEncrypted: false
+		});
+		const normalizedPrivateGroup = await app.ms.group.getGroup(privateGroup.id);
+		assert.equal(normalizedPrivateGroup.isPublic, false);
+		assert.equal(normalizedPrivateGroup.isOpen, false);
+		assert.equal(normalizedPrivateGroup.isEncrypted, true);
+		await assert.rejects(
+			() => app.ms.group.updateGroup(testUser.id, privateGroup.id, {
+				type: GroupType.Channel
+			}),
+			(error: Error) => error.message === 'group_type_change_not_supported'
+		);
+		await assert.rejects(
+			() => app.ms.group.updatePost(secondUser.id, post.id, {view: 'forbidden'}),
+			(error: Error) => error.message === 'not_permitted'
+		);
+		await assert.rejects(
+			() => app.ms.group.deletePosts(secondUser.id, [post.id]),
+			(error: Error) => error.message === 'not_permitted'
+		);
+		await app.ms.group.updatePost(testUser.id, post.id, {view: 'author-edit'});
+
+		const updatedPost = await app.ms.group.getPostPure(post.id);
+		assert.equal(updatedPost.view, 'author-edit');
+
+		app.ms.privateGroup.afterPrivatePostManifestUpdate = privateManifestHook;
+		app.ms.activityPub.afterPostManifestUpdate = activityPubManifestHook;
 	});
 
 	it('requires actor-scoped content rows for post attachments', async () => {

--- a/test/privateGroup.test.ts
+++ b/test/privateGroup.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert';
+import {GroupType} from '../app/modules/group/interface.js';
+import {
+	privateGroupPostManifestHook,
+	publicPostManifestHook
+} from '../app/modules/privateGroup/interface.js';
+import {getModule} from '../app/modules/privateGroup/index.js';
+
+describe('private group policy', () => {
+	it('normalizes the private group capability without changing other groups', () => {
+		const module = getModule({
+			config: {privateGroupConfig: {enabled: true}}
+		} as any);
+		const privateGroup = module.normalizeGroupData({
+			type: GroupType.PrivateGroup,
+			isPublic: true,
+			isOpen: true,
+			isEncrypted: false
+		});
+		const channel = module.normalizeGroupData({
+			type: GroupType.Channel,
+			isPublic: true,
+			isOpen: true,
+			isEncrypted: false
+		});
+
+		assert.equal(privateGroup.isPublic, false);
+		assert.equal(privateGroup.isOpen, false);
+		assert.equal(privateGroup.isEncrypted, true);
+		assert.equal(channel.isPublic, true);
+		assert.equal(channel.isOpen, true);
+		assert.equal(channel.isEncrypted, false);
+	});
+
+	it('routes private posts separately and limits shared mutation to the author', () => {
+		const module = getModule({
+			config: {privateGroupConfig: {enabled: true}}
+		} as any);
+
+		assert.equal(
+			module.getPostManifestHook({type: GroupType.PrivateGroup}),
+			privateGroupPostManifestHook
+		);
+		assert.equal(
+			module.getPostManifestHook({type: GroupType.Channel}),
+			publicPostManifestHook
+		);
+		assert.equal(module.canMutateSharedPost(7, {userId: 7}), true);
+		assert.equal(module.canMutateSharedPost(8, {userId: 7}), false);
+	});
+
+	it('accepts the private manifest hook only for private-group posts', async () => {
+		const app: any = {
+			config: {privateGroupConfig: {enabled: true}},
+			ms: {
+				group: {
+					getPostPure: async (postId) => ({
+						id: postId,
+						groupId: 12,
+						group: {type: GroupType.PrivateGroup}
+					})
+				}
+			}
+		};
+		const module = getModule(app);
+
+		assert.deepEqual(await module.afterPrivatePostManifestUpdate(7, 41), {
+			groupId: 12,
+			postId: 41,
+			private: true
+		});
+
+		app.ms.group.getPostPure = async () => ({
+			id: 42,
+			groupId: 12,
+			group: {type: GroupType.Channel}
+		});
+		await assert.rejects(
+			() => module.afterPrivatePostManifestUpdate(7, 42),
+			(error: Error) => error.message === 'private_group_post_required'
+		);
+	});
+
+	it('keeps private-group creation disabled by default', () => {
+		const module = getModule({config: {}} as any);
+
+		assert.throws(
+			() => module.normalizeGroupData({type: GroupType.PrivateGroup}),
+			(error: Error) => error.message === 'private_group_disabled'
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- add a default-off `PrivateGroup` module and additive `private_group` group type
- normalize private groups to closed, non-public, encrypted state and keep that type stable
- route private post manifests through an explicit private hook instead of public publishing hooks
- limit shared private-post mutation to the original author while preserving existing group behavior
- document the module boundary and add focused policy/integration coverage

## Rollout

`PRIVATE_GROUP_ENABLED` defaults to disabled. Existing `personal_chat` groups and browser-first direct `ChatEvent` conversations are unchanged. This establishes the first boundary from the migration plan in #1307 without exposing unfinished private-group chat to users.

## Validation

- `npx mocha --require tsx test/privateGroup.test.ts` (4 passing)
- focused Docker policy/group integration run (5 passing)
- `npm run test:docker` (620 passing, 11 pending)
- `git diff --check`
